### PR TITLE
docs: add version-bump & release routine to agent knowledge base

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -61,11 +61,18 @@ perform a **full two-way refresh**:
 1. **`05` codebase-map** — re-inspect the repo regardless of the bookmark, rewrite `05`, and
    reset the bookmark commit to current HEAD.
 2. **`06` milestones-roadmap — two-way sync with GitHub.** Beyond reading, you should
-   **use `gh` to make GitHub match the roadmap**: reconcile milestone titles/descriptions and
-   issue descriptions, and reason about **(a) the current package version, (b) the next one or
-   two minor-version milestones, and (c) the next major-version milestone** — proposing the
-   issues that each should contain. (Confirm with the user before creating/editing GitHub
-   milestones or issues — these are outward-facing writes.)
+   **use `gh` to make GitHub match the roadmap**, treating the freshly-updated `.claude/`
+   knowledge base (post-task learnings from `05`/`07` and the code) as the source of truth:
+   - **Reconcile existing open issues** (created by you or the user). As new learnings land,
+     issues may need their **titles/descriptions edited**, be **closed** (already done, obsolete,
+     or superseded), be **re-scoped/split/merged**, or be **moved to a different milestone**.
+   - **Reconcile the milestones themselves.** Reason about **(a) the current package version,
+     (b) the next one or two minor-version milestones, and (c) the next major-version
+     milestone** — and adjust as learnings dictate: the **number of remaining future minor
+     versions**, each milestone's **scope and issue set**, and the same for the **next major
+     version** (titles, descriptions, which issues belong where, adding/removing issues).
+   - Propose the concrete `gh` edits (issue closes/edits, milestone edits, new issues). **Confirm
+     with the user before any create/edit/close — these are outward-facing writes.**
 3. **`07` glossary** — update [knowledge/07-glossary.md](knowledge/07-glossary.md) to add any
    new symbols/terms introduced by code or roadmap changes since the last refresh.
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -48,6 +48,8 @@ the current GitHub state. Do **not** push changes to GitHub during normal sessio
 
 ### Step 4 — Ready to work
 Pick up the issue/milestone in focus (see `06`) and use `02`/`03` as the implementation spec.
+When a session's work **closes an issue**, follow the **Version bump & release** routine below
+(bump inside the PR; tag + release only after the user confirms the merge).
 
 ---
 
@@ -68,6 +70,51 @@ perform a **full two-way refresh**:
    new symbols/terms introduced by code or roadmap changes since the last refresh.
 
 `RKB` = the manual superset of the session-start routine, plus the GitHub write-back for `06`.
+It also **re-checks the release state** (`git tag` / `gh release list` vs. `package.json`) so a
+version that was bumped-but-not-yet-released is surfaced.
+
+---
+
+## 🚀 Version bump & release (when a working session closes an issue)
+
+The repo ships via **tag → GitHub Release → CI/CD**. Publishing a GitHub Release
+(`release: published`) fires `.github/workflows/publish.yml`, which **publishes the package to
+npm** (`npm publish --provenance --access public`) **and builds + pushes the multi-arch Docker
+image** to Docker Hub. Tags are the **bare version with no `v` prefix** (`0.15.0`, not
+`v0.15.0`) and must match `package.json`. (Separately: pushes/PRs to `main` run lint + test via
+`npm-build.yml`, and `docs/**` changes deploy Pages via `static.yml` — those need no action.)
+
+> **This is an outward-facing publish (npm + Docker Hub). The release half is GATED on explicit
+> user confirmation that the PR merged. Never create a tag or GitHub Release autonomously.**
+
+### Phase 1 — bump the version *inside the PR that closes the issue*
+Do this as part of the same PR that closes the issue, so `package.json` **and**
+`package-lock.json` (both the root `version` and the `packages[""]` entry) move together. Use
+npm so all stay in sync — **do not hand-edit** the version fields:
+
+```bash
+# repo root, on the feature branch, before committing the PR:
+npm version minor --no-git-tag-version   # e.g. 0.15.0 → 0.16.0; edits package.json + package-lock.json, no git tag/commit
+```
+
+Convention: every historical release is a **minor** bump (`0.N.0`), one per closed issue while
+pre-1.0 — use `minor` unless the user directs otherwise (e.g. the final `1.0.0` milestone close
+is a `major` bump). Commit the bump with the rest of the PR's changes.
+
+### Phase 2 — tag + release *after the user confirms the PR is merged*
+Only once the user confirms the PR is merged (issue closed), from an up-to-date `main`:
+
+```bash
+git checkout main && git pull origin main               # pull the merged bump commit
+git fetch --tags --force                                # sync local tags with GitHub (local can be stale)
+VERSION=$(node -p "require('./package.json').version")  # e.g. 0.16.0
+git tag "$VERSION" && git push origin "$VERSION"        # tag == version, no "v" prefix
+gh release create "$VERSION" --title "$VERSION" --target main --generate-notes
+```
+
+Publishing the release triggers `publish.yml` → npm + Docker Hub. After creating it, confirm the
+CD started (`gh run list --workflow=publish.yml` / `gh release view "$VERSION"`) and report the
+result to the user.
 
 ---
 

--- a/.claude/knowledge/05-codebase-map.md
+++ b/.claude/knowledge/05-codebase-map.md
@@ -1,9 +1,10 @@
 # 05 — Codebase Map (current state)
 
-<!-- BOOKMARK-COMMIT: 611cd53306240b182b6be29c2ad7867de87ae7a4 -->
-<!-- BOOKMARK-BRANCH: feat/45-adjacency-map -->
-<!-- Last validated against the above commit (RKB refresh). This commit is on the #45 feature
-     branch; when PR #160 merges, main HEAD will differ and session start will re-validate. -->
+<!-- BOOKMARK-COMMIT: c71f6b919df9eb12d6f3b65fec2be82428c98db9 -->
+<!-- BOOKMARK-BRANCH: main -->
+<!-- Last validated at session start. PR #160 (#45 adjacency map + benchmark harness) is now
+     MERGED to main; the 611cd53..c71f6b9 diff touched only .claude/knowledge/ files, so the
+     src/test/benchmarks/package.json layout below is unchanged from the prior validation. -->
 <!-- Update both the comment and the body when HEAD moves. -->
 
 Snapshot of what exists in `bmssp-js` today, so you know what to build on vs. what's missing.

--- a/.claude/knowledge/06-milestones-roadmap.md
+++ b/.claude/knowledge/06-milestones-roadmap.md
@@ -17,14 +17,17 @@ build next); `05-codebase-map.md` is the "reality" side (what exists now).
   gh issue list --repo Sirivasv/bmssp-js --state closed --limit 100 --json number,title,milestone
   ```
 - **On-demand `RKB` (`revitalize_knowledge_base`) — two-way sync.** In addition to the read
-  above, **make GitHub match this roadmap**: reconcile milestone titles/descriptions and issue
-  descriptions via `gh`, and reason forward about versioning:
-  - the **current version** (from `package.json`),
-  - the **next one or two minor-version milestones**, and
-  - the **next major-version milestone**,
-  proposing which issues each should contain.
-  Outward-facing writes (creating/editing milestones or issues) are **confirmed with the user
-  first**. See the "Forward-looking version plan" section for the working proposal.
+  above, **make GitHub match this roadmap**, using the just-refreshed knowledge base + code as
+  the source of truth:
+  - **Existing open issues** (yours or the user's) may be **edited** (title/description),
+    **closed** (done/obsolete/superseded), **re-scoped/split/merged**, or **moved** to another
+    milestone as new learnings dictate.
+  - **Milestones** are adjusted the same way — reason forward about versioning and update the
+    **current version** (from `package.json`), the **number and scope of the next one or two
+    minor-version milestones**, and the **next major-version milestone** (titles, descriptions,
+    and which issues belong to each — adding or removing issues as needed).
+  Outward-facing writes (creating/editing/closing milestones or issues) are **confirmed with the
+  user first**. See the "Forward-looking version plan" section for the working proposal.
 
 ---
 

--- a/.claude/knowledge/06-milestones-roadmap.md
+++ b/.claude/knowledge/06-milestones-roadmap.md
@@ -1,6 +1,6 @@
 # 06 — Milestones Roadmap
 
-<!-- SYNCED-FROM-GITHUB: 2026-07-15 (RKB refresh) -->
+<!-- SYNCED-FROM-GITHUB: 2026-07-15 (session-start reconciliation; PR #160 merged) -->
 <!-- Current package version: 0.15.0 -->
 
 Maps GitHub **milestones** and **issues** (Sirivasv/bmssp-js) to the paper's building blocks,
@@ -32,17 +32,16 @@ build next); `05-codebase-map.md` is the "reality" side (what exists now).
 
 - **Package version:** `0.15.0` (pre-1.0; the algorithm is not yet functional end-to-end).
 - **Active milestone:** **`1.0.0` — "Have a first functional version of the whole algorithm."**
-  - GitHub progress: **5 closed / 6 open** issues (issue #45 is implemented but its PR #160 is
-    not merged yet, so GitHub still counts it open).
-  - The 6 open issues (#40–#45) are exactly the algorithm pieces from §02–§03.
-- **In flight:** **#45 — adjacency map — implemented in PR #160** (`feat/45-adjacency-map`),
-  awaiting merge. See `05-codebase-map.md` for the shipped `this.adjacency` / `getEdges` API.
+  - GitHub progress: **6 closed / 5 open** issues (PR #160 merged, so #45 now counts closed).
+  - The 5 open issues (#40–#44) are exactly the remaining algorithm pieces from §02–§03.
+- **Just merged:** **#45 — adjacency map + benchmark harness — PR #160 is now on `main`**
+  (commit `c71f6b9`). See `05-codebase-map.md` for the shipped `this.adjacency` / `getEdges` API.
 
 ## Milestone `1.0.0` — issues → paper
 
 | # | Title | What it is (paper) | Labels | Depends on | Status |
 |---|---|---|---|---|---|
-| **45** | Add a map of arrays for edges of each node | Adjacency map so edge lookups aren't O(m). §05 | help wanted · good first issue | — | ✅ PR #160 (open) |
+| **45** | Add a map of arrays for edges of each node | Adjacency map so edge lookups aren't O(m). §05 | help wanted · good first issue | — | ✅ merged (PR #160) |
 | **41** | Implement a priority heap | Binary min-heap for the base case (Alg 2). §03-A | help wanted · good first issue | — | ⬜ open |
 | **40** | Implement the base case of the bmssp algorithm | `BaseCase(B, S)` bounded mini-Dijkstra. **Alg 2**, §02 | help wanted | #41 | ⬜ open |
 | **42** | Implement Lema 3.3 data structure | Block-based partial-sort list `D`. **Lemma 3.3**, §03-B | help wanted | — | ⬜ open |
@@ -126,6 +125,19 @@ _Note:_ the seeded **benchmark harness already landed early** with #45 (`benchma
 | 173 | Stabilize the public API surface for 1.0 → 2.0 | documentation · enhancement |
 
 ---
+
+## Release mechanics (version bump per closed issue)
+
+Closing an issue bumps the package version and, after the PR merges, ships a release:
+
+1. **In the PR that closes the issue** — `npm version minor --no-git-tag-version` (keeps
+   `package.json` + `package-lock.json` in sync; historical cadence is a **minor** `0.N.0` bump
+   per issue). The `1.0.0` milestone close is the `major` bump to `1.0.0`.
+2. **After the user confirms the merge** — tag `main` with the bare version (no `v` prefix) and
+   `gh release create` it; publishing the release fires `publish.yml` → **npm + Docker Hub**.
+
+Full procedure + exact commands live in **`../CLAUDE.md` → "Version bump & release"**. The
+release step is an outward-facing publish and is **gated on explicit user confirmation**.
 
 ## Definition of done for `1.0.0`
 


### PR DESCRIPTION
## What

Documents the repo's **tag → GitHub Release → CI/CD** flow in the agent knowledge base so agents (and future sessions) bump the package version when a working session closes an issue, then — **only after the user confirms the PR merged** — tag `main` and publish the release, which fires `publish.yml` (npm publish + Docker Hub).

## Changes

- **`.claude/CLAUDE.md`** — new **"🚀 Version bump & release"** section:
  - **Phase 1 (in the PR that closes the issue):** `npm version minor --no-git-tag-version` keeps `package.json` **and** `package-lock.json` (root + `packages[""]`) in sync — no hand-editing.
  - **Phase 2 (after merge confirmation):** `git pull` + `git fetch --tags --force`, tag with the **bare version (no `v` prefix)**, push, `gh release create`, then verify the CD run.
  - Flagged as an outward-facing publish, **gated on explicit user confirmation** — never autonomous.
  - Pointers added from Step 4 of the session routine and the RKB command.
- **`.claude/knowledge/06-milestones-roadmap.md`** — "Release mechanics" cross-reference; reconciled milestone `1.0.0` state after PR #160 merged (**6 closed / 5 open**).
- **`.claude/knowledge/05-codebase-map.md`** — re-stamped `BOOKMARK-COMMIT` to current `main` HEAD (session-start validation).

## Notes

Docs-only (`.claude/**`), which is excluded from lint. No source or test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)