### PR TITLE
feat(#42): Lemma 3.3 block-based partial-sort structure (BlockList)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bmssp",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bmssp",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "MPL-2.0",
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bmssp",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Javascript package implementation of the bmssp algorithm.",
   "main": "index.mjs",
   "keywords": [

--- a/src/blockList.mjs
+++ b/src/blockList.mjs
@@ -1,0 +1,248 @@
+/**
+ * Block-based "partial-sort" structure D from Lemma 3.3 of the BMSSP paper
+ * ("Breaking the Sorting Barrier for Directed Single-Source Shortest Paths").
+ *
+ * Holds <key, value> pairs (vertex, distance estimate) semi-sorted: values
+ * are ordered BETWEEN blocks but unsorted WITHIN a block. That is enough to
+ * repeatedly pull the M smallest values as a batch (pull) and to cheaply
+ * add a batch of values known to be smaller than everything present
+ * (batchPrepend) — without paying for a full sort.
+ *
+ * Internal layout:
+ * - d1: blocks filled by insert(). Each block carries an upper bound on its
+ *   values; bounds are non-decreasing across blocks, and the last block
+ *   always has bound B so every value < B has a home.
+ * - d0: blocks filled by batchPrepend() only; they conceptually sit in front
+ *   of d1 (their values are smaller than everything inserted so far).
+ *
+ * The block-bound index is a plain array searched with binary search instead
+ * of the paper's balanced BST — same behavior, worse constants (issue #167).
+ */
+class BlockList {
+  /**
+   * Initialize the structure (Lemma 3.3 Initialize).
+   * @param {number} M - Block size / pull batch size, >= 1. At recursion level l this is 2^((l-1)·t).
+   * @param {number} B - Strict upper bound on every value ever stored (Infinity is allowed)
+   * @throws {Error} If M is not a number >= 1
+   */
+  constructor(M, B) {
+    if (typeof M !== "number" || Number.isNaN(M) || M < 1) {
+      throw new Error("M must be a number >= 1");
+    }
+    this.M = Math.floor(M);
+    this.B = B;
+    // d1 starts as a single empty block with upper bound B
+    this.d1 = [this.makeBlock(B)];
+    this.d0 = [];
+    // key -> block currently holding that key, for O(1) duplicate handling
+    this.locator = new Map();
+    this.count = 0;
+  }
+
+  // Internal: create an empty block with the given value upper bound
+  makeBlock(bound) {
+    return { bound, entries: new Map() };
+  }
+
+  // Number of pairs currently stored
+  get size() {
+    return this.count;
+  }
+
+  isEmpty() {
+    return this.count === 0;
+  }
+
+  /**
+   * Insert a pair (Lemma 3.3 Insert). If the key is already stored, the
+   * smallest value wins (the pair is replaced only when value is smaller).
+   * @param {*} key - Typically a node ID
+   * @param {number} value - Must be < B
+   * @throws {Error} If value >= B
+   */
+  insert(key, value) {
+    if (!(value < this.B)) {
+      throw new Error("value must be < B");
+    }
+    const holder = this.locator.get(key);
+    if (holder !== undefined) {
+      if (holder.entries.get(key) <= value) return;
+      this.removeKey(key, holder);
+    }
+    // Binary-search d1 for the first block whose bound covers the value
+    let lo = 0;
+    let hi = this.d1.length - 1;
+    while (lo < hi) {
+      const mid = (lo + hi) >> 1;
+      if (this.d1[mid].bound >= value) {
+        hi = mid;
+      } else {
+        lo = mid + 1;
+      }
+    }
+    const block = this.d1[lo];
+    block.entries.set(key, value);
+    this.locator.set(key, block);
+    this.count += 1;
+    if (block.entries.size > this.M) {
+      this.splitBlock(lo);
+    }
+  }
+
+  // Internal: split an overfull d1 block into two halves around its median
+  // value. The lower half gets bound = its own max value; the upper half
+  // keeps the original bound, so inter-block ordering is preserved.
+  // (The paper uses linear-time median selection; sorting is O(M log M) but
+  // simpler — acceptable for this correctness-first implementation.)
+  splitBlock(index) {
+    const block = this.d1[index];
+    const sorted = [...block.entries].sort((a, b) => a[1] - b[1]);
+    const half = sorted.length >> 1;
+    const lower = this.makeBlock(sorted[half - 1][1]);
+    for (let i = 0; i < half; i += 1) {
+      const [key, value] = sorted[i];
+      block.entries.delete(key);
+      lower.entries.set(key, value);
+      this.locator.set(key, lower);
+    }
+    this.d1.splice(index, 0, lower);
+  }
+
+  /**
+   * Insert a batch of pairs whose values are all smaller than every value
+   * currently stored (Lemma 3.3 BatchPrepend). On duplicate keys — within
+   * the batch or against the current contents — the smallest value wins.
+   * The caller is responsible for the "smaller than everything" contract;
+   * only the value < B bound is checked here.
+   * @param {Iterable<[*, number]>} pairs - [key, value] pairs, each value < B
+   * @throws {Error} If any value >= B
+   */
+  batchPrepend(pairs) {
+    // Dedupe the batch, keeping the smallest value per key
+    const best = new Map();
+    for (const [key, value] of pairs) {
+      if (!(value < this.B)) {
+        throw new Error("value must be < B");
+      }
+      const seen = best.get(key);
+      if (seen === undefined || value < seen) {
+        best.set(key, value);
+      }
+    }
+    // Resolve clashes with keys already stored (smallest value wins)
+    const fresh = [];
+    for (const [key, value] of best) {
+      const holder = this.locator.get(key);
+      if (holder !== undefined) {
+        if (holder.entries.get(key) <= value) continue;
+        this.removeKey(key, holder);
+      }
+      fresh.push([key, value]);
+    }
+    if (fresh.length === 0) return;
+    // One block if the batch fits, otherwise sorted chunks of <= ceil(M/2)
+    let chunks;
+    if (fresh.length <= this.M) {
+      chunks = [fresh];
+    } else {
+      fresh.sort((a, b) => a[1] - b[1]);
+      const chunkSize = Math.ceil(this.M / 2);
+      chunks = [];
+      for (let i = 0; i < fresh.length; i += chunkSize) {
+        chunks.push(fresh.slice(i, i + chunkSize));
+      }
+    }
+    // Prepend in reverse chunk order so the smallest chunk lands at the front
+    for (let c = chunks.length - 1; c >= 0; c -= 1) {
+      const chunk = chunks[c];
+      const block = this.makeBlock(-Infinity);
+      for (const [key, value] of chunk) {
+        block.entries.set(key, value);
+        this.locator.set(key, block);
+        if (value > block.bound) block.bound = value;
+        this.count += 1;
+      }
+      this.d0.unshift(block);
+    }
+  }
+
+  /**
+   * Remove and return the (at most) M smallest-valued keys plus a separating
+   * bound (Lemma 3.3 Pull). In Algorithm 3 this is `Bi, Si <- D.Pull()`:
+   * `keys` is Si and `bound` is Bi, satisfying
+   * max(pulled values) <= bound <= min(remaining values).
+   * When the pull drains the structure the bound is B.
+   * @returns {{ keys: Set<*>, bound: number }}
+   */
+  pull() {
+    if (this.count <= this.M) {
+      // Everything fits in one batch: drain the structure and reset it
+      const keys = new Set(this.locator.keys());
+      this.d0 = [];
+      this.d1 = [this.makeBlock(this.B)];
+      this.locator.clear();
+      this.count = 0;
+      return { keys, bound: this.B };
+    }
+    // Collect prefix blocks from each sequence until that side holds >= M
+    // candidate elements (or runs out). The M smallest overall are in there.
+    const candidates = [];
+    for (const seq of [this.d0, this.d1]) {
+      let collected = 0;
+      for (const block of seq) {
+        if (collected >= this.M) break;
+        for (const [key, value] of block.entries) {
+          candidates.push([key, value, block]);
+        }
+        collected += block.entries.size;
+      }
+    }
+    // Take the M smallest candidates out of the structure
+    candidates.sort((a, b) => a[1] - b[1]);
+    const keys = new Set();
+    for (let i = 0; i < this.M; i += 1) {
+      const [key, , block] = candidates[i];
+      keys.add(key);
+      this.removeKey(key, block);
+    }
+    // Separator = smallest value still stored. Thanks to the inter-block
+    // ordering it lives in the first non-empty block of d0 or d1.
+    let bound = Infinity;
+    for (const seq of [this.d0, this.d1]) {
+      const block = seq.find((b) => b.entries.size > 0);
+      if (block) {
+        for (const value of block.entries.values()) {
+          if (value < bound) bound = value;
+        }
+      }
+    }
+    return { keys, bound };
+  }
+
+  // Internal: remove a key from the block that holds it, dropping the block
+  // if it becomes empty (deletion cost amortizes into insertion, Lemma 3.3)
+  removeKey(key, block) {
+    block.entries.delete(key);
+    this.locator.delete(key);
+    this.count -= 1;
+    if (block.entries.size === 0) {
+      this.dropIfEmpty(block);
+    }
+  }
+
+  // Internal: physically remove an emptied block. The last d1 block (bound B)
+  // is kept even when empty so insert always finds a home for any value < B.
+  dropIfEmpty(block) {
+    const i0 = this.d0.indexOf(block);
+    if (i0 !== -1) {
+      this.d0.splice(i0, 1);
+      return;
+    }
+    const i1 = this.d1.indexOf(block);
+    if (i1 !== -1 && i1 < this.d1.length - 1) {
+      this.d1.splice(i1, 1);
+    }
+  }
+}
+
+export { BlockList };

--- a/test/blockList.test.mjs
+++ b/test/blockList.test.mjs
@@ -1,0 +1,306 @@
+import { describe, test, expect } from "@jest/globals";
+import { BlockList } from "../src/blockList.mjs";
+
+// Small deterministic PRNG so stress-test failures are reproducible
+function mulberry32(seed) {
+  let a = seed >>> 0;
+  return function () {
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// Drain the structure with repeated pulls, returning every batch with the
+// separating bound reported alongside it
+function drain(list) {
+  const batches = [];
+  while (!list.isEmpty()) {
+    const { keys, bound } = list.pull();
+    batches.push({ keys, bound });
+  }
+  return batches;
+}
+
+describe("BlockList initialization", () => {
+  test("throws when M is not a number >= 1", () => {
+    expect(() => new BlockList(0, 100)).toThrow("M must be a number >= 1");
+    expect(() => new BlockList(NaN, 100)).toThrow("M must be a number >= 1");
+    expect(() => new BlockList("4", 100)).toThrow("M must be a number >= 1");
+  });
+
+  test("starts empty", () => {
+    const list = new BlockList(4, 100);
+    expect(list.isEmpty()).toBe(true);
+    expect(list.size).toBe(0);
+  });
+
+  test("pull on an empty structure returns no keys and bound B", () => {
+    const list = new BlockList(4, 100);
+    const { keys, bound } = list.pull();
+    expect(keys.size).toBe(0);
+    expect(bound).toBe(100);
+  });
+});
+
+describe("BlockList insert + pull", () => {
+  test("rejects values >= B", () => {
+    const list = new BlockList(4, 100);
+    expect(() => list.insert(1, 100)).toThrow("value must be < B");
+    expect(() => list.insert(1, 250)).toThrow("value must be < B");
+  });
+
+  test("accepts any finite value when B is Infinity", () => {
+    const list = new BlockList(2, Infinity);
+    list.insert(1, 1e18);
+    list.insert(2, 5);
+    const { keys, bound } = list.pull();
+    expect(keys).toEqual(new Set([1, 2]));
+    expect(bound).toBe(Infinity);
+  });
+
+  test("a pull that drains the structure returns everything and bound B", () => {
+    const list = new BlockList(4, 100);
+    list.insert(10, 7);
+    list.insert(11, 3);
+    list.insert(12, 9);
+    const { keys, bound } = list.pull();
+    expect(keys).toEqual(new Set([10, 11, 12]));
+    expect(bound).toBe(100);
+    expect(list.isEmpty()).toBe(true);
+  });
+
+  test("pulls return the M smallest keys per batch, in batch-sorted order", () => {
+    const M = 4;
+    const list = new BlockList(M, 1000);
+    // 23 pairs with distinct shuffled values: key i has value (i * 37) % 100
+    const pairs = [];
+    for (let i = 0; i < 23; i += 1) {
+      pairs.push([i, (i * 37) % 100]);
+    }
+    for (const [key, value] of pairs) {
+      list.insert(key, value);
+    }
+    const expected = [...pairs].sort((a, b) => a[1] - b[1]);
+    const batches = drain(list);
+    let offset = 0;
+    for (const { keys } of batches) {
+      const expectedKeys = new Set(
+        expected.slice(offset, offset + keys.size).map(([key]) => key),
+      );
+      expect(keys).toEqual(expectedKeys);
+      expect(keys.size).toBeLessThanOrEqual(M);
+      offset += keys.size;
+    }
+    expect(offset).toBe(pairs.length);
+  });
+
+  test("separator satisfies max(pulled) < bound <= min(remaining)", () => {
+    const list = new BlockList(3, 1000);
+    const values = new Map();
+    for (let i = 0; i < 17; i += 1) {
+      const value = (i * 61) % 200; // distinct values
+      values.set(i, value);
+      list.insert(i, value);
+    }
+    while (!list.isEmpty()) {
+      const before = list.size;
+      const { keys, bound } = list.pull();
+      const pulled = [...keys].map((k) => values.get(k));
+      for (const k of keys) values.delete(k);
+      if (values.size > 0) {
+        expect(Math.max(...pulled)).toBeLessThan(bound);
+        expect(bound).toBeLessThanOrEqual(Math.min(...values.values()));
+      } else {
+        expect(bound).toBe(1000);
+      }
+      expect(list.size).toBe(before - keys.size);
+    }
+  });
+
+  test("duplicate key keeps the smallest value (either insert order)", () => {
+    const list = new BlockList(1, 100);
+    list.insert(7, 50);
+    list.insert(7, 10); // smaller replaces
+    list.insert(8, 20);
+    list.insert(8, 60); // larger is ignored
+    list.insert(9, 30);
+    list.insert(9, 30); // equal keeps the existing pair
+    expect(list.size).toBe(3);
+    expect(drain(list).map(({ keys }) => keys)).toEqual([
+      new Set([7]),
+      new Set([8]),
+      new Set([9]),
+    ]);
+  });
+
+  test("splits keep pulls correct when many inserts land in one block", () => {
+    const M = 2;
+    const list = new BlockList(M, 100);
+    const values = [9, 1, 8, 2, 7, 3, 6, 4, 5];
+    values.forEach((value, key) => list.insert(key, value));
+    const pulledValues = drain(list).flatMap(({ keys }) =>
+      [...keys].map((key) => values[key]).sort((a, b) => a - b),
+    );
+    expect(pulledValues).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  });
+
+  test("a pulled key can be inserted again", () => {
+    const list = new BlockList(2, 100);
+    list.insert(1, 10);
+    list.insert(2, 20);
+    list.pull();
+    list.insert(1, 30);
+    expect(list.pull().keys).toEqual(new Set([1]));
+  });
+});
+
+describe("BlockList batchPrepend", () => {
+  test("rejects values >= B", () => {
+    const list = new BlockList(4, 100);
+    expect(() => list.batchPrepend([[1, 100]])).toThrow("value must be < B");
+  });
+
+  test("prepended pairs come out before previously inserted ones", () => {
+    const list = new BlockList(2, 1000);
+    list.insert(1, 100);
+    list.insert(2, 110);
+    list.insert(3, 120);
+    list.batchPrepend([
+      ["a", 5],
+      ["b", 7],
+    ]);
+    const { keys, bound } = list.pull();
+    expect(keys).toEqual(new Set(["a", "b"]));
+    expect(bound).toBeLessThanOrEqual(100);
+  });
+
+  test("a batch larger than M is chunked and still pulls in order", () => {
+    const M = 4;
+    const list = new BlockList(M, 1000);
+    for (let i = 0; i < 5; i += 1) {
+      list.insert(100 + i, 500 + i);
+    }
+    const prepended = [];
+    for (let i = 0; i < 10; i += 1) {
+      prepended.push([i, 10 + ((i * 7) % 10)]); // distinct values 10..19
+    }
+    list.batchPrepend(prepended);
+    expect(list.size).toBe(15);
+    const order = [];
+    const valueOf = new Map([
+      ...prepended,
+      [100, 500],
+      [101, 501],
+      [102, 502],
+      [103, 503],
+      [104, 504],
+    ]);
+    for (const { keys } of drain(list)) {
+      expect(keys.size).toBeLessThanOrEqual(M);
+      order.push(...[...keys].map((k) => valueOf.get(k)).sort((a, b) => a - b));
+    }
+    expect(order).toEqual([...valueOf.values()].sort((a, b) => a - b));
+  });
+
+  test("duplicate keys keep the smallest value, within the batch and vs stored", () => {
+    const list = new BlockList(2, 100);
+    list.insert("x", 50);
+    list.insert("y", 60);
+    list.batchPrepend([
+      ["x", 9], // beats the stored 50
+      ["z", 8],
+      ["z", 4], // beats the in-batch 8
+      ["y", 60], // does not beat the stored 60
+    ]);
+    expect(list.size).toBe(3);
+    const first = list.pull();
+    expect(first.keys).toEqual(new Set(["x", "z"]));
+    expect(first.bound).toBeLessThanOrEqual(60);
+    expect(list.pull().keys).toEqual(new Set(["y"]));
+  });
+
+  test("an empty batch is a no-op", () => {
+    const list = new BlockList(2, 100);
+    list.insert(1, 10);
+    list.batchPrepend([]);
+    list.batchPrepend([[1, 10]]); // fully deduped away
+    expect(list.size).toBe(1);
+  });
+
+  test("insert can replace a key held in a prepended block", () => {
+    const list = new BlockList(2, 100);
+    list.insert(1, 90);
+    list.pull();
+    list.batchPrepend([["a", 50]]);
+    list.insert("a", 20); // removes the pair from its d0 block
+    expect(list.size).toBe(1);
+    const { keys, bound } = list.pull();
+    expect(keys).toEqual(new Set(["a"]));
+    expect(bound).toBe(100);
+  });
+});
+
+describe("BlockList stress (seeded)", () => {
+  // Mimics how Algorithm 3 drives D: after a pull with separator Bi, new
+  // inserts land in [Bi, B) and batch-prepends land in [Bi', Bi) — i.e. at
+  // or above everything already pulled. Under that contract, batches must
+  // come out globally non-decreasing and each batch must be exactly the
+  // current M smallest pairs.
+  test("random inserts, prepends and pulls always come out value-sorted", () => {
+    const rand = mulberry32(42);
+    const M = 8;
+    const list = new BlockList(M, Infinity);
+    const values = new Map();
+    let nextKey = 0;
+    let floor = 0; // max value pulled so far; later batches must not go below
+    let lastBound = 0; // separator of the last pull; inserts stay above it
+    for (let round = 0; round < 60; round += 1) {
+      // Insert a random handful of fresh pairs with distinct values >= lastBound
+      const inserts = 1 + Math.floor(rand() * 12);
+      for (let i = 0; i < inserts; i += 1) {
+        const value = lastBound + rand() * 1e6;
+        list.insert(nextKey, value);
+        values.set(nextKey, value);
+        nextKey += 1;
+      }
+      // Occasionally pull and check the batch is exactly the current minimums
+      if (rand() < 0.6 && !list.isEmpty()) {
+        const { keys, bound } = list.pull();
+        const sorted = [...values.entries()].sort((a, b) => a[1] - b[1]);
+        const expectedKeys = new Set(
+          sorted.slice(0, keys.size).map(([key]) => key),
+        );
+        expect(keys).toEqual(expectedKeys);
+        const pulled = [...keys].map((k) => values.get(k));
+        expect(Math.min(...pulled)).toBeGreaterThanOrEqual(floor);
+        floor = Math.max(...pulled);
+        expect(bound).toBeGreaterThan(floor);
+        for (const k of keys) values.delete(k);
+        // Sometimes prepend a few pairs into [floor, bound) — all smaller
+        // than everything still stored, like the K batch in Algorithm 3
+        if (bound < Infinity && rand() < 0.5) {
+          const prepends = 1 + Math.floor(rand() * M);
+          const batch = [];
+          for (let i = 0; i < prepends; i += 1) {
+            const value = floor + rand() * (bound - floor);
+            batch.push([nextKey, value]);
+            values.set(nextKey, value);
+            nextKey += 1;
+          }
+          list.batchPrepend(batch);
+        }
+        lastBound = bound === Infinity ? floor : bound;
+      }
+    }
+    // Drain what is left and verify the global ordering held throughout
+    for (const { keys } of drain(list)) {
+      const pulled = [...keys].map((k) => values.get(k));
+      expect(Math.min(...pulled)).toBeGreaterThanOrEqual(floor);
+      floor = Math.max(...pulled);
+      for (const k of keys) values.delete(k);
+    }
+    expect(values.size).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #42 (milestone `1.0.0`).

## What

Implements the **Lemma 3.3 block-based "partial-sort" structure `D`** from the BMSSP paper as `src/blockList.mjs` — the data structure at the heart of the main `BMSSP(l, B, S)` recursion (#43). It keeps `⟨key, value⟩` pairs **ordered between blocks but unsorted within**, which is enough to batch-pull minimums and batch-prepend smaller values without paying for a full sort.

### API (maps 1:1 to the paper's operations)

| Paper | Code | Notes |
|---|---|---|
| `Initialize(M, B)` | `new BlockList(M, B)` | `d1` = one empty block bounded by `B`; `d0` empty |
| `Insert(⟨k,v⟩)` | `insert(key, value)` | smallest value per key wins; binary-searches the block bounds; splits blocks that exceed `M` |
| `BatchPrepend(L)` | `batchPrepend(pairs)` | single block if `|L| ≤ M`, else sorted chunks of `≤ ⌈M/2⌉` at the front of `d0` |
| `Pull()` | `pull() → { keys, bound }` | the `≤ M` smallest keys (`Si`) + separating bound (`Bi`), with `max(pulled) ≤ bound ≤ min(remaining)`; `bound = B` when the pull drains the structure |
| `D` non-empty | `isEmpty()` / `size` | loop guard for Algorithm 3 |

### Implementation notes

- **Correctness-first shortcuts** (per the knowledge base): the block-bound index is a plain sorted array with binary search instead of a balanced BST, and splits sort the block instead of linear-time median selection. Same behavior, worse constants — #167 tracks the BST swap.
- The last `d1` block always keeps bound `B` so every `value < B` has a home; emptied blocks are dropped eagerly.
- A `key → block` locator map gives O(1) duplicate resolution and deletion.

## Tests

18 new Jest tests (`test/blockList.test.mjs`), **100% statement/branch/function/line coverage** on `blockList.mjs`, covering the Lemma 3.3 contracts: cross-batch non-decreasing order, the separator invariant, prepend-comes-out-first, smallest-value-wins dedup (insert and batchPrepend, both directions), block splits, re-insert after pull, `value ≥ B` rejection, and a seeded stress test that drives the structure exactly the way Algorithm 3 will (inserts in `[Bi, B)`, prepends in `[Bi', Bi)`).

Full suite: 30 tests passing, lint clean.

## Version

`npm version minor` → **0.15.0 → 0.16.0** (one minor per closed issue, pre-1.0 convention). Tag + GitHub Release happen after merge confirmation per the release routine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)