### PR TITLE
docs: pull latest main before validating the knowledge base

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -21,18 +21,26 @@ Read these once per session for full algorithm context. They are **static** — 
 - [knowledge/03-data-structures.md](knowledge/03-data-structures.md) — Lemma 3.3 block-list + heap
 - [knowledge/04-external-enhancement.md](knowledge/04-external-enhancement.md) — consolidated intuition (fixed)
 
-### Step 2 — Validate the codebase map against the bookmark commit
-Open [knowledge/05-codebase-map.md](knowledge/05-codebase-map.md) and read its
-**`<!-- BOOKMARK-COMMIT: … -->`** line, then compare to the repo's current `main` HEAD:
+### Step 2 — Sync `main`, then validate the codebase map bookmark
+**Always pull the latest `main` first — never reason from a stale local checkout.** PRs may
+have merged between sessions (e.g. a local branch that "has no open PR" may simply be merged
+already), so sync with GitHub before drawing any conclusion about branch or merge state:
 
 ```bash
-git rev-parse HEAD
+git checkout main && git pull origin main   # sync with GitHub before anything else
+git rev-parse HEAD                          # now compare to the bookmark
 ```
+
+Open [knowledge/05-codebase-map.md](knowledge/05-codebase-map.md) and read its
+**`<!-- BOOKMARK-COMMIT: … -->`** line, then compare to the freshly-pulled `main` HEAD:
 
 - **If HEAD == bookmark** → `05` is current; do nothing.
 - **If HEAD != bookmark** → the repo moved. Re-inspect `src/`, `test/`, `examples/`,
   `package.json`, update `05` to match the new reality, and set the bookmark to the new HEAD.
   (See the "Session-start validation" block inside `05` for the exact procedure.)
+- Need to judge whether some local branch or commit is merged? Check
+  `gh pr list --state merged` or `git branch --contains <commit>` against the fresh
+  `origin/main` — do **not** infer merge state from the local working tree.
 
 ### Step 3 — Refresh the milestones roadmap from GitHub (read)
 Using `gh`, read the live milestones and issues and reconcile
@@ -58,8 +66,9 @@ When a session's work **closes an issue**, follow the **Version bump & release**
 When the user types **`RKB`** or **`revitalize_knowledge_base`** at any point in a session,
 perform a **full two-way refresh**:
 
-1. **`05` codebase-map** — re-inspect the repo regardless of the bookmark, rewrite `05`, and
-   reset the bookmark commit to current HEAD.
+1. **`05` codebase-map** — first sync `main` exactly as in session-start Step 2
+   (`git checkout main && git pull origin main`), then re-inspect the repo regardless of the
+   bookmark, rewrite `05`, and reset the bookmark commit to current HEAD.
 2. **`06` milestones-roadmap — two-way sync with GitHub.** Beyond reading, you should
    **use `gh` to make GitHub match the roadmap**, treating the freshly-updated `.claude/`
    knowledge base (post-task learnings from `05`/`07` and the code) as the source of truth:

--- a/.claude/knowledge/05-codebase-map.md
+++ b/.claude/knowledge/05-codebase-map.md
@@ -1,10 +1,12 @@
 # 05 — Codebase Map (current state)
 
-<!-- BOOKMARK-COMMIT: c71f6b919df9eb12d6f3b65fec2be82428c98db9 -->
+<!-- BOOKMARK-COMMIT: 3210c091b6b7638574a95e8b58a1a19b74b7972a -->
 <!-- BOOKMARK-BRANCH: main -->
-<!-- Last validated at session start. PR #160 (#45 adjacency map + benchmark harness) is now
-     MERGED to main; the 611cd53..c71f6b9 diff touched only .claude/knowledge/ files, so the
-     src/test/benchmarks/package.json layout below is unchanged from the prior validation. -->
+<!-- Last validated after pulling main. PR #174 (docs: version-bump & release routine) is
+     MERGED to main; the c71f6b9..3210c09 diff touched only .claude/ files, so the
+     src/test/benchmarks/package.json layout below is unchanged from the prior validation.
+     Pending: PR #175 (feat(#42) BlockList, src/blockList.mjs + tests, bump to 0.16.0) is
+     OPEN — fold it into this map once merged. -->
 <!-- Update both the comment and the body when HEAD moves. -->
 
 Snapshot of what exists in `bmssp-js` today, so you know what to build on vs. what's missing.
@@ -13,9 +15,11 @@ Snapshot of what exists in `bmssp-js` today, so you know what to build on vs. wh
 
 This map is only true as of the **bookmark commit** recorded in the HTML comment at the top
 of this file (`BOOKMARK-COMMIT`). The repo changes as commits land, so validate at the start
-of every session:
+of every session — **after pulling the latest `main`** (never validate against a stale local
+checkout; a branch that looks unmerged locally may already be on `origin/main`):
 
 ```bash
+git checkout main && git pull origin main
 git rev-parse HEAD          # compare to BOOKMARK-COMMIT above
 ```
 


### PR DESCRIPTION
Process fix from today's session: the agent validated the knowledge base against a **stale local checkout** and wrongly concluded the `docs/version-bump-release-routine` branch was unmerged — it had already merged as #174. 

## Changes

- **`.claude/CLAUDE.md` Step 2** — renamed to "Sync `main`, then validate": `git checkout main && git pull origin main` is now the mandatory first action, and merge-state judgments must come from `gh pr list --state merged` / `git branch --contains` against the fresh `origin/main`, never from the local working tree.
- **`.claude/CLAUDE.md` RKB step 1** — the same sync is now the first action of `revitalize_knowledge_base`.
- **`knowledge/05-codebase-map.md`** — validation block gets the same pull-first instruction; bookmark re-stamped to `3210c09` (docs-only merge of #174, layout unchanged) with a note that #175 (feat #42 BlockList) is pending.

Docs-only (`.claude/**`), no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)