### PR TITLE
feat(#41): indexed binary min-heap for the base case (MinHeap)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -85,6 +85,13 @@ perform a **full two-way refresh**:
 3. **`07` glossary** — update [knowledge/07-glossary.md](knowledge/07-glossary.md) to add any
    new symbols/terms introduced by code or roadmap changes since the last refresh.
 
+> **Not gated on the `RKB` keyword:** the roadmap-reshaping powers of item 2 — adjusting the
+> **number, scope, and issue sets of the upcoming minor-version milestones** and the **next
+> major-version milestone** (and the issues within them) — may be exercised **at any point in
+> a working session** when new learnings warrant it, not only when the user types `RKB`.
+> The same gate applies: propose the concrete edits and **confirm with the user before any
+> outward-facing GitHub write**.
+
 `RKB` = the manual superset of the session-start routine, plus the GitHub write-back for `06`.
 It also **re-checks the release state** (`git tag` / `gh release list` vs. `package.json`) so a
 version that was bumped-but-not-yet-released is surfaced.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -92,6 +92,16 @@ perform a **full two-way refresh**:
 > The same gate applies: propose the concrete edits and **confirm with the user before any
 > outward-facing GitHub write**.
 
+> **You co-own the roadmap.** Do not wait to be told to fold post-session learnings into it —
+> the user expects that **every RKB after real progress produces concrete edit proposals**,
+> because every increment of progress teaches something about the issues ahead. On each `RKB`,
+> actively re-derive: are existing issue titles/descriptions still the best statement of the
+> work? Is the issue layout of the **current and future minor versions** still the right
+> slicing? Does the **next major version** still have the right scope? Then put the specific
+> edits in front of the user — **asking per edit** (issues / versions / milestones), since the
+> confirmation gate is per outward-facing write, not per batch. An RKB that proposes nothing
+> after a session that shipped code should be the rare exception, not the default.
+
 `RKB` = the manual superset of the session-start routine, plus the GitHub write-back for `06`.
 It also **re-checks the release state** (`git tag` / `gh release list` vs. `package.json`) so a
 version that was bumped-but-not-yet-released is surfaced.

--- a/.claude/knowledge/05-codebase-map.md
+++ b/.claude/knowledge/05-codebase-map.md
@@ -1,12 +1,13 @@
 # 05 — Codebase Map (current state)
 
-<!-- BOOKMARK-COMMIT: 3210c091b6b7638574a95e8b58a1a19b74b7972a -->
+<!-- BOOKMARK-COMMIT: 3cca82a35595f97a9c7b2420af55772ae95eed8a -->
 <!-- BOOKMARK-BRANCH: main -->
-<!-- Last validated after pulling main. PR #174 (docs: version-bump & release routine) is
-     MERGED to main; the c71f6b9..3210c09 diff touched only .claude/ files, so the
-     src/test/benchmarks/package.json layout below is unchanged from the prior validation.
-     Pending: PR #175 (feat(#42) BlockList, src/blockList.mjs + tests, bump to 0.16.0) is
-     OPEN — fold it into this map once merged. -->
+<!-- Last validated after pulling main. PR #175 (feat(#42) Lemma 3.3 BlockList) is MERGED:
+     adds src/blockList.mjs + test/blockList.test.mjs and bumps the version to 0.16.0
+     (tagged + released; publish.yml fired). #42 is closed — remaining 1.0.0 issues are
+     #40, #41, #43, #44.
+     Pending: PR for #41 (feat: src/heap.mjs indexed MinHeap + tests, bump to 0.17.0) is
+     OPEN — re-stamp the bookmark once merged. -->
 <!-- Update both the comment and the body when HEAD moves. -->
 
 Snapshot of what exists in `bmssp-js` today, so you know what to build on vs. what's missing.
@@ -43,8 +44,12 @@ index.mjs                 # re-exports { BMSSP } and { dijkstra }
 src/
   bmssp.mjs               # BMSSP class — scaffolding + #45 adjacency map (no real algorithm yet)
   dijkstra.mjs            # reference Dijkstra (array binary-heap) — DONE, used as oracle
+  blockList.mjs           # NEW (#42, PR #175): Lemma 3.3 block-based partial-sort structure D
+  heap.mjs                # NEW (#41): indexed binary min-heap (MinHeap) for BaseCase (Alg 2)
 test/
   main.test.mjs           # Jest tests: constructor, nodeIDs, adjacency map, shortestPaths, BMSSP-vs-Dijkstra
+  blockList.test.mjs      # NEW (#42): 18 BlockList tests incl. a seeded random stress test
+  heap.test.mjs           # NEW (#41): 16 MinHeap tests incl. a seeded stress test vs. a naive queue
   roadNet-CA.txt          # real road-network edge list (SNAP roadNet-CA), weights randomized at load
   README.md
 benchmarks/               # NEW (#45 PR): dependency-free benchmark harness, `npm run bench`
@@ -94,6 +99,50 @@ FindPivots → block list → main recursion) has **not** been written yet — t
 #40–#44. The eventual BMSSP entry point should reproduce Dijkstra's answers via the paper's
 method, not by calling Dijkstra.
 
+## `src/blockList.mjs` — Lemma 3.3 structure `D` (#42, DONE in PR #175)
+
+```js
+class BlockList {
+  constructor(M, B)        // block/pull size M >= 1 (floored), strict value upper bound B (Infinity OK)
+  get size / isEmpty()
+  insert(key, value)       // throws if !(value < B); duplicate key keeps the smallest value
+  batchPrepend(pairs)      // iterable of [key, value]; caller guarantees "smaller than everything stored"
+  pull()                   // → { keys: Set, bound } — the ≤M smallest keys; max(pulled) ≤ bound ≤ min(remaining);
+}                          //   bound === B when the pull drains the structure
+export { BlockList };      // NOT re-exported from index.mjs — internal to the algorithm
+```
+
+Implementation notes (matches §03-B including its documented shortcuts):
+- `d1` (insert blocks) + `d0` (prepend blocks); values ordered between blocks, unsorted within.
+  Blocks are `{ bound, entries: Map }`; a `locator` Map (key → block) gives O(1) duplicate handling.
+- Bound index = plain array + binary search instead of a balanced BST (upgrade tracked as #167).
+- Overfull `d1` block splits around the median via sort (O(M log M), not linear-time selection).
+- Big `batchPrepend` batches are sorted and chunked into blocks of ≤ ⌈M/2⌉, prepended to `d0`.
+- Last `d1` block (bound `B`) is kept even when empty so every `insert` finds a home.
+- API surface for Algorithm 3: `Bi, Si ← D.Pull()` maps to `const { keys, bound } = d.pull()`.
+
+## `src/heap.mjs` — indexed binary min-heap (#41)
+
+```js
+class MinHeap {
+  constructor()            // no parameters
+  get size / isEmpty()
+  has(key)                 // O(1) membership — Algorithm 2's "if v not in H"
+  getValue(key)            // current value or undefined
+  peekMin()                // → { key, value } without removing; throws when empty
+  insert(key, value)       // throws on duplicate key or non-number value
+  decreaseKey(key, value)  // throws on missing key; ignored unless value < current (smallest wins)
+  extractMin()             // → { key, value }; throws when empty
+}
+export { MinHeap };        // NOT re-exported from index.mjs — internal to the algorithm
+```
+
+The **true indexed heap** from §03-A (entries array + `position` Map for O(log n)
+`decreaseKey`), matching Algorithm 2 literally — deliberately not the lazy duplicate-and-skip
+variant `src/dijkstra.mjs` uses internally. An extracted key may be re-inserted later.
+16 tests in `test/heap.test.mjs` (contracts, ordering, decreaseKey, the BaseCase
+insert-or-decrease relaxation pattern, seeded stress vs. a naive linear-scan queue).
+
 ## `src/dijkstra.mjs` — the oracle (already done)
 
 `dijkstra(graph, nodeIDs, source) → Map<nodeId, distance>`. Standard array binary min-heap
@@ -111,7 +160,12 @@ implementation is tested against. Reuse its heap style / adjacency-list building
 - `dijkstra` throws on a source not in `nodeIDs`.
 - **Key one:** "BMSSP vs Dijkstra" — for a fixed source, `myBMSSP.shortestPaths` must equal
   `dijkstra(...)` for every node. **Any real BMSSP implementation must keep this passing.**
-- Current suite: **12 tests, all passing; 100% coverage on `bmssp.mjs`.**
+- Current suite: **12 tests in `main.test.mjs` + 18 in `blockList.test.mjs` + 16 in
+  `heap.test.mjs`, all passing.**
+- **BlockList (#42):** init validation, `value < B` enforcement, drain-pull returns bound `B`,
+  batch-sorted pulls of the M smallest, separator invariant, smallest-value-wins dedupe
+  (insert and batchPrepend, vs. stored and within-batch), split correctness, re-insert after
+  pull, chunked large prepends, and a seeded random stress test checking global sorted order.
 
 Graph data: `roadNet-CA.txt` is a large real directed road network; edge weights are assigned
 a random integer in `[1, 1e8]` at load time (so weights differ per run, but BMSSP and Dijkstra
@@ -130,9 +184,9 @@ lands. `benchmarks/README.md` holds the "when to use which" guidance.
 | Missing piece | Lives where (suggested) | Issue | Status |
 |---|---|---|---|
 | Per-node edge adjacency map | `BMSSP` constructor | #45 | ✅ done (PR #160) |
-| Binary min-heap module | `src/heap.mjs` (or inline) | #41 | ⬜ open |
+| Lemma 3.3 block-list `D` | `src/blockList.mjs` | #42 | ✅ done (PR #175) |
+| Binary min-heap module | `src/heap.mjs` | #41 | 🔶 PR open (this branch) |
 | Base case (bounded Dijkstra) | `src/baseCase.mjs` / method | #40 | ⬜ open |
-| Lemma 3.3 block-list `D` | `src/blockList.mjs` | #42 | ⬜ open |
 | FindPivots | `src/findPivots.mjs` / method | #44 | ⬜ open |
 | Main `BMSSP(l, B, S)` recursion + `k,t` derivation | `src/bmssp.mjs` | #43 | ⬜ open |
 

--- a/.claude/knowledge/06-milestones-roadmap.md
+++ b/.claude/knowledge/06-milestones-roadmap.md
@@ -27,7 +27,10 @@ build next); `05-codebase-map.md` is the "reality" side (what exists now).
     minor-version milestones**, and the **next major-version milestone** (titles, descriptions,
     and which issues belong to each — adding or removing issues as needed).
   Outward-facing writes (creating/editing/closing milestones or issues) are **confirmed with the
-  user first**. See the "Forward-looking version plan" section for the working proposal.
+  user first, one ask per edit**. See the "Forward-looking version plan" section for the working
+  proposal. **The agent co-owns this roadmap**: every RKB after real progress should proactively
+  propose issue/milestone improvements from the session's learnings (see `../CLAUDE.md`), rather
+  than waiting for the user to request them.
 
 ---
 
@@ -116,13 +119,19 @@ tables above.
 ### `1.2.0` (milestone #3) — performance & ergonomics
 | # | Issue | Labels |
 |---|---|---|
-| 167 | Replace block-list bound index with a real balanced BST | enhancement · help wanted |
+| 167 | Restore Lemma 3.3's exact asymptotics in BlockList (balanced-BST bound index + linear-time selection) | enhancement · help wanted |
 | 168 | Adjacency and relaxation micro-optimizations | enhancement · help wanted |
 | 169 | Optional shortest-path reconstruction (`Pred[]` → paths) | enhancement · help wanted |
 | 170 | BMSSP-vs-Dijkstra benchmark comparison | enhancement · help wanted |
 
 _Note:_ the seeded **benchmark harness already landed early** with #45 (`benchmarks/`,
 `npm run bench`); #170 just adds the BMSSP column once #43 is done.
+
+_RKB 2026-07-15 (post #42/#41) — issue bodies updated on GitHub:_ #167 widened to both
+BlockList shortcuts (bound index **and** sort-based median selection); #168 widened with the
+indexed-vs-lazy **heap strategy** benchmark/consolidation; #166 re-scoped to the older doc
+surface (new modules ship with JSDoc already); #173 gained the explicit internal-vs-public
+exposure decision (BlockList/MinHeap are not re-exported from `index.mjs`).
 
 ### `2.0.0` (milestone #4) — API-breaking generalization
 | # | Issue | Labels |

--- a/.claude/knowledge/06-milestones-roadmap.md
+++ b/.claude/knowledge/06-milestones-roadmap.md
@@ -1,7 +1,7 @@
 # 06 — Milestones Roadmap
 
-<!-- SYNCED-FROM-GITHUB: 2026-07-15 (session-start reconciliation; PR #160 merged) -->
-<!-- Current package version: 0.15.0 -->
+<!-- SYNCED-FROM-GITHUB: 2026-07-15 (session-start reconciliation; PR #175 merged, #42 closed) -->
+<!-- Current package version: 0.16.0 (tagged + released) -->
 
 Maps GitHub **milestones** and **issues** (Sirivasv/bmssp-js) to the paper's building blocks,
 with a dependency-aware build order. This is the "intent" side of the knowledge base (what to
@@ -33,12 +33,14 @@ build next); `05-codebase-map.md` is the "reality" side (what exists now).
 
 ## Current state (as synced)
 
-- **Package version:** `0.15.0` (pre-1.0; the algorithm is not yet functional end-to-end).
+- **Package version:** `0.16.0` (pre-1.0; the algorithm is not yet functional end-to-end).
+  The `0.16.0` tag + GitHub Release are published (npm + Docker Hub CD fired).
 - **Active milestone:** **`1.0.0` — "Have a first functional version of the whole algorithm."**
-  - GitHub progress: **6 closed / 5 open** issues (PR #160 merged, so #45 now counts closed).
-  - The 5 open issues (#40–#44) are exactly the remaining algorithm pieces from §02–§03.
-- **Just merged:** **#45 — adjacency map + benchmark harness — PR #160 is now on `main`**
-  (commit `c71f6b9`). See `05-codebase-map.md` for the shipped `this.adjacency` / `getEdges` API.
+  - GitHub progress: **7 closed / 4 open** issues (PR #175 merged, so #42 now counts closed).
+  - The 4 open issues (#40, #41, #43, #44) are the remaining algorithm pieces from §02–§03.
+- **Just merged:** **#42 — Lemma 3.3 BlockList — PR #175 is now on `main`** (commit `3cca82a`).
+  See `05-codebase-map.md` for the shipped `src/blockList.mjs` API (`insert` / `batchPrepend` /
+  `pull`) and its documented shortcuts (array bound index → #167).
 
 ## Milestone `1.0.0` — issues → paper
 
@@ -47,7 +49,7 @@ build next); `05-codebase-map.md` is the "reality" side (what exists now).
 | **45** | Add a map of arrays for edges of each node | Adjacency map so edge lookups aren't O(m). §05 | help wanted · good first issue | — | ✅ merged (PR #160) |
 | **41** | Implement a priority heap | Binary min-heap for the base case (Alg 2). §03-A | help wanted · good first issue | — | ⬜ open |
 | **40** | Implement the base case of the bmssp algorithm | `BaseCase(B, S)` bounded mini-Dijkstra. **Alg 2**, §02 | help wanted | #41 | ⬜ open |
-| **42** | Implement Lema 3.3 data structure | Block-based partial-sort list `D`. **Lemma 3.3**, §03-B | help wanted | — | ⬜ open |
+| **42** | Implement Lema 3.3 data structure | Block-based partial-sort list `D`. **Lemma 3.3**, §03-B | help wanted | — | ✅ merged (PR #175) |
 | **44** | Implement the findingPivots function | `FindPivots(B, S)` frontier shrink. **Alg 1**, §02 | help wanted | #45 (helpful) | ⬜ open |
 | **43** | Implement main bmssp algorithm | `BMSSP(l, B, S)` recursion + `k,t`. **Alg 3**, §02 | help wanted | #40, #42, #44 | ⬜ open |
 
@@ -63,14 +65,15 @@ Leaves first; two independent tracks converge on the main recursion:
 ```
 Track A (base case):     #45 adjacency map ─┬─▶ #41 heap ─▶ #40 BaseCase ─┐   (#45 ✅ done)
 Track B (recursion core):    (✅ done)       └─▶ #44 FindPivots ───────────┼─▶ #43 BMSSP main
-                                                #42 BlockList ─────────────┘
+                                                #42 BlockList (✅ done) ───┘
 ```
 
 1. ~~**#45** adjacency map~~ — ✅ **done (PR #160):** `this.adjacency: Map<nodeId, [to,w][]>`
    + `getEdges()`, built in the constructor. Unblocks #40 and #44.
-2. **#41** binary min-heap — standalone, unit-testable (or reuse `dijkstra.mjs`'s lazy heap).
-   **← recommended next (leaf on Track A).**
-3. **#42** block-list `D` — standalone; biggest/riskiest; do early in isolation (§03-B tests).
+2. ~~**#42** block-list `D`~~ — ✅ **done (PR #175):** `src/blockList.mjs` + 18 tests
+   (§03-B contracts incl. seeded stress). Bound index is a sorted array for now (#167).
+3. **#41** binary min-heap — 🔶 **PR open:** `src/heap.mjs` indexed `MinHeap`
+   (insert/extractMin/decreaseKey/has) + 16 tests; bump to 0.17.0. Unblocks #40 once merged.
 4. **#40** BaseCase — needs #41 (+ #45 ✅). Test vs. a plain bounded Dijkstra from `x`.
 5. **#44** FindPivots — needs relaxation + adjacency (#45 ✅). Test both branches (`|W|>k|S|`
    and forest roots).
@@ -97,7 +100,8 @@ Clamp `k`,`t` to `≥ 1` for tiny graphs; correctness must not depend on the asy
 > GitHub going forward.
 
 ### `1.0.0` (milestone #1) — first end-to-end functional BMSSP
-Issues #40–#45. #45 done (PR #160); #40–#44 open. See the tables above.
+Issues #40–#45. #45 done (PR #160), #42 done (PR #175); #40, #41, #43, #44 open. See the
+tables above.
 
 ### `1.1.0` (milestone #2) — correctness hardening
 | # | Issue | Labels |

--- a/.claude/knowledge/07-glossary.md
+++ b/.claude/knowledge/07-glossary.md
@@ -1,6 +1,6 @@
 # 07 — Glossary
 
-<!-- Updated on: RKB (revitalize_knowledge_base) -->
+<!-- Updated on: RKB 2026-07-15 (added #42 BlockList and #41 MinHeap code terms) -->
 
 > **Lifecycle: dynamic — updated on `RKB`.** This glossary is refreshed on the on-demand
 > `revitalize_knowledge_base` (`RKB`) command (see `../CLAUDE.md`). When code or the roadmap
@@ -71,6 +71,30 @@ Quick lookup for the symbols and terms used across the paper, the notes, and the
   `[to, weight]` pairs; returns `[]` for unknown nodes.
 - **Adjacency list (oracle)** — the *local* adjacency `Map` that `src/dijkstra.mjs` builds
   internally per call; distinct from the class's persistent `this.adjacency`.
+- **`BlockList`** (#42) — `src/blockList.mjs`, the Lemma 3.3 structure `D`. API:
+  `insert(key, value)` / `batchPrepend(pairs)` / `pull() → { keys, bound }`, plus
+  `size` / `isEmpty()`. `pull()`'s `{ keys, bound }` is Algorithm 3's `Si, Bi`. Values must
+  be `< B`; duplicate keys keep the smallest value everywhere. Internal to the algorithm
+  (not re-exported from `index.mjs`).
+- **`d0` / `d1`** (#42) — the `BlockList`'s two block sequences: `d1` receives `insert`s
+  (each block carries an upper `bound`, non-decreasing across blocks; the last block's bound
+  is `B`), `d0` receives `batchPrepend` blocks and conceptually sits in front of `d1`.
+- **`locator`** (#42) — the `BlockList`'s `Map<key, block>` giving O(1) duplicate handling
+  (find/replace an existing key without scanning blocks).
+- **Bound index shortcut** (#42) — `d1`'s block bounds are binary-searched in a plain array
+  instead of the paper's balanced BST; upgrading it is issue #167. Block **splits** use a
+  sort (O(M log M)) instead of linear-time median selection — same correctness, worse
+  constants.
+- **`MinHeap`** (#41) — `src/heap.mjs`, the *indexed* binary min-heap for BaseCase (Alg 2):
+  `insert` / `extractMin()` / `peekMin() → { key, value }` / `decreaseKey` / `has` /
+  `getValue` / `size` / `isEmpty()`. `has` is Algorithm 2's "is `v` in `H`?" branch;
+  `decreaseKey` ignores non-decreasing values (smallest wins, mirroring `≤` relaxation);
+  an extracted key may be re-inserted. Internal (not re-exported from `index.mjs`).
+- **`position` map** (#41) — the `MinHeap`'s `Map<key, arrayIndex>` kept in sync on every
+  swap; what makes `has`/`getValue` O(1) and `decreaseKey` O(log n).
+- **Indexed vs. lazy heap** — `MinHeap` is the paper-literal *indexed* variant (true
+  `DecreaseKey`); `src/dijkstra.mjs` internally uses the *lazy* variant (push duplicates,
+  skip stale pops). Both are correct; §03-A discusses the trade-off.
 - **Benchmark harness** — `benchmarks/` (run via `npm run bench`): seeded graph
   **generators** + a `SCENARIOS` registry (sparse-random / dense-random / grid / chain /
   star), `timeMany` timing, and two benchmarks (adjacency-vs-scan, per-shape Dijkstra). Will

--- a/.claude/knowledge/07-glossary.md
+++ b/.claude/knowledge/07-glossary.md
@@ -82,9 +82,9 @@ Quick lookup for the symbols and terms used across the paper, the notes, and the
 - **`locator`** (#42) — the `BlockList`'s `Map<key, block>` giving O(1) duplicate handling
   (find/replace an existing key without scanning blocks).
 - **Bound index shortcut** (#42) — `d1`'s block bounds are binary-searched in a plain array
-  instead of the paper's balanced BST; upgrading it is issue #167. Block **splits** use a
-  sort (O(M log M)) instead of linear-time median selection — same correctness, worse
-  constants.
+  instead of the paper's balanced BST, and block **splits**/batch chunking use a sort
+  (O(M log M)) instead of linear-time median selection — same correctness, worse constants.
+  Both upgrades are tracked together in issue #167.
 - **`MinHeap`** (#41) — `src/heap.mjs`, the *indexed* binary min-heap for BaseCase (Alg 2):
   `insert` / `extractMin()` / `peekMin() → { key, value }` / `decreaseKey` / `has` /
   `getValue` / `size` / `isEmpty()`. `has` is Algorithm 2's "is `v` in `H`?" branch;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bmssp",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bmssp",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "MPL-2.0",
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bmssp",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Javascript package implementation of the bmssp algorithm.",
   "main": "index.mjs",
   "keywords": [

--- a/src/heap.mjs
+++ b/src/heap.mjs
@@ -1,0 +1,167 @@
+/**
+ * Array-backed indexed binary min-heap for the BMSSP base case (Algorithm 2
+ * of "Breaking the Sorting Barrier for Directed Single-Source Shortest
+ * Paths"). Holds <key, value> pairs (vertex, distance estimate) ordered by
+ * value and supports exactly the operations BaseCase(B, S) needs:
+ *
+ *   insert(key, value)      — add a key not currently stored
+ *   extractMin()            — remove and return the smallest-valued pair
+ *   decreaseKey(key, value) — lower the value of a stored key
+ *   has(key)                — membership test ("is v in H?")
+ *
+ * A position map (key -> array index) makes decreaseKey and has O(log n) /
+ * O(1), matching the paper's heap literally instead of the lazy
+ * duplicate-and-skip variant used inside src/dijkstra.mjs.
+ */
+class MinHeap {
+  constructor() {
+    // entries[i] = [key, value], heap-ordered by value
+    this.entries = [];
+    // key -> index of that key in entries, for O(1) membership / lookup
+    this.position = new Map();
+  }
+
+  // Number of pairs currently stored
+  get size() {
+    return this.entries.length;
+  }
+
+  isEmpty() {
+    return this.entries.length === 0;
+  }
+
+  has(key) {
+    return this.position.has(key);
+  }
+
+  /**
+   * Current value of a stored key, or undefined if the key is not present.
+   * @param {*} key - Typically a node ID
+   * @returns {number|undefined}
+   */
+  getValue(key) {
+    const index = this.position.get(key);
+    return index === undefined ? undefined : this.entries[index][1];
+  }
+
+  /**
+   * Smallest-valued pair without removing it.
+   * @returns {{ key: *, value: number }}
+   * @throws {Error} If the heap is empty
+   */
+  peekMin() {
+    if (this.entries.length === 0) {
+      throw new Error("heap is empty");
+    }
+    const [key, value] = this.entries[0];
+    return { key, value };
+  }
+
+  /**
+   * Add a pair for a key that is not currently stored (Algorithm 2 Insert).
+   * A key that was extracted earlier may be inserted again.
+   * @param {*} key - Typically a node ID
+   * @param {number} value - Priority; smaller comes out first
+   * @throws {Error} If the key is already stored, or value is not a number
+   */
+  insert(key, value) {
+    if (typeof value !== "number" || Number.isNaN(value)) {
+      throw new Error("value must be a number");
+    }
+    if (this.position.has(key)) {
+      throw new Error("key already in heap — use decreaseKey");
+    }
+    this.entries.push([key, value]);
+    this.position.set(key, this.entries.length - 1);
+    this.siftUp(this.entries.length - 1);
+  }
+
+  /**
+   * Lower the value of a stored key (Algorithm 2 DecreaseKey). A value that
+   * would not decrease the stored one is ignored — the smallest value wins,
+   * mirroring the `<=` edge relaxation which re-relaxes with equal sums.
+   * @param {*} key - Must be currently stored
+   * @param {number} value - New priority; applied only when smaller
+   * @throws {Error} If the key is not stored, or value is not a number
+   */
+  decreaseKey(key, value) {
+    if (typeof value !== "number" || Number.isNaN(value)) {
+      throw new Error("value must be a number");
+    }
+    const index = this.position.get(key);
+    if (index === undefined) {
+      throw new Error("key not in heap — use insert");
+    }
+    if (this.entries[index][1] <= value) return;
+    this.entries[index][1] = value;
+    this.siftUp(index);
+  }
+
+  /**
+   * Remove and return the smallest-valued pair (Algorithm 2 ExtractMin).
+   * @returns {{ key: *, value: number }}
+   * @throws {Error} If the heap is empty
+   */
+  extractMin() {
+    if (this.entries.length === 0) {
+      throw new Error("heap is empty");
+    }
+    const [key, value] = this.entries[0];
+    this.position.delete(key);
+    const last = this.entries.pop();
+    if (this.entries.length > 0) {
+      this.entries[0] = last;
+      this.position.set(last[0], 0);
+      this.siftDown(0);
+    }
+    return { key, value };
+  }
+
+  // Internal: swap two entries and keep the position map in sync
+  swap(i, j) {
+    const a = this.entries[i];
+    const b = this.entries[j];
+    this.entries[i] = b;
+    this.entries[j] = a;
+    this.position.set(b[0], i);
+    this.position.set(a[0], j);
+  }
+
+  // Internal: move the entry at index up until its parent is not larger
+  siftUp(index) {
+    let i = index;
+    while (i > 0) {
+      const parent = (i - 1) >> 1;
+      if (this.entries[parent][1] <= this.entries[i][1]) break;
+      this.swap(parent, i);
+      i = parent;
+    }
+  }
+
+  // Internal: move the entry at index down until no child is smaller
+  siftDown(index) {
+    let i = index;
+    for (;;) {
+      const left = 2 * i + 1;
+      const right = left + 1;
+      let smallest = i;
+      if (
+        left < this.entries.length &&
+        this.entries[left][1] < this.entries[smallest][1]
+      ) {
+        smallest = left;
+      }
+      if (
+        right < this.entries.length &&
+        this.entries[right][1] < this.entries[smallest][1]
+      ) {
+        smallest = right;
+      }
+      if (smallest === i) break;
+      this.swap(smallest, i);
+      i = smallest;
+    }
+  }
+}
+
+export { MinHeap };

--- a/test/heap.test.mjs
+++ b/test/heap.test.mjs
@@ -1,0 +1,195 @@
+import { describe, test, expect } from "@jest/globals";
+import { MinHeap } from "../src/heap.mjs";
+
+// Small deterministic PRNG so stress-test failures are reproducible
+function mulberry32(seed) {
+  let a = seed >>> 0;
+  return function () {
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// Extract every pair, returning the values in extraction order
+function drainValues(heap) {
+  const values = [];
+  while (!heap.isEmpty()) {
+    values.push(heap.extractMin().value);
+  }
+  return values;
+}
+
+describe("MinHeap basics", () => {
+  test("starts empty", () => {
+    const heap = new MinHeap();
+    expect(heap.isEmpty()).toBe(true);
+    expect(heap.size).toBe(0);
+  });
+
+  test("extractMin and peekMin on an empty heap throw", () => {
+    const heap = new MinHeap();
+    expect(() => heap.extractMin()).toThrow("heap is empty");
+    expect(() => heap.peekMin()).toThrow("heap is empty");
+  });
+
+  test("insert rejects non-numeric values", () => {
+    const heap = new MinHeap();
+    expect(() => heap.insert(1, NaN)).toThrow("value must be a number");
+    expect(() => heap.insert(1, "7")).toThrow("value must be a number");
+  });
+
+  test("insert rejects a key that is already stored", () => {
+    const heap = new MinHeap();
+    heap.insert(1, 10);
+    expect(() => heap.insert(1, 5)).toThrow(
+      "key already in heap — use decreaseKey",
+    );
+  });
+
+  test("size, has and getValue reflect inserts and extracts", () => {
+    const heap = new MinHeap();
+    heap.insert("a", 3);
+    heap.insert("b", 1);
+    expect(heap.size).toBe(2);
+    expect(heap.has("a")).toBe(true);
+    expect(heap.getValue("a")).toBe(3);
+    expect(heap.getValue("missing")).toBeUndefined();
+    expect(heap.extractMin()).toEqual({ key: "b", value: 1 });
+    expect(heap.has("b")).toBe(false);
+    expect(heap.size).toBe(1);
+  });
+
+  test("Infinity is a valid value", () => {
+    const heap = new MinHeap();
+    heap.insert(1, Infinity);
+    heap.insert(2, 42);
+    expect(heap.extractMin()).toEqual({ key: 2, value: 42 });
+    expect(heap.extractMin()).toEqual({ key: 1, value: Infinity });
+  });
+});
+
+describe("MinHeap ordering", () => {
+  test("extracts pairs in non-decreasing value order", () => {
+    const heap = new MinHeap();
+    const values = [9, 4, 7, 1, 8, 2, 6, 3, 5, 0];
+    values.forEach((value, key) => heap.insert(key, value));
+    expect(drainValues(heap)).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  });
+
+  test("equal values all come out, adjacent to each other", () => {
+    const heap = new MinHeap();
+    heap.insert("a", 5);
+    heap.insert("b", 5);
+    heap.insert("c", 1);
+    expect(heap.extractMin().value).toBe(1);
+    const keys = [heap.extractMin(), heap.extractMin()].map((e) => e.key);
+    expect(new Set(keys)).toEqual(new Set(["a", "b"]));
+    expect(heap.isEmpty()).toBe(true);
+  });
+
+  test("peekMin returns the minimum without removing it", () => {
+    const heap = new MinHeap();
+    heap.insert(1, 20);
+    heap.insert(2, 10);
+    expect(heap.peekMin()).toEqual({ key: 2, value: 10 });
+    expect(heap.size).toBe(2);
+  });
+
+  test("an extracted key can be inserted again", () => {
+    const heap = new MinHeap();
+    heap.insert(1, 10);
+    heap.extractMin();
+    heap.insert(1, 4);
+    expect(heap.extractMin()).toEqual({ key: 1, value: 4 });
+  });
+});
+
+describe("MinHeap decreaseKey", () => {
+  test("rejects a key that is not stored", () => {
+    const heap = new MinHeap();
+    expect(() => heap.decreaseKey(1, 5)).toThrow(
+      "key not in heap — use insert",
+    );
+  });
+
+  test("rejects non-numeric values", () => {
+    const heap = new MinHeap();
+    heap.insert(1, 10);
+    expect(() => heap.decreaseKey(1, NaN)).toThrow("value must be a number");
+  });
+
+  test("a lowered key becomes the new minimum", () => {
+    const heap = new MinHeap();
+    heap.insert("a", 10);
+    heap.insert("b", 20);
+    heap.insert("c", 30);
+    heap.decreaseKey("c", 1);
+    expect(heap.getValue("c")).toBe(1);
+    expect(heap.extractMin()).toEqual({ key: "c", value: 1 });
+  });
+
+  test("a value that would not decrease the stored one is ignored", () => {
+    const heap = new MinHeap();
+    heap.insert(1, 10);
+    heap.decreaseKey(1, 10);
+    heap.decreaseKey(1, 25);
+    expect(heap.getValue(1)).toBe(10);
+  });
+
+  test("supports the BaseCase relaxation pattern (insert or decreaseKey)", () => {
+    // Relax edge (u, v): if v not in H insert it, else lower its key —
+    // exactly the branch Algorithm 2 performs after each edge relaxation
+    const heap = new MinHeap();
+    const relax = (v, d) => {
+      if (!heap.has(v)) heap.insert(v, d);
+      else heap.decreaseKey(v, d);
+    };
+    relax("v", 50);
+    relax("w", 30);
+    relax("v", 20);
+    relax("w", 40);
+    expect(heap.extractMin()).toEqual({ key: "v", value: 20 });
+    expect(heap.extractMin()).toEqual({ key: "w", value: 30 });
+  });
+});
+
+describe("MinHeap stress (seeded)", () => {
+  test("random inserts, decreases and extracts match a naive queue", () => {
+    const rand = mulberry32(41);
+    const heap = new MinHeap();
+    const naive = new Map(); // key -> value, scanned linearly for the min
+    let nextKey = 0;
+    for (let step = 0; step < 5000; step += 1) {
+      const roll = rand();
+      if (roll < 0.5) {
+        const value = Math.floor(rand() * 1e6);
+        heap.insert(nextKey, value);
+        naive.set(nextKey, value);
+        nextKey += 1;
+      } else if (roll < 0.75 && naive.size > 0) {
+        // Decrease a random stored key by a random amount
+        const keys = [...naive.keys()];
+        const key = keys[Math.floor(rand() * keys.length)];
+        const value = naive.get(key) - Math.floor(rand() * 1e5);
+        heap.decreaseKey(key, value);
+        if (value < naive.get(key)) naive.set(key, value);
+      } else if (naive.size > 0) {
+        const { key, value } = heap.extractMin();
+        let minValue = Infinity;
+        for (const v of naive.values()) {
+          if (v < minValue) minValue = v;
+        }
+        expect(value).toBe(minValue);
+        expect(naive.get(key)).toBe(minValue);
+        naive.delete(key);
+      }
+      expect(heap.size).toBe(naive.size);
+    }
+    // Drain what is left: extraction order must be non-decreasing
+    const rest = drainValues(heap);
+    const sorted = [...rest].sort((a, b) => a - b);
+    expect(rest).toEqual(sorted);
+  });
+});


### PR DESCRIPTION
## Summary

Implements **#41 — the priority heap** for the BMSSP base case (Algorithm 2, `BaseCase(B, S)`).

- **`src/heap.mjs`** — `MinHeap`, an array-backed **indexed** binary min-heap of `<key, value>` pairs with a `key → index` position map:
  - `insert(key, value)` — throws on duplicate keys and non-numeric values; an extracted key may be re-inserted.
  - `extractMin()` / `peekMin()` — `{ key, value }`; throw when empty.
  - `decreaseKey(key, value)` — O(log n) via the position map; a value that would not decrease the stored one is ignored (smallest wins, mirroring the paper's `≤` relaxation).
  - `has(key)` / `getValue(key)` / `size` / `isEmpty()` — O(1); `has` is Algorithm 2's "if v not in H" branch.
- This is the **paper-literal indexed variant** from the design notes (`.claude/knowledge/03-data-structures.md` §A), deliberately distinct from the lazy duplicate-and-skip heap inside `dijkstra.mjs`. Not re-exported from `index.mjs` — internal to the algorithm.
- **`test/heap.test.mjs`** — 16 tests: contracts/validation, ordering (incl. ties and Infinity), `decreaseKey` behavior, the BaseCase insert-or-decrease relaxation pattern, and a seeded (mulberry32) stress test against a naive linear-scan queue. 100% coverage on `heap.mjs`.

Also in this PR (housekeeping):
- **Version bump `0.16.0 → 0.17.0`** via `npm version minor --no-git-tag-version` (release routine phase 1; tag + release after merge confirmation).
- Knowledge-base sync: `05`/`06` updated for the merged #42 BlockList (PR #175) and this PR.
- `CLAUDE.md`: note that RKB's milestone-reshaping powers can be exercised at any point in a session (GitHub writes still user-confirmed).

Closes #41

## Test plan

- [x] `npm run lint` clean (Prettier + ESLint)
- [x] `npm test` — 46/46 passing (main 12, blockList 18, heap 16); 100% line coverage on `heap.mjs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)