### PR TITLE
feat(#40): BaseCase(B, S) bounded mini-Dijkstra (Algorithm 2)

### DIFF
--- a/.claude/knowledge/05-codebase-map.md
+++ b/.claude/knowledge/05-codebase-map.md
@@ -1,13 +1,13 @@
 # 05 — Codebase Map (current state)
 
-<!-- BOOKMARK-COMMIT: 3cca82a35595f97a9c7b2420af55772ae95eed8a -->
+<!-- BOOKMARK-COMMIT: 7e36afc63828ccefea4db037c0d506d28ae3100a -->
 <!-- BOOKMARK-BRANCH: main -->
-<!-- Last validated after pulling main. PR #175 (feat(#42) Lemma 3.3 BlockList) is MERGED:
-     adds src/blockList.mjs + test/blockList.test.mjs and bumps the version to 0.16.0
-     (tagged + released; publish.yml fired). #42 is closed — remaining 1.0.0 issues are
-     #40, #41, #43, #44.
-     Pending: PR for #41 (feat: src/heap.mjs indexed MinHeap + tests, bump to 0.17.0) is
-     OPEN — re-stamp the bookmark once merged. -->
+<!-- Last validated 2026-07-16 after pulling main. PR #177 (feat(#41) indexed MinHeap) is
+     MERGED: src/heap.mjs + test/heap.test.mjs are on main and the version is 0.17.0
+     (tagged + released 2026-07-15; publish.yml fired). #41 is closed — remaining 1.0.0
+     issues are #40, #43, #44.
+     Pending: PR for #40 (feat: src/baseCase.mjs BaseCase(B, S) + tests, bump to 0.18.0)
+     is OPEN — re-stamp the bookmark once merged. -->
 <!-- Update both the comment and the body when HEAD moves. -->
 
 Snapshot of what exists in `bmssp-js` today, so you know what to build on vs. what's missing.
@@ -46,10 +46,12 @@ src/
   dijkstra.mjs            # reference Dijkstra (array binary-heap) — DONE, used as oracle
   blockList.mjs           # NEW (#42, PR #175): Lemma 3.3 block-based partial-sort structure D
   heap.mjs                # NEW (#41): indexed binary min-heap (MinHeap) for BaseCase (Alg 2)
+  baseCase.mjs            # NEW (#40): BaseCase(B, S) — Algorithm 2 bounded mini-Dijkstra
 test/
   main.test.mjs           # Jest tests: constructor, nodeIDs, adjacency map, shortestPaths, BMSSP-vs-Dijkstra
   blockList.test.mjs      # NEW (#42): 18 BlockList tests incl. a seeded random stress test
   heap.test.mjs           # NEW (#41): 16 MinHeap tests incl. a seeded stress test vs. a naive queue
+  baseCase.test.mjs       # NEW (#40): 13 BaseCase tests incl. seeded oracle-comparison stress
   roadNet-CA.txt          # real road-network edge list (SNAP roadNet-CA), weights randomized at load
   README.md
 benchmarks/               # NEW (#45 PR): dependency-free benchmark harness, `npm run bench`
@@ -143,6 +145,26 @@ variant `src/dijkstra.mjs` uses internally. An extracted key may be re-inserted 
 16 tests in `test/heap.test.mjs` (contracts, ordering, decreaseKey, the BaseCase
 insert-or-decrease relaxation pattern, seeded stress vs. a naive linear-scan queue).
 
+## `src/baseCase.mjs` — `BaseCase(B, S)`, Algorithm 2 (#40)
+
+```js
+baseCase(B, S, dHat, adjacency, k)  // → { bound, vertices }
+// B         : strict distance upper bound (Infinity OK)
+// S         : singleton Set holding the complete source x (throws otherwise)
+// dHat      : Map<nodeId, number> — the global d̂[·]; RELAXED IN PLACE
+// adjacency : Map<nodeId, [to, weight][]> — the class's this.adjacency
+// k         : settle cap >= 1 (floored); throws otherwise
+export { baseCase };     // NOT re-exported from index.mjs — internal to the algorithm
+```
+
+Bounded mini-Dijkstra from `x` on the `MinHeap`, stopping after settling `k+1` vertices.
+Full success (heap exhausted at ≤ k settled) → `{ bound: B, vertices: U0 }`; partial (cap
+hit) → `bound` = max settled `d̂`, `vertices` = the strictly-closer ones. Relaxation uses
+the paper's `≤` + `< B` test, with one guard: a vertex already settled **in this call** is
+never re-inserted into the heap (an equal-sum relaxation — e.g. a zero-weight cycle — would
+otherwise loop forever; with non-negative weights a settled vertex cannot strictly improve,
+so nothing is lost). Callers wire it as `Bi', Ui ← BaseCase(Bi, Si)` at level 0 of #43.
+
 ## `src/dijkstra.mjs` — the oracle (already done)
 
 `dijkstra(graph, nodeIDs, source) → Map<nodeId, distance>`. Standard array binary min-heap
@@ -161,7 +183,12 @@ implementation is tested against. Reuse its heap style / adjacency-list building
 - **Key one:** "BMSSP vs Dijkstra" — for a fixed source, `myBMSSP.shortestPaths` must equal
   `dijkstra(...)` for every node. **Any real BMSSP implementation must keep this passing.**
 - Current suite: **12 tests in `main.test.mjs` + 18 in `blockList.test.mjs` + 16 in
-  `heap.test.mjs`, all passing.**
+  `heap.test.mjs` + 13 in `baseCase.test.mjs`, all passing (59).**
+- **BaseCase (#40):** validation (k, singleton S, complete source), full-success vs. finite/
+  infinite B, partial k+1-cap boundary reporting (incl. ties excluded by the strict filter),
+  zero-weight-cycle termination, and two seeded stress tests checking the Algorithm 2
+  contract against the Dijkstra oracle (exact distances, completeness below B', d̂ never
+  underestimates).
 - **BlockList (#42):** init validation, `value < B` enforcement, drain-pull returns bound `B`,
   batch-sorted pulls of the M smallest, separator invariant, smallest-value-wins dedupe
   (insert and batchPrepend, vs. stored and within-batch), split correctness, re-insert after
@@ -185,8 +212,8 @@ lands. `benchmarks/README.md` holds the "when to use which" guidance.
 |---|---|---|---|
 | Per-node edge adjacency map | `BMSSP` constructor | #45 | ✅ done (PR #160) |
 | Lemma 3.3 block-list `D` | `src/blockList.mjs` | #42 | ✅ done (PR #175) |
-| Binary min-heap module | `src/heap.mjs` | #41 | 🔶 PR open (this branch) |
-| Base case (bounded Dijkstra) | `src/baseCase.mjs` / method | #40 | ⬜ open |
+| Binary min-heap module | `src/heap.mjs` | #41 | ✅ done (PR #177) |
+| Base case (bounded Dijkstra) | `src/baseCase.mjs` | #40 | 🔶 PR open (this branch) |
 | FindPivots | `src/findPivots.mjs` / method | #44 | ⬜ open |
 | Main `BMSSP(l, B, S)` recursion + `k,t` derivation | `src/bmssp.mjs` | #43 | ⬜ open |
 

--- a/.claude/knowledge/06-milestones-roadmap.md
+++ b/.claude/knowledge/06-milestones-roadmap.md
@@ -1,7 +1,7 @@
 # 06 — Milestones Roadmap
 
-<!-- SYNCED-FROM-GITHUB: 2026-07-15 (session-start reconciliation; PR #175 merged, #42 closed) -->
-<!-- Current package version: 0.16.0 (tagged + released) -->
+<!-- SYNCED-FROM-GITHUB: 2026-07-16 (session-start reconciliation; PR #177 merged, #41 closed) -->
+<!-- Current package version: 0.17.0 (tagged + released) -->
 
 Maps GitHub **milestones** and **issues** (Sirivasv/bmssp-js) to the paper's building blocks,
 with a dependency-aware build order. This is the "intent" side of the knowledge base (what to
@@ -36,22 +36,23 @@ build next); `05-codebase-map.md` is the "reality" side (what exists now).
 
 ## Current state (as synced)
 
-- **Package version:** `0.16.0` (pre-1.0; the algorithm is not yet functional end-to-end).
-  The `0.16.0` tag + GitHub Release are published (npm + Docker Hub CD fired).
+- **Package version:** `0.17.0` (pre-1.0; the algorithm is not yet functional end-to-end).
+  The `0.17.0` tag + GitHub Release are published (npm + Docker Hub CD fired).
 - **Active milestone:** **`1.0.0` — "Have a first functional version of the whole algorithm."**
-  - GitHub progress: **7 closed / 4 open** issues (PR #175 merged, so #42 now counts closed).
-  - The 4 open issues (#40, #41, #43, #44) are the remaining algorithm pieces from §02–§03.
-- **Just merged:** **#42 — Lemma 3.3 BlockList — PR #175 is now on `main`** (commit `3cca82a`).
-  See `05-codebase-map.md` for the shipped `src/blockList.mjs` API (`insert` / `batchPrepend` /
-  `pull`) and its documented shortcuts (array bound index → #167).
+  - GitHub progress: **8 closed / 3 open** issues (PR #177 merged, so #41 now counts closed).
+  - The 3 open issues (#40, #43, #44) are the remaining algorithm pieces from §02–§03.
+- **Just merged:** **#41 — indexed binary MinHeap — PR #177 is now on `main`** (commit
+  `7e36afc`). See `05-codebase-map.md` for the shipped `src/heap.mjs` API
+  (`insert` / `extractMin` / `decreaseKey` / `has` / `peekMin`). With #41 done, **#40
+  (BaseCase) is fully unblocked** — both its dependencies (#41 heap, #45 adjacency) are in.
 
 ## Milestone `1.0.0` — issues → paper
 
 | # | Title | What it is (paper) | Labels | Depends on | Status |
 |---|---|---|---|---|---|
 | **45** | Add a map of arrays for edges of each node | Adjacency map so edge lookups aren't O(m). §05 | help wanted · good first issue | — | ✅ merged (PR #160) |
-| **41** | Implement a priority heap | Binary min-heap for the base case (Alg 2). §03-A | help wanted · good first issue | — | ⬜ open |
-| **40** | Implement the base case of the bmssp algorithm | `BaseCase(B, S)` bounded mini-Dijkstra. **Alg 2**, §02 | help wanted | #41 | ⬜ open |
+| **41** | Implement a priority heap | Binary min-heap for the base case (Alg 2). §03-A | help wanted · good first issue | — | ✅ merged (PR #177) |
+| **40** | Implement the base case of the bmssp algorithm | `BaseCase(B, S)` bounded mini-Dijkstra. **Alg 2**, §02 | help wanted | #41 | 🔶 PR open |
 | **42** | Implement Lema 3.3 data structure | Block-based partial-sort list `D`. **Lemma 3.3**, §03-B | help wanted | — | ✅ merged (PR #175) |
 | **44** | Implement the findingPivots function | `FindPivots(B, S)` frontier shrink. **Alg 1**, §02 | help wanted | #45 (helpful) | ⬜ open |
 | **43** | Implement main bmssp algorithm | `BMSSP(l, B, S)` recursion + `k,t`. **Alg 3**, §02 | help wanted | #40, #42, #44 | ⬜ open |
@@ -66,7 +67,7 @@ build next); `05-codebase-map.md` is the "reality" side (what exists now).
 Leaves first; two independent tracks converge on the main recursion:
 
 ```
-Track A (base case):     #45 adjacency map ─┬─▶ #41 heap ─▶ #40 BaseCase ─┐   (#45 ✅ done)
+Track A (base case):     #45 adjacency map ─┬─▶ #41 heap ─▶ #40 BaseCase ─┐   (#45 ✅, #41 ✅)
 Track B (recursion core):    (✅ done)       └─▶ #44 FindPivots ───────────┼─▶ #43 BMSSP main
                                                 #42 BlockList (✅ done) ───┘
 ```
@@ -75,9 +76,10 @@ Track B (recursion core):    (✅ done)       └─▶ #44 FindPivots ───
    + `getEdges()`, built in the constructor. Unblocks #40 and #44.
 2. ~~**#42** block-list `D`~~ — ✅ **done (PR #175):** `src/blockList.mjs` + 18 tests
    (§03-B contracts incl. seeded stress). Bound index is a sorted array for now (#167).
-3. **#41** binary min-heap — 🔶 **PR open:** `src/heap.mjs` indexed `MinHeap`
-   (insert/extractMin/decreaseKey/has) + 16 tests; bump to 0.17.0. Unblocks #40 once merged.
-4. **#40** BaseCase — needs #41 (+ #45 ✅). Test vs. a plain bounded Dijkstra from `x`.
+3. ~~**#41** binary min-heap~~ — ✅ **done (PR #177):** `src/heap.mjs` indexed `MinHeap`
+   (insert/extractMin/decreaseKey/has) + 16 tests; version 0.17.0 released. Unblocks #40.
+4. **#40** BaseCase — 🔶 **PR open:** `src/baseCase.mjs` `baseCase(B, S, dHat, adjacency, k)`
+   + 13 tests (incl. seeded oracle stress); bump to 0.18.0. Unblocks the level-0 leg of #43.
 5. **#44** FindPivots — needs relaxation + adjacency (#45 ✅). Test both branches (`|W|>k|S|`
    and forest roots).
 6. **#43** BMSSP main — wires #40+#42+#44 with `k`/`t`; replaces the Dijkstra delegation in
@@ -103,8 +105,8 @@ Clamp `k`,`t` to `≥ 1` for tiny graphs; correctness must not depend on the asy
 > GitHub going forward.
 
 ### `1.0.0` (milestone #1) — first end-to-end functional BMSSP
-Issues #40–#45. #45 done (PR #160), #42 done (PR #175); #40, #41, #43, #44 open. See the
-tables above.
+Issues #40–#45. #45 done (PR #160), #42 done (PR #175), #41 done (PR #177); #40, #43, #44
+open. See the tables above.
 
 ### `1.1.0` (milestone #2) — correctness hardening
 | # | Issue | Labels |

--- a/.claude/knowledge/06-milestones-roadmap.md
+++ b/.claude/knowledge/06-milestones-roadmap.md
@@ -1,7 +1,7 @@
 # 06 — Milestones Roadmap
 
-<!-- SYNCED-FROM-GITHUB: 2026-07-16 (session-start reconciliation; PR #177 merged, #41 closed) -->
-<!-- Current package version: 0.17.0 (tagged + released) -->
+<!-- SYNCED-FROM-GITHUB: 2026-07-16 (RKB after #40 implementation; PR #178 open, bump to 0.18.0 riding in it) -->
+<!-- Current released version: 0.17.0; 0.18.0 bumped in open PR #178 (tag+release after merge) -->
 
 Maps GitHub **milestones** and **issues** (Sirivasv/bmssp-js) to the paper's building blocks,
 with a dependency-aware build order. This is the "intent" side of the knowledge base (what to
@@ -128,6 +128,14 @@ open. See the tables above.
 
 _Note:_ the seeded **benchmark harness already landed early** with #45 (`benchmarks/`,
 `npm run bench`); #170 just adds the BMSSP column once #43 is done.
+
+_RKB 2026-07-16 (post #40) — issue bodies updated on GitHub:_ #44 rewritten as a full
+FindPivots spec (signature mirroring `baseCase`, early exit, tight-edge forest, tie caveat,
+test plan); #43 gained the concrete wiring contract (baseCase/BlockList APIs, `k`/`t`
+derivation, workload guard, definition of done); #163 gained the two tie manifestations
+found in #40 (settled-vertex guard vs zero-weight cycles; forest-DAG ambiguity in
+FindPivots); #169 noted that `Pred[]` must be wired into all three relaxation sites.
+Milestone slicing unchanged — 1.0.0 (#44 → #43 after #40 merges) still the right shape.
 
 _RKB 2026-07-15 (post #42/#41) — issue bodies updated on GitHub:_ #167 widened to both
 BlockList shortcuts (bound index **and** sort-based median selection); #168 widened with the

--- a/.claude/knowledge/07-glossary.md
+++ b/.claude/knowledge/07-glossary.md
@@ -1,6 +1,6 @@
 # 07 — Glossary
 
-<!-- Updated on: RKB 2026-07-15 (added #42 BlockList and #41 MinHeap code terms) -->
+<!-- Updated on: 2026-07-16, in the #40 PR (added the baseCase code terms) -->
 
 > **Lifecycle: dynamic — updated on `RKB`.** This glossary is refreshed on the on-demand
 > `revitalize_knowledge_base` (`RKB`) command (see `../CLAUDE.md`). When code or the roadmap
@@ -95,6 +95,14 @@ Quick lookup for the symbols and terms used across the paper, the notes, and the
 - **Indexed vs. lazy heap** — `MinHeap` is the paper-literal *indexed* variant (true
   `DecreaseKey`); `src/dijkstra.mjs` internally uses the *lazy* variant (push duplicates,
   skip stale pops). Both are correct; §03-A discusses the trade-off.
+- **`baseCase(B, S, dHat, adjacency, k)`** (#40) — `src/baseCase.mjs`, Algorithm 2:
+  bounded mini-Dijkstra from the singleton complete source in `S`, settling at most `k+1`
+  vertices, relaxing the shared `dHat` (`d̂[·]`) **in place**. Returns `{ bound, vertices }`
+  (= the paper's `B', U`). Internal (not re-exported from `index.mjs`).
+- **Settled-vertex guard** (#40) — `baseCase` never re-inserts a vertex it already settled
+  in the same call: the paper's `≤` relaxation admits equal-sum re-relaxations (e.g.
+  zero-weight cycles) that would loop forever, and with non-negative weights a settled
+  vertex cannot strictly improve, so skipping it is loss-free.
 - **Benchmark harness** — `benchmarks/` (run via `npm run bench`): seeded graph
   **generators** + a `SCENARIOS` registry (sparse-random / dense-random / grid / chain /
   star), `timeMany` timing, and two benchmarks (adjacency-vs-scan, per-shape Dijkstra). Will

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bmssp",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bmssp",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "license": "MPL-2.0",
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bmssp",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Javascript package implementation of the bmssp algorithm.",
   "main": "index.mjs",
   "keywords": [

--- a/src/baseCase.mjs
+++ b/src/baseCase.mjs
@@ -1,0 +1,94 @@
+import { MinHeap } from "./heap.mjs";
+
+/**
+ * BaseCase(B, S) — Algorithm 2 of "Breaking the Sorting Barrier for Directed
+ * Single-Source Shortest Paths". The level-0 case of the BMSSP recursion: a
+ * mini Dijkstra from the single complete source x in S, bounded above by B,
+ * that stops after settling k + 1 vertices.
+ *
+ * Preconditions (guaranteed by the caller, Algorithm 3):
+ * - S is a singleton {x} and x is complete (dHat holds its true distance).
+ * - Every incomplete vertex v with d(v) < B has a shortest path through x.
+ *
+ * Distance estimates are read from and written into dHat in place — exactly
+ * like the paper's global d̂[·] labels, so improvements made here are visible
+ * to the levels above.
+ *
+ * Two outcomes:
+ * - Full success (fewer than k + 1 vertices exist under B): every vertex
+ *   with d(v) < B is settled and returned, with bound === B.
+ * - Partial (the k + 1 cap was hit): bound = the largest settled distance
+ *   B' <= B, and only the strictly-closer vertices (d̂ < B') are returned.
+ *   Every returned vertex is complete either way.
+ *
+ * @param {number} B - Strict upper bound on the distances to settle (Infinity is allowed)
+ * @param {Set<*>|Iterable<*>} S - Singleton set holding the complete source x
+ * @param {Map<*, number>} dHat - Global distance estimates d̂[·], updated in place
+ * @param {Map<*, Array<[*, number]>>} adjacency - nodeId -> outgoing [to, weight] edges
+ * @param {number} k - Settle cap parameter, >= 1 (floored); the paper's ⌊log^(1/3) n⌋
+ * @returns {{ bound: number, vertices: Set<*> }} The boundary B' <= B and the
+ *   set U of vertices settled below it
+ * @throws {Error} If k is not a number >= 1, S is not a singleton, or the
+ *   source has no finite distance estimate
+ */
+function baseCase(B, S, dHat, adjacency, k) {
+  if (typeof k !== "number" || Number.isNaN(k) || k < 1) {
+    throw new Error("k must be a number >= 1");
+  }
+  const cap = Math.floor(k);
+  const sources = [...S];
+  if (sources.length !== 1) {
+    throw new Error("S must contain exactly one source node");
+  }
+  const [x] = sources;
+  const sourceDistance = dHat.get(x);
+  if (typeof sourceDistance !== "number" || !Number.isFinite(sourceDistance)) {
+    throw new Error("the source must have a finite distance estimate");
+  }
+
+  // U0 in the paper: the vertices settled by this call, seeded with x
+  const settled = new Set([x]);
+  const heap = new MinHeap();
+  heap.insert(x, sourceDistance);
+
+  while (!heap.isEmpty() && settled.size < cap + 1) {
+    const { key: u, value: du } = heap.extractMin();
+    settled.add(u);
+    for (const [v, weight] of adjacency.get(u) ?? []) {
+      const candidate = du + weight;
+      // Paper relaxation: d̂[u] + w(u,v) <= d̂[v], and below the bound B
+      if (candidate <= (dHat.get(v) ?? Infinity) && candidate < B) {
+        dHat.set(v, candidate);
+        // With non-negative weights a vertex settled in this call cannot
+        // strictly improve, so an equal-sum relaxation (which the <= allows,
+        // e.g. via a zero-weight cycle) must not re-enter the heap.
+        if (settled.has(v)) continue;
+        if (heap.has(v)) {
+          heap.decreaseKey(v, candidate);
+        } else {
+          heap.insert(v, candidate);
+        }
+      }
+    }
+  }
+
+  if (settled.size <= cap) {
+    // Exhausted before the cap: everything under B is settled (B' = B)
+    return { bound: B, vertices: settled };
+  }
+
+  // Hit the k + 1 cap: report B' = the largest settled distance and return
+  // only the vertices strictly below it
+  let boundary = -Infinity;
+  for (const v of settled) {
+    const distance = dHat.get(v);
+    if (distance > boundary) boundary = distance;
+  }
+  const vertices = new Set();
+  for (const v of settled) {
+    if (dHat.get(v) < boundary) vertices.add(v);
+  }
+  return { bound: boundary, vertices };
+}
+
+export { baseCase };

--- a/test/baseCase.test.mjs
+++ b/test/baseCase.test.mjs
@@ -1,0 +1,281 @@
+import { describe, test, expect } from "@jest/globals";
+import { baseCase } from "../src/baseCase.mjs";
+import { BMSSP } from "../src/bmssp.mjs";
+import { dijkstra } from "../src/dijkstra.mjs";
+
+// Small deterministic PRNG so stress-test failures are reproducible
+function mulberry32(seed) {
+  let a = seed >>> 0;
+  return function () {
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// Build the shared state BaseCase runs against: the class's adjacency map
+// and d̂ labels, with the source marked complete at distance 0
+function setup(edges, source) {
+  const bmssp = new BMSSP(edges);
+  bmssp.shortestPaths.set(source, 0);
+  return bmssp;
+}
+
+// Seeded random directed graph with an edge out of node 0 guaranteed
+function randomEdges(rand, n, m) {
+  const edges = [[0, 1 + Math.floor(rand() * (n - 1)), 1]];
+  for (let i = 1; i < m; i += 1) {
+    const from = Math.floor(rand() * n);
+    const to = Math.floor(rand() * n);
+    const weight = 1 + Math.floor(rand() * 20);
+    edges.push([from, to, weight]);
+  }
+  return edges;
+}
+
+describe("baseCase validation", () => {
+  test("rejects k that is not a number >= 1", () => {
+    const { shortestPaths, adjacency } = setup([[0, 1, 1]], 0);
+    expect(() =>
+      baseCase(Infinity, new Set([0]), shortestPaths, adjacency, 0),
+    ).toThrow("k must be a number >= 1");
+    expect(() =>
+      baseCase(Infinity, new Set([0]), shortestPaths, adjacency, NaN),
+    ).toThrow("k must be a number >= 1");
+  });
+
+  test("rejects an S that is not a singleton", () => {
+    const { shortestPaths, adjacency } = setup([[0, 1, 1]], 0);
+    expect(() =>
+      baseCase(Infinity, new Set(), shortestPaths, adjacency, 2),
+    ).toThrow("S must contain exactly one source node");
+    expect(() =>
+      baseCase(Infinity, new Set([0, 1]), shortestPaths, adjacency, 2),
+    ).toThrow("S must contain exactly one source node");
+  });
+
+  test("rejects a source without a finite distance estimate", () => {
+    // No setup(): every d̂ stays Infinity, so the source is not complete
+    const bmssp = new BMSSP([[0, 1, 1]]);
+    expect(() =>
+      baseCase(Infinity, new Set([0]), bmssp.shortestPaths, bmssp.adjacency, 2),
+    ).toThrow("the source must have a finite distance estimate");
+  });
+});
+
+describe("baseCase full success (fewer than k + 1 vertices under B)", () => {
+  const edges = [
+    [0, 1, 2],
+    [0, 2, 5],
+    [1, 2, 1],
+    [2, 3, 1],
+    [4, 0, 1],
+  ];
+
+  test("with B = Infinity settles every reachable vertex exactly", () => {
+    const { shortestPaths, adjacency } = setup(edges, 0);
+    const result = baseCase(
+      Infinity,
+      new Set([0]),
+      shortestPaths,
+      adjacency,
+      10,
+    );
+    expect(result.bound).toBe(Infinity);
+    expect(result.vertices).toEqual(new Set([0, 1, 2, 3]));
+    expect(shortestPaths.get(0)).toBe(0);
+    expect(shortestPaths.get(1)).toBe(2);
+    expect(shortestPaths.get(2)).toBe(3);
+    expect(shortestPaths.get(3)).toBe(4);
+    // Node 4 is not reachable from 0 and must stay untouched
+    expect(shortestPaths.get(4)).toBe(Infinity);
+  });
+
+  test("a finite B keeps distances >= B out of the result and out of d̂", () => {
+    const { shortestPaths, adjacency } = setup(edges, 0);
+    const result = baseCase(4, new Set([0]), shortestPaths, adjacency, 10);
+    // d(3) = 4 is not < B, so 3 is neither settled nor even relaxed
+    expect(result.bound).toBe(4);
+    expect(result.vertices).toEqual(new Set([0, 1, 2]));
+    expect(shortestPaths.get(3)).toBe(Infinity);
+  });
+
+  test("a source with no outgoing edges succeeds with just itself", () => {
+    const { shortestPaths, adjacency } = setup(edges, 3);
+    const result = baseCase(
+      Infinity,
+      new Set([3]),
+      shortestPaths,
+      adjacency,
+      5,
+    );
+    expect(result.bound).toBe(Infinity);
+    expect(result.vertices).toEqual(new Set([3]));
+  });
+});
+
+describe("baseCase partial (the k + 1 cap is hit)", () => {
+  test("on a chain it reports B' = max settled distance, returns closer ones", () => {
+    const edges = [
+      [0, 1, 1],
+      [1, 2, 1],
+      [2, 3, 1],
+      [3, 4, 1],
+    ];
+    const { shortestPaths, adjacency } = setup(edges, 0);
+    const result = baseCase(
+      Infinity,
+      new Set([0]),
+      shortestPaths,
+      adjacency,
+      2,
+    );
+    // Settled = {0, 1, 2} (k + 1 = 3 vertices), so B' = d̂(2) = 2
+    expect(result.bound).toBe(2);
+    expect(result.vertices).toEqual(new Set([0, 1]));
+    expect(shortestPaths.get(0)).toBe(0);
+    expect(shortestPaths.get(1)).toBe(1);
+    expect(shortestPaths.get(2)).toBe(2);
+  });
+
+  test("ties at the boundary are all excluded (strictly-closer filter)", () => {
+    const edges = [
+      [0, 1, 5],
+      [0, 2, 5],
+      [0, 3, 5],
+    ];
+    const { shortestPaths, adjacency } = setup(edges, 0);
+    const result = baseCase(
+      Infinity,
+      new Set([0]),
+      shortestPaths,
+      adjacency,
+      2,
+    );
+    // Settled = {0} plus two of the distance-5 leaves; B' = 5, and every
+    // leaf sits exactly on the boundary, so only the source is returned
+    expect(result.bound).toBe(5);
+    expect(result.vertices).toEqual(new Set([0]));
+  });
+
+  test("the k + 1 cap still respects the bound B", () => {
+    const edges = [
+      [0, 1, 1],
+      [1, 2, 1],
+      [2, 3, 1],
+    ];
+    const { shortestPaths, adjacency } = setup(edges, 0);
+    const result = baseCase(2, new Set([0]), shortestPaths, adjacency, 1);
+    // k + 1 = 2 settled: {0, 1}; B' = d̂(1) = 1 < B = 2
+    expect(result.bound).toBe(1);
+    expect(result.vertices).toEqual(new Set([0]));
+    expect(shortestPaths.get(3)).toBe(Infinity);
+  });
+});
+
+describe("baseCase equal-sum relaxations", () => {
+  test("a zero-weight cycle terminates and settles correctly", () => {
+    const edges = [
+      [0, 1, 0],
+      [1, 0, 0],
+      [1, 2, 1],
+    ];
+    const { shortestPaths, adjacency } = setup(edges, 0);
+    const result = baseCase(
+      Infinity,
+      new Set([0]),
+      shortestPaths,
+      adjacency,
+      10,
+    );
+    expect(result.bound).toBe(Infinity);
+    expect(result.vertices).toEqual(new Set([0, 1, 2]));
+    expect(shortestPaths.get(1)).toBe(0);
+    expect(shortestPaths.get(2)).toBe(1);
+  });
+
+  test("two equal-length paths to the same vertex settle it once", () => {
+    const edges = [
+      [0, 1, 1],
+      [0, 2, 1],
+      [1, 3, 1],
+      [2, 3, 1],
+    ];
+    const { shortestPaths, adjacency } = setup(edges, 0);
+    const result = baseCase(
+      Infinity,
+      new Set([0]),
+      shortestPaths,
+      adjacency,
+      10,
+    );
+    expect(result.vertices).toEqual(new Set([0, 1, 2, 3]));
+    expect(shortestPaths.get(3)).toBe(2);
+  });
+});
+
+describe("baseCase vs Dijkstra oracle (seeded)", () => {
+  test("full success on random graphs matches the reachable set exactly", () => {
+    const rand = mulberry32(40);
+    for (let round = 0; round < 20; round += 1) {
+      const edges = randomEdges(rand, 40, 160);
+      const bmssp = setup(edges, 0);
+      const oracle = dijkstra(bmssp.graph, bmssp.nodeIDs, 0);
+      const result = baseCase(
+        Infinity,
+        new Set([0]),
+        bmssp.shortestPaths,
+        bmssp.adjacency,
+        bmssp.nodeIDs.size,
+      );
+      expect(result.bound).toBe(Infinity);
+      const reachable = new Set(
+        [...oracle].filter(([, d]) => d < Infinity).map(([v]) => v),
+      );
+      expect(result.vertices).toEqual(reachable);
+      for (const v of result.vertices) {
+        expect(bmssp.shortestPaths.get(v)).toBe(oracle.get(v));
+      }
+    }
+  });
+
+  test("bounded, capped runs keep the Algorithm 2 contract", () => {
+    const rand = mulberry32(41);
+    for (let round = 0; round < 30; round += 1) {
+      const edges = randomEdges(rand, 50, 200);
+      const bmssp = setup(edges, 0);
+      const oracle = dijkstra(bmssp.graph, bmssp.nodeIDs, 0);
+      const finite = [...oracle.values()]
+        .filter((d) => d < Infinity)
+        .sort((a, b) => a - b);
+      // A bound somewhere inside the distance distribution, and a small cap
+      const B = finite[Math.floor(finite.length * 0.6)] + 0.5;
+      const k = 1 + Math.floor(rand() * 8);
+      const result = baseCase(
+        B,
+        new Set([0]),
+        bmssp.shortestPaths,
+        bmssp.adjacency,
+        k,
+      );
+      // B' never exceeds B, and B' = B means full success under the bound
+      expect(result.bound).toBeLessThanOrEqual(B);
+      // Every returned vertex is complete (d̂ = true distance) and below B'
+      for (const v of result.vertices) {
+        expect(bmssp.shortestPaths.get(v)).toBe(oracle.get(v));
+        expect(oracle.get(v)).toBeLessThan(result.bound);
+      }
+      // Completeness: everything with a true distance below B' is returned
+      for (const [v, d] of oracle) {
+        if (d < result.bound) {
+          expect(result.vertices.has(v)).toBe(true);
+        }
+      }
+      // d̂ never underestimates the true distance anywhere
+      for (const [v, d] of bmssp.shortestPaths) {
+        expect(d).toBeGreaterThanOrEqual(oracle.get(v));
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Implements **`BaseCase(B, S)`** — Algorithm 2 of the paper, the level-0 case of the BMSSP recursion — as `src/baseCase.mjs`. Closes #40.

- Bounded mini-Dijkstra from the singleton complete source `x` in `S`, run on the indexed `MinHeap` (#41), settling at most `k+1` vertices and relaxing the shared `d̂` map (`shortestPaths`) **in place** so improvements are visible to the levels above.
- Relaxation is the paper's `d̂[u] + w(u,v) ≤ d̂[v]` **and** `< B` test; neighbors at or above `B` are never written.
- **Full success** (heap exhausted at ≤ k settled): returns `{ bound: B, vertices: U0 }` — everything under `B` is settled.
- **Partial** (`k+1` cap hit): returns `bound` = max settled `d̂` (the paper's `B'`) and only the strictly-closer vertices.
- One deliberate guard over the literal pseudocode: a vertex settled **within this call** is never re-inserted into the heap. The `≤` relaxation admits equal-sum re-relaxations (e.g. zero-weight cycles) that would loop forever; with non-negative weights a settled vertex cannot strictly improve, so the skip is loss-free.

Also included: version bump **0.17.0 → 0.18.0** (Phase 1 of the release routine) and knowledge-base updates (`05` map re-stamped for the #41 merge + this module, `06` roadmap statuses, `07` glossary code terms).

## Tests

13 new tests in `test/baseCase.test.mjs` (suite now 59, all passing; `npm run lint` clean):
- validation: `k >= 1`, singleton `S`, source must have a finite estimate
- full success with `B = ∞` and with a finite `B` (unreachable/out-of-bound vertices untouched)
- partial runs: boundary reporting on a chain, ties at the boundary excluded by the strict filter, cap + bound interaction
- equal-sum relaxations: zero-weight cycle terminates; equal-length parallel paths
- two seeded stress tests vs. the `dijkstra` oracle: exact distances on returned vertices, completeness below `B'`, `B' ≤ B`, and `d̂` never underestimates

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)