### PR TITLE
docs: automate pre-PR knowledge-base sync (auto-RKB) and refresh the public README

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -5,149 +5,178 @@ _"Breaking the Sorting Barrier for Directed Single-Source Shortest Paths"_ — a
 **O(m·log^(2/3) n)** SSSP algorithm, the first to beat Dijkstra on sparse directed graphs.
 **BMSSP** = **B**ounded **M**ulti-**S**ource **S**hortest **P**ath.
 
-This file is the **operational entrypoint**. It tells you what to run at the **start of every
-working session** in this repo so the `.claude/knowledge/` base stays in sync with reality
-(the codebase) and intent (the GitHub milestones/issues). The knowledge base exists so you can
-work on the project **without** re-reading the paper, PDF, or any external article.
+This file is the **operational entrypoint**: the complete lifecycle of a working session,
+from session start to release. The `.claude/knowledge/` base exists so **any agent — any
+model** — can work on this project without re-reading the paper, PDF, or any external
+article. Follow the checklists literally; every decision point is written as an explicit
+if/else so nothing depends on inference.
 
 ---
 
-## ▶ Session-start routine (run these every time, in order)
+## Ground rules (apply to everything below)
 
-### Step 1 — Load the fixed knowledge (read-only, never changes)
-Read these once per session for full algorithm context. They are **static** — do not edit:
-- [knowledge/01-paper-overview.md](knowledge/01-paper-overview.md) — core idea, `k`/`t`, model
-- [knowledge/02-algorithms.md](knowledge/02-algorithms.md) — FindPivots / BaseCase / BMSSP pseudocode
-- [knowledge/03-data-structures.md](knowledge/03-data-structures.md) — Lemma 3.3 block-list + heap
-- [knowledge/04-external-enhancement.md](knowledge/04-external-enhancement.md) — consolidated intuition (fixed)
+1. **Single source of truth.** Static files (this file, `knowledge/01–04`) must never carry
+   dynamic facts (version numbers, issue states, test counts, module lists). Every dynamic
+   fact lives in exactly one dynamic file:
+   - What the code looks like today → [knowledge/05-codebase-map.md](knowledge/05-codebase-map.md)
+   - What to build next (milestones/issues) → [knowledge/06-milestones-roadmap.md](knowledge/06-milestones-roadmap.md)
+   - Symbol/term lookup → [knowledge/07-glossary.md](knowledge/07-glossary.md)
+   If you spot a dynamic fact anywhere else (including this file), treat it as a bug: move
+   it to the right dynamic file and replace it with a pointer.
+2. **One PR per issue, and that PR carries everything**: code + tests + version bump +
+   refreshed `05`/`06`/`07` + `README.md` updates. Never open a second "sync the docs" PR —
+   the pre-PR sync (Phase C below) exists precisely to prevent that.
+3. **Two hard gates — never bypass:**
+   - **GitHub writes beyond the PR itself** (creating/editing/closing issues or milestones):
+     _propose_ first, _execute_ only after explicit user confirmation, **one ask per edit**.
+     Collect proposals in the PR body (Phase C) and execute approved ones in Phase E.
+   - **Tag + GitHub Release** (fires npm + Docker Hub publish): only after the user
+     explicitly confirms the PR is merged. Never tag or release autonomously.
+4. **Correctness over speed.** BMSSP output must match the Dijkstra oracle exactly
+   (`test/main.test.mjs`, "BMSSP vs Dijkstra"). The asymptotic win is theoretical; this repo
+   optimizes for a correct, readable implementation.
+5. **Knowledge-base authoring style** (when you rewrite `05`/`06`/`07`): keep the existing
+   heading/table structure stable, write procedures as numbered steps with exact commands,
+   use absolute dates (never "yesterday"), and prefer short declarative sentences. The next
+   reader may be a smaller model — leave it nothing to guess.
 
-### Step 2 — Sync `main`, then validate the codebase map bookmark
-**Always pull the latest `main` first — never reason from a stale local checkout.** PRs may
-have merged between sessions (e.g. a local branch that "has no open PR" may simply be merged
-already), so sync with GitHub before drawing any conclusion about branch or merge state:
+---
 
-```bash
-git checkout main && git pull origin main   # sync with GitHub before anything else
-git rev-parse HEAD                          # now compare to the bookmark
+## The session lifecycle
+
+```
+A. Session start  →  B. Implement  →  C. Pre-PR sync (automatic RKB)  →  D. Open the PR
+        →  (user reviews & merges, then confirms)  →  E. Release + approved GitHub edits
 ```
 
-Open [knowledge/05-codebase-map.md](knowledge/05-codebase-map.md) and read its
-**`<!-- BOOKMARK-COMMIT: … -->`** line, then compare to the freshly-pulled `main` HEAD:
+### Phase A — Session start (run every time, in order)
 
-- **If HEAD == bookmark** → `05` is current; do nothing.
-- **If HEAD != bookmark** → the repo moved. Re-inspect `src/`, `test/`, `examples/`,
-  `package.json`, update `05` to match the new reality, and set the bookmark to the new HEAD.
-  (See the "Session-start validation" block inside `05` for the exact procedure.)
-- Need to judge whether some local branch or commit is merged? Check
-  `gh pr list --state merged` or `git branch --contains <commit>` against the fresh
-  `origin/main` — do **not** infer merge state from the local working tree.
+1. **Load the fixed knowledge** (read-only, never changes):
+   [01-paper-overview.md](knowledge/01-paper-overview.md) ·
+   [02-algorithms.md](knowledge/02-algorithms.md) ·
+   [03-data-structures.md](knowledge/03-data-structures.md) ·
+   [04-external-enhancement.md](knowledge/04-external-enhancement.md).
+   For a task-scoped shortcut ("implementing issue X → read exactly this"), see the
+   reading map in [knowledge/README.md](knowledge/README.md).
+2. **Sync `main` — never reason from a stale checkout:**
+   ```bash
+   git checkout main && git pull origin main
+   git rev-parse HEAD
+   ```
+3. **Validate the codebase map** (`05`): follow the **bookmark validation procedure written
+   at the top of `05` itself** — it is an explicit if/else covering the normal case, the
+   "our own PR just merged" case (`PENDING-PR-BRANCH` marker), and the "repo moved under
+   us" case. Outcome: `05` describes reality and its bookmark equals `main` HEAD.
+4. **Reconcile the roadmap** (`06`) — read-only against live GitHub:
+   ```bash
+   gh api repos/Sirivasv/bmssp-js/milestones --jq '.[] | {number,title,state,description,open_issues,closed_issues}'
+   gh issue list --repo Sirivasv/bmssp-js --state open --limit 100 --json number,title,milestone,labels
+   ```
+   Update the `06` markdown to match GitHub. Do **not** write to GitHub in this phase.
+5. **Check release state** — surface a bumped-but-unreleased version instead of silently
+   working past it:
+   ```bash
+   git fetch --tags --force && git tag --sort=-creatordate | head -3
+   node -p "require('./package.json').version"
+   ```
+   If `package.json`'s version has no matching tag, tell the user before doing anything else.
+6. **Check `README.md` currency** — compare its Status section against `05`/`06`. If stale,
+   note it now and fix it in Phase C (inside the next PR), not as a separate PR.
 
-### Step 3 — Refresh the milestones roadmap from GitHub (read)
-Using `gh`, read the live milestones and issues and reconcile
-[knowledge/06-milestones-roadmap.md](knowledge/06-milestones-roadmap.md) to match:
+### Phase B — Implement
+
+Pick the next issue from the build order in `06`. Use `02`/`03` as the spec and `05` for the
+existing APIs to build on. Ship focused unit tests with every piece. Before Phase C:
+`npm test` and `npm run lint` must both pass.
+
+### Phase C — Pre-PR sync (automatic; this replaces the old on-request `RKB`)
+
+**Run this on the feature branch, before opening any PR. Do not wait to be asked.**
+
+1. **Version bump** (only if the PR closes an issue — see "Version bump & release" below):
+   ```bash
+   npm version minor --no-git-tag-version
+   ```
+2. **Rewrite `05`** to describe the tree **as it will exist once this PR merges** (the
+   branch's own tree). Set the `PENDING-PR-BRANCH:` marker to the feature branch name and
+   leave `BOOKMARK-COMMIT:` at the `main` commit the branch is based on — the Phase A
+   procedure uses these to fast-path validation after the merge.
+3. **Reconcile `06`**: mark the issue done-pending-merge, re-derive what's next, and
+   **re-examine the roadmap itself** — every increment of progress teaches something about
+   the issues ahead. Are open issue titles/descriptions still the best statement of the
+   work? Is the milestone slicing (next one or two minors, next major) still right? Write
+   any resulting GitHub edits (issue edits/closes/moves, milestone re-scoping, new issues)
+   as a **"Roadmap proposals"** list — into `06` and into the PR body — but do **not**
+   execute them yet (gate 3). Proposing nothing after real progress should be rare.
+4. **Update `07`** with any new symbols, module names, or terms this PR introduces.
+5. **Update `README.md`** — the public face must showcase the current state: version,
+   status/progress table, usage that actually works, roadmap summary. Keep it honest about
+   what is and isn't implemented yet.
+6. Commit all of the above **in the same PR branch** as the code.
+
+### Phase D — Open the PR
 
 ```bash
-gh api repos/Sirivasv/bmssp-js/milestones --jq '.[] | {number,title,state,description,open_issues,closed_issues}'
-gh issue list --repo Sirivasv/bmssp-js --state open --limit 100 --json number,title,milestone,labels
+git push -u origin <feature-branch>
+gh pr create --title "<type>(#<issue>): <summary>" --body "..."
 ```
 
-On session start this is **read-only reconciliation**: update the `06` markdown so it reflects
-the current GitHub state. Do **not** push changes to GitHub during normal session start.
+PR body must contain: `Closes #<issue>`, a summary of the change, test/lint status, and the
+**Roadmap proposals** section from Phase C (or "none"). Then hand off to the user for review.
+One PR = the whole increment; if review feedback requires changes, push to the same branch.
 
-### Step 4 — Ready to work
-Pick up the issue/milestone in focus (see `06`) and use `02`/`03` as the implementation spec.
-When a session's work **closes an issue**, follow the **Version bump & release** routine below
-(bump inside the PR; tag + release only after the user confirms the merge).
+### Phase E — After the user confirms the merge
+
+1. Run the **release routine** below (tag + GitHub Release → npm + Docker Hub).
+2. Walk the **Roadmap proposals** with the user and execute each approved GitHub edit
+   (`gh issue edit/close/create`, milestone edits) — one confirmation per edit.
+3. Session can end here; the next session's Phase A will find everything consistent.
 
 ---
 
 ## ⟳ On-demand command: `revitalize_knowledge_base` (alias `RKB`)
 
-When the user types **`RKB`** or **`revitalize_knowledge_base`** at any point in a session,
-perform a **full two-way refresh**:
-
-1. **`05` codebase-map** — first sync `main` exactly as in session-start Step 2
-   (`git checkout main && git pull origin main`), then re-inspect the repo regardless of the
-   bookmark, rewrite `05`, and reset the bookmark commit to current HEAD.
-2. **`06` milestones-roadmap — two-way sync with GitHub.** Beyond reading, you should
-   **use `gh` to make GitHub match the roadmap**, treating the freshly-updated `.claude/`
-   knowledge base (post-task learnings from `05`/`07` and the code) as the source of truth:
-   - **Reconcile existing open issues** (created by you or the user). As new learnings land,
-     issues may need their **titles/descriptions edited**, be **closed** (already done, obsolete,
-     or superseded), be **re-scoped/split/merged**, or be **moved to a different milestone**.
-   - **Reconcile the milestones themselves.** Reason about **(a) the current package version,
-     (b) the next one or two minor-version milestones, and (c) the next major-version
-     milestone** — and adjust as learnings dictate: the **number of remaining future minor
-     versions**, each milestone's **scope and issue set**, and the same for the **next major
-     version** (titles, descriptions, which issues belong where, adding/removing issues).
-   - Propose the concrete `gh` edits (issue closes/edits, milestone edits, new issues). **Confirm
-     with the user before any create/edit/close — these are outward-facing writes.**
-3. **`07` glossary** — update [knowledge/07-glossary.md](knowledge/07-glossary.md) to add any
-   new symbols/terms introduced by code or roadmap changes since the last refresh.
-
-> **Not gated on the `RKB` keyword:** the roadmap-reshaping powers of item 2 — adjusting the
-> **number, scope, and issue sets of the upcoming minor-version milestones** and the **next
-> major-version milestone** (and the issues within them) — may be exercised **at any point in
-> a working session** when new learnings warrant it, not only when the user types `RKB`.
-> The same gate applies: propose the concrete edits and **confirm with the user before any
-> outward-facing GitHub write**.
-
-> **You co-own the roadmap.** Do not wait to be told to fold post-session learnings into it —
-> the user expects that **every RKB after real progress produces concrete edit proposals**,
-> because every increment of progress teaches something about the issues ahead. On each `RKB`,
-> actively re-derive: are existing issue titles/descriptions still the best statement of the
-> work? Is the issue layout of the **current and future minor versions** still the right
-> slicing? Does the **next major version** still have the right scope? Then put the specific
-> edits in front of the user — **asking per edit** (issues / versions / milestones), since the
-> confirmation gate is per outward-facing write, not per batch. An RKB that proposes nothing
-> after a session that shipped code should be the rare exception, not the default.
-
-`RKB` = the manual superset of the session-start routine, plus the GitHub write-back for `06`.
-It also **re-checks the release state** (`git tag` / `gh release list` vs. `package.json`) so a
-version that was bumped-but-not-yet-released is surfaced.
+`RKB` is no longer required around PRs — Phase C runs automatically. It remains available
+for **out-of-band refreshes** (e.g. after external PRs merged, or when things feel out of
+sync). When the user types **`RKB`**: run Phase A steps 2–6, then Phase C steps 2–5 directly
+on `main`'s state (no `PENDING-PR-BRANCH` marker; re-stamp `05`'s bookmark to HEAD), present
+any Roadmap proposals, and execute only user-approved GitHub edits.
 
 ---
 
 ## 🚀 Version bump & release (when a working session closes an issue)
 
 The repo ships via **tag → GitHub Release → CI/CD**. Publishing a GitHub Release
-(`release: published`) fires `.github/workflows/publish.yml`, which **publishes the package to
-npm** (`npm publish --provenance --access public`) **and builds + pushes the multi-arch Docker
-image** to Docker Hub. Tags are the **bare version with no `v` prefix** (`0.15.0`, not
-`v0.15.0`) and must match `package.json`. (Separately: pushes/PRs to `main` run lint + test via
-`npm-build.yml`, and `docs/**` changes deploy Pages via `static.yml` — those need no action.)
+(`release: published`) fires `.github/workflows/publish.yml`, which **publishes to npm**
+(`npm publish --provenance --access public`) **and pushes the multi-arch Docker image** to
+Docker Hub. Tags are the **bare version, no `v` prefix** (`0.19.0`, not `v0.19.0`) and must
+match `package.json`. (Pushes/PRs to `main` run lint + test via `npm-build.yml`; `docs/**`
+changes deploy Pages via `static.yml` — no action needed for those.)
 
-> **This is an outward-facing publish (npm + Docker Hub). The release half is GATED on explicit
-> user confirmation that the PR merged. Never create a tag or GitHub Release autonomously.**
+> **Outward-facing publish — gate 3 applies. Never create a tag or Release autonomously.**
 
-### Phase 1 — bump the version *inside the PR that closes the issue*
-Do this as part of the same PR that closes the issue, so `package.json` **and**
-`package-lock.json` (both the root `version` and the `packages[""]` entry) move together. Use
-npm so all stay in sync — **do not hand-edit** the version fields:
+**Phase 1 — bump inside the PR** (part of Phase C, step 1). Use npm so `package.json` and
+`package-lock.json` (root `version` **and** the `packages[""]` entry) move together — never
+hand-edit:
 
 ```bash
-# repo root, on the feature branch, before committing the PR:
-npm version minor --no-git-tag-version   # e.g. 0.15.0 → 0.16.0; edits package.json + package-lock.json, no git tag/commit
+npm version minor --no-git-tag-version   # e.g. 0.18.0 → 0.19.0
 ```
 
-Convention: every historical release is a **minor** bump (`0.N.0`), one per closed issue while
-pre-1.0 — use `minor` unless the user directs otherwise (e.g. the final `1.0.0` milestone close
-is a `major` bump). Commit the bump with the rest of the PR's changes.
+Convention: one **minor** bump (`0.N.0`) per closed issue while pre-1.0, unless the user
+directs otherwise (the `1.0.0` milestone close is the `major` bump).
 
-### Phase 2 — tag + release *after the user confirms the PR is merged*
-Only once the user confirms the PR is merged (issue closed), from an up-to-date `main`:
+**Phase 2 — tag + release, only after the user confirms the merge:**
 
 ```bash
-git checkout main && git pull origin main               # pull the merged bump commit
-git fetch --tags --force                                # sync local tags with GitHub (local can be stale)
-VERSION=$(node -p "require('./package.json').version")  # e.g. 0.16.0
-git tag "$VERSION" && git push origin "$VERSION"        # tag == version, no "v" prefix
+git checkout main && git pull origin main
+git fetch --tags --force
+VERSION=$(node -p "require('./package.json').version")
+git tag "$VERSION" && git push origin "$VERSION"
 gh release create "$VERSION" --title "$VERSION" --target main --generate-notes
 ```
 
-Publishing the release triggers `publish.yml` → npm + Docker Hub. After creating it, confirm the
-CD started (`gh run list --workflow=publish.yml` / `gh release view "$VERSION"`) and report the
-result to the user.
+Then confirm CD fired (`gh run list --workflow=publish.yml`) and report the result.
 
 ---
 
@@ -155,21 +184,23 @@ result to the user.
 
 | File | Lifecycle |
 |------|-----------|
-| `CLAUDE.md` (this file) | Entrypoint / routine. Stable. |
-| `knowledge/01–03` | **Fixed** — paper facts, algorithms, data structures. Never change. |
-| `knowledge/04-external-enhancement.md` | **Fixed** — one-time consolidated intuition. Don't change. |
-| `knowledge/05-codebase-map.md` | **Dynamic** — validated at session start vs. bookmark commit; refreshed on `RKB`. |
-| `knowledge/06-milestones-roadmap.md` | **Dynamic** — read-reconciled from GitHub at session start; two-way synced on `RKB`. |
-| `knowledge/07-glossary.md` | **Dynamic** — updated on `RKB`. |
-| `knowledge/README.md` | KB index / reading order. |
+| `CLAUDE.md` (this file) | Entrypoint / lifecycle. Stable; no dynamic facts. |
+| `knowledge/01–03` | **Fixed** — verified paper transcription (facts, algorithms, structures). Change only to fix a factual error against the paper. |
+| `knowledge/04` | **Fixed** — one-time consolidated intuition. Don't change. |
+| `knowledge/05-codebase-map.md` | **Dynamic** — validated in Phase A; rewritten in Phase C of every PR. |
+| `knowledge/06-milestones-roadmap.md` | **Dynamic** — read-reconciled in Phase A; updated + proposals in Phase C; GitHub writes in Phase E. |
+| `knowledge/07-glossary.md` | **Dynamic** — updated in Phase C. |
+| `knowledge/README.md` | KB index, reading order, per-task reading map. |
+| `README.md` (repo root) | **Public face** — kept current in Phase C of every PR. |
 
-## Project quick facts
+## Project quick facts (stable only — dynamic facts live in `05`/`06`)
 
-- **Package:** `bmssp` on npm (currently `0.15.0`). Author: Saul Ivan Rivas Vega. License: MPL-2.0.
-- **Entry:** `index.mjs` re-exports `BMSSP` (`src/bmssp.mjs`) and `dijkstra` (`src/dijkstra.mjs`).
-- **Runtime:** ESM only, `.mjs`. **Test:** `npm test` (Jest, `--experimental-vm-modules`).
-  **Lint/format:** `npm run lint` / `npm run format`.
+- **Package:** `bmssp` on npm. Author: Saul Ivan Rivas Vega. License: MPL-2.0.
+  Current version: see `package.json` / `05`.
+- **Entry:** `index.mjs` re-exports `BMSSP` (`src/bmssp.mjs`) and `dijkstra`
+  (`src/dijkstra.mjs`). Algorithm-internal modules are deliberately **not** re-exported.
+- **Runtime:** ESM only, `.mjs`. **Test:** `npm test` (Jest). **Lint/format:**
+  `npm run lint` / `npm run format`. **Benchmarks:** `npm run bench`.
 - **Graph input:** array of `[from, to, weight]` edges; numeric node IDs; non-negative weights.
-- **Oracle:** `src/dijkstra.mjs` — BMSSP output must match it exactly (see `test/main.test.mjs`).
-- **Status:** Scaffolding + reference Dijkstra done; the real BMSSP algorithm (issues #40–#45,
-  milestone `1.0.0`) is not yet implemented.
+- **Oracle:** `src/dijkstra.mjs` — BMSSP output must match it exactly.
+- **Implementation status, module inventory, next issue:** see `05` and `06`.

--- a/.claude/knowledge/05-codebase-map.md
+++ b/.claude/knowledge/05-codebase-map.md
@@ -1,41 +1,53 @@
 # 05 — Codebase Map (current state)
 
-<!-- BOOKMARK-COMMIT: 7e36afc63828ccefea4db037c0d506d28ae3100a -->
-<!-- BOOKMARK-BRANCH: main -->
-<!-- Last validated 2026-07-16 after pulling main. PR #177 (feat(#41) indexed MinHeap) is
-     MERGED: src/heap.mjs + test/heap.test.mjs are on main and the version is 0.17.0
-     (tagged + released 2026-07-15; publish.yml fired). #41 is closed — remaining 1.0.0
-     issues are #40, #43, #44.
-     Pending: PR for #40 (feat: src/baseCase.mjs BaseCase(B, S) + tests, bump to 0.18.0)
-     is OPEN — re-stamp the bookmark once merged. -->
-<!-- Update both the comment and the body when HEAD moves. -->
+<!-- BOOKMARK-COMMIT: 9a753b09d77d8b7b2f72118c17b74dafa5d0df0f -->
+<!-- PENDING-PR-BRANCH: chore/agent-process-v2 -->
+<!-- Last validated: 2026-07-16, on main. Version 0.18.0 (tagged + released; publish.yml
+     fired). #40 (BaseCase) closed via PR #178; remaining 1.0.0 issues: #44 (FindPivots,
+     fully specced on GitHub) then #43 (main recursion). No pending release work. -->
 
 Snapshot of what exists in `bmssp-js` today, so you know what to build on vs. what's missing.
 
-## 🔄 Session-start validation (this file is DYNAMIC)
+## 🔄 Bookmark validation procedure (this file is DYNAMIC)
 
-This map is only true as of the **bookmark commit** recorded in the HTML comment at the top
-of this file (`BOOKMARK-COMMIT`). The repo changes as commits land, so validate at the start
-of every session — **after pulling the latest `main`** (never validate against a stale local
-checkout; a branch that looks unmerged locally may already be on `origin/main`):
+This map describes the repo **as of the tree identified by the two markers above**:
 
-```bash
-git checkout main && git pull origin main
-git rev-parse HEAD          # compare to BOOKMARK-COMMIT above
-```
+- `BOOKMARK-COMMIT` — the `main` commit this map was last validated against.
+- `PENDING-PR-BRANCH` — set only while a PR is in flight: this map was rewritten **inside
+  that PR** (Phase C of `../CLAUDE.md`) and already describes the tree that PR will merge.
+  `(none)` otherwise.
 
-- **HEAD == bookmark** → this map is current; nothing to do.
-- **HEAD != bookmark** → the repo moved. Re-inspect and reconcile:
-  1. `git diff --stat <BOOKMARK-COMMIT> HEAD` to see what changed.
-  2. Re-read anything under `src/`, `test/`, `examples/`, `benchmarks/`, `index.mjs`,
-     `package.json` that changed (especially: did any of the missing pieces below get built?).
-  3. Rewrite the affected sections below (layout, class behavior, "Gaps to fill" table,
-     package version).
-  4. **Update the `BOOKMARK-COMMIT` comment to the new `HEAD`.**
+**At session start** (Phase A — after `git checkout main && git pull origin main`), run
+`git rev-parse HEAD` and follow exactly one branch:
 
-This same procedure runs in full on the on-demand **`RKB`** (`revitalize_knowledge_base`)
-command — see `../CLAUDE.md`. `RKB` always rewrites this file and re-stamps the bookmark,
-regardless of whether HEAD moved.
+1. **HEAD == `BOOKMARK-COMMIT`** → map is current. Done.
+2. **`PENDING-PR-BRANCH` is set** (not `(none)`) → our own PR may have just merged:
+   ```bash
+   gh pr list --repo Sirivasv/bmssp-js --head <PENDING-PR-BRANCH> --state merged \
+     --json number,mergeCommit --jq '.[0]'
+   ```
+   - If it merged and its `mergeCommit` **== HEAD** → this map already describes HEAD.
+     Set `BOOKMARK-COMMIT` to HEAD, set `PENDING-PR-BRANCH` to `(none)`, refresh the
+     "Last validated" comment. Done — no re-inspection needed.
+   - If it merged but HEAD moved **past** the merge commit → do step 3 using the merge
+     commit as the baseline instead of `BOOKMARK-COMMIT`.
+   - If it did **not** merge (PR still open/closed unmerged) → the map describes a tree
+     that isn't on `main`; rewrite the map from `main`'s actual tree (step 3 with
+     `BOOKMARK-COMMIT` as baseline), keep or clear the marker to match PR reality.
+3. **Otherwise (repo moved under us)** →
+   ```bash
+   git diff --stat <baseline> HEAD    # if the baseline commit is unresolvable locally,
+                                      # skip the diff and re-inspect everything below
+   ```
+   Re-read whatever changed under `src/`, `test/`, `benchmarks/`, `examples/`,
+   `index.mjs`, `package.json`; rewrite the affected sections (layout, module APIs,
+   "Gaps to fill" table); set `BOOKMARK-COMMIT` to HEAD and `PENDING-PR-BRANCH` to
+   `(none)`.
+
+**In Phase C (pre-PR, on the feature branch):** rewrite the body of this map to describe
+the branch's tree (i.e. post-merge reality), leave `BOOKMARK-COMMIT` at the `main` commit
+the branch is based on (`git merge-base main HEAD`), and set `PENDING-PR-BRANCH` to the
+feature branch name. Step 2 above then fast-paths the post-merge session start.
 
 ## Layout
 
@@ -213,7 +225,7 @@ lands. `benchmarks/README.md` holds the "when to use which" guidance.
 | Per-node edge adjacency map | `BMSSP` constructor | #45 | ✅ done (PR #160) |
 | Lemma 3.3 block-list `D` | `src/blockList.mjs` | #42 | ✅ done (PR #175) |
 | Binary min-heap module | `src/heap.mjs` | #41 | ✅ done (PR #177) |
-| Base case (bounded Dijkstra) | `src/baseCase.mjs` | #40 | 🔶 PR open (this branch) |
+| Base case (bounded Dijkstra) | `src/baseCase.mjs` | #40 | ✅ done (PR #178) |
 | FindPivots | `src/findPivots.mjs` / method | #44 | ⬜ open |
 | Main `BMSSP(l, B, S)` recursion + `k,t` derivation | `src/bmssp.mjs` | #43 | ⬜ open |
 

--- a/.claude/knowledge/06-milestones-roadmap.md
+++ b/.claude/knowledge/06-milestones-roadmap.md
@@ -1,7 +1,7 @@
 # 06 — Milestones Roadmap
 
-<!-- SYNCED-FROM-GITHUB: 2026-07-16 (RKB after #40 implementation; PR #178 open, bump to 0.18.0 riding in it) -->
-<!-- Current released version: 0.17.0; 0.18.0 bumped in open PR #178 (tag+release after merge) -->
+<!-- SYNCED-FROM-GITHUB: 2026-07-16 (PR #178 merged, #40 closed, 0.18.0 tagged + released) -->
+<!-- Current package version: 0.18.0 (tagged + released) -->
 
 Maps GitHub **milestones** and **issues** (Sirivasv/bmssp-js) to the paper's building blocks,
 with a dependency-aware build order. This is the "intent" side of the knowledge base (what to
@@ -9,42 +9,50 @@ build next); `05-codebase-map.md` is the "reality" side (what exists now).
 
 ## 🔄 How this file stays current (this file is DYNAMIC)
 
-- **Session start — read-only reconciliation.** Pull live milestones + issues via `gh` and
-  update the markdown below to match GitHub. Do **not** write to GitHub here.
+Three touch-points, matching the lifecycle in `../CLAUDE.md`:
+
+- **Phase A (session start) — read-only reconciliation.** Pull live milestones + issues via
+  `gh` and update the markdown below to match GitHub. Do **not** write to GitHub here.
   ```bash
   gh api repos/Sirivasv/bmssp-js/milestones --jq '.[] | {number,title,state,description,open_issues,closed_issues}'
   gh issue list --repo Sirivasv/bmssp-js --state open  --limit 100 --json number,title,milestone,labels
   gh issue list --repo Sirivasv/bmssp-js --state closed --limit 100 --json number,title,milestone
   ```
-- **On-demand `RKB` (`revitalize_knowledge_base`) — two-way sync.** In addition to the read
-  above, **make GitHub match this roadmap**, using the just-refreshed knowledge base + code as
-  the source of truth:
-  - **Existing open issues** (yours or the user's) may be **edited** (title/description),
-    **closed** (done/obsolete/superseded), **re-scoped/split/merged**, or **moved** to another
-    milestone as new learnings dictate.
-  - **Milestones** are adjusted the same way — reason forward about versioning and update the
-    **current version** (from `package.json`), the **number and scope of the next one or two
-    minor-version milestones**, and the **next major-version milestone** (titles, descriptions,
-    and which issues belong to each — adding or removing issues as needed).
-  Outward-facing writes (creating/editing/closing milestones or issues) are **confirmed with the
-  user first, one ask per edit**. See the "Forward-looking version plan" section for the working
-  proposal. **The agent co-owns this roadmap**: every RKB after real progress should proactively
-  propose issue/milestone improvements from the session's learnings (see `../CLAUDE.md`), rather
-  than waiting for the user to request them.
+- **Phase C (pre-PR, automatic — the old on-request `RKB`).** Inside the PR branch: mark the
+  closed issue done-pending-merge, re-derive the build order, and **re-examine the roadmap
+  itself** with the session's learnings — issue titles/descriptions, the slicing of the next
+  one or two minor-version milestones, and the next major-version milestone (which issues
+  belong where; add/remove/split/merge as warranted). Write the resulting GitHub edits as a
+  **"Roadmap proposals"** list here and in the PR body. **Do not execute them in this phase.**
+  Proposing nothing after real progress should be the rare exception: every increment teaches
+  something about the issues ahead, and the agent co-owns this roadmap.
+- **Phase E (post-merge) — gated GitHub writes.** Walk the Roadmap proposals with the user and
+  execute each approved edit (`gh issue edit/close/create`, milestone edits) — **one
+  confirmation per edit**. Then clear the executed proposals from this file.
+
+The on-demand **`RKB`** command still exists for out-of-band refreshes (see `../CLAUDE.md`);
+it runs the same Phase C reconciliation directly on `main`.
+
+---
+
+## 📋 Roadmap proposals (pending user approval)
+
+_None right now. Phase C writes proposed GitHub edits here (and in the PR body); Phase E
+executes the approved ones — one confirmation each — and clears them from this list._
 
 ---
 
 ## Current state (as synced)
 
-- **Package version:** `0.17.0` (pre-1.0; the algorithm is not yet functional end-to-end).
-  The `0.17.0` tag + GitHub Release are published (npm + Docker Hub CD fired).
+- **Package version:** `0.18.0` (pre-1.0; the algorithm is not yet functional end-to-end).
+  The `0.18.0` tag + GitHub Release are published (npm + Docker Hub CD fired).
 - **Active milestone:** **`1.0.0` — "Have a first functional version of the whole algorithm."**
-  - GitHub progress: **8 closed / 3 open** issues (PR #177 merged, so #41 now counts closed).
-  - The 3 open issues (#40, #43, #44) are the remaining algorithm pieces from §02–§03.
-- **Just merged:** **#41 — indexed binary MinHeap — PR #177 is now on `main`** (commit
-  `7e36afc`). See `05-codebase-map.md` for the shipped `src/heap.mjs` API
-  (`insert` / `extractMin` / `decreaseKey` / `has` / `peekMin`). With #41 done, **#40
-  (BaseCase) is fully unblocked** — both its dependencies (#41 heap, #45 adjacency) are in.
+  - GitHub progress: **9 closed / 2 open** issues (PR #178 merged, so #40 now counts closed).
+  - The 2 open issues (#44, #43) are the remaining algorithm pieces from §02–§03.
+- **Just merged:** **#40 — BaseCase(B, S), Algorithm 2 — PR #178 is now on `main`** (commit
+  `9a753b0`). See `05-codebase-map.md` for the shipped `src/baseCase.mjs` API. **#44
+  (FindPivots) is next** — fully specced in its GitHub issue body (RKB 2026-07-16) — and
+  then #43 wires everything together.
 
 ## Milestone `1.0.0` — issues → paper
 
@@ -52,7 +60,7 @@ build next); `05-codebase-map.md` is the "reality" side (what exists now).
 |---|---|---|---|---|---|
 | **45** | Add a map of arrays for edges of each node | Adjacency map so edge lookups aren't O(m). §05 | help wanted · good first issue | — | ✅ merged (PR #160) |
 | **41** | Implement a priority heap | Binary min-heap for the base case (Alg 2). §03-A | help wanted · good first issue | — | ✅ merged (PR #177) |
-| **40** | Implement the base case of the bmssp algorithm | `BaseCase(B, S)` bounded mini-Dijkstra. **Alg 2**, §02 | help wanted | #41 | 🔶 PR open |
+| **40** | Implement the base case of the bmssp algorithm | `BaseCase(B, S)` bounded mini-Dijkstra. **Alg 2**, §02 | help wanted | #41 | ✅ merged (PR #178) |
 | **42** | Implement Lema 3.3 data structure | Block-based partial-sort list `D`. **Lemma 3.3**, §03-B | help wanted | — | ✅ merged (PR #175) |
 | **44** | Implement the findingPivots function | `FindPivots(B, S)` frontier shrink. **Alg 1**, §02 | help wanted | #45 (helpful) | ⬜ open |
 | **43** | Implement main bmssp algorithm | `BMSSP(l, B, S)` recursion + `k,t`. **Alg 3**, §02 | help wanted | #40, #42, #44 | ⬜ open |
@@ -78,8 +86,9 @@ Track B (recursion core):    (✅ done)       └─▶ #44 FindPivots ───
    (§03-B contracts incl. seeded stress). Bound index is a sorted array for now (#167).
 3. ~~**#41** binary min-heap~~ — ✅ **done (PR #177):** `src/heap.mjs` indexed `MinHeap`
    (insert/extractMin/decreaseKey/has) + 16 tests; version 0.17.0 released. Unblocks #40.
-4. **#40** BaseCase — 🔶 **PR open:** `src/baseCase.mjs` `baseCase(B, S, dHat, adjacency, k)`
-   + 13 tests (incl. seeded oracle stress); bump to 0.18.0. Unblocks the level-0 leg of #43.
+4. ~~**#40** BaseCase~~ — ✅ **done (PR #178):** `src/baseCase.mjs`
+   `baseCase(B, S, dHat, adjacency, k)` + 13 tests (incl. seeded oracle stress); version
+   0.18.0 released. The level-0 leg of #43 is ready.
 5. **#44** FindPivots — needs relaxation + adjacency (#45 ✅). Test both branches (`|W|>k|S|`
    and forest roots).
 6. **#43** BMSSP main — wires #40+#42+#44 with `k`/`t`; replaces the Dijkstra delegation in
@@ -105,8 +114,8 @@ Clamp `k`,`t` to `≥ 1` for tiny graphs; correctness must not depend on the asy
 > GitHub going forward.
 
 ### `1.0.0` (milestone #1) — first end-to-end functional BMSSP
-Issues #40–#45. #45 done (PR #160), #42 done (PR #175), #41 done (PR #177); #40, #43, #44
-open. See the tables above.
+Issues #40–#45. #45 done (PR #160), #42 done (PR #175), #41 done (PR #177), #40 done
+(PR #178); #44 and #43 open. See the tables above.
 
 ### `1.1.0` (milestone #2) — correctness hardening
 | # | Issue | Labels |

--- a/.claude/knowledge/07-glossary.md
+++ b/.claude/knowledge/07-glossary.md
@@ -1,11 +1,11 @@
 # 07 — Glossary
 
-<!-- Updated on: 2026-07-16, in the #40 PR (added the baseCase code terms) -->
+<!-- Updated on: 2026-07-16 (lifecycle note; terms last extended in the #40 PR) -->
 
-> **Lifecycle: dynamic — updated on `RKB`.** This glossary is refreshed on the on-demand
-> `revitalize_knowledge_base` (`RKB`) command (see `../CLAUDE.md`). When code or the roadmap
-> introduces new symbols/terms (e.g. new module names, new data-structure fields), add them
-> here during the `RKB` refresh. Not touched during normal session start.
+> **Lifecycle: dynamic — updated in Phase C of every PR.** When a PR introduces new symbols
+> or terms (module names, data-structure fields, paper notation newly used in code), add
+> them here as part of the automatic pre-PR sync (see `../CLAUDE.md`, Phase C), inside the
+> same PR. Also refreshed by the on-demand `RKB` command. Not touched during session start.
 
 Quick lookup for the symbols and terms used across the paper, the notes, and the code.
 

--- a/.claude/knowledge/README.md
+++ b/.claude/knowledge/README.md
@@ -1,12 +1,12 @@
 # bmssp-js Knowledge Base
 
 A distilled, self-contained "mental map" of everything needed to implement the BMSSP
-algorithm in this repo, so an agent can start on the issues **without visiting the paper,
-PDF, or any external article**.
+algorithm in this repo, so an agent — **any model** — can start on the issues **without
+visiting the paper, PDF, or any external article**.
 
-**Operational entrypoint is [`../CLAUDE.md`](../CLAUDE.md)** — it defines the session-start
-routine and the on-demand `RKB` (`revitalize_knowledge_base`) command that keep the dynamic
-files below in sync. Read it first each session.
+**Operational entrypoint is [`../CLAUDE.md`](../CLAUDE.md)** — it defines the full working
+lifecycle (Phase A session start → Phase C automatic pre-PR sync → Phase E gated release)
+that keeps the dynamic files below in sync. Read it first each session.
 
 ## Files and lifecycle
 
@@ -16,9 +16,28 @@ files below in sync. Read it first each session.
 | 2 | **[02-algorithms.md](02-algorithms.md)** — FindPivots / BaseCase / BMSSP pseudocode | Fixed |
 | 3 | **[03-data-structures.md](03-data-structures.md)** — Lemma 3.3 block-list + heap | Fixed |
 | 4 | **[04-external-enhancement.md](04-external-enhancement.md)** — consolidated intuition | Fixed |
-| 5 | **[05-codebase-map.md](05-codebase-map.md)** — what exists in `src/` today | **Dynamic** — validated vs. bookmark commit at session start; refreshed on `RKB` |
-| 6 | **[06-milestones-roadmap.md](06-milestones-roadmap.md)** — milestones/issues → build order | **Dynamic** — read-reconciled from GitHub at session start; two-way synced on `RKB` |
-| 7 | **[07-glossary.md](07-glossary.md)** — symbol/term lookup | **Dynamic** — updated on `RKB` |
+| 5 | **[05-codebase-map.md](05-codebase-map.md)** — what exists in `src/` today | **Dynamic** — validated at session start (Phase A); rewritten inside every PR (Phase C) |
+| 6 | **[06-milestones-roadmap.md](06-milestones-roadmap.md)** — milestones/issues → build order | **Dynamic** — read-reconciled at session start; proposals in Phase C; gated GitHub writes in Phase E |
+| 7 | **[07-glossary.md](07-glossary.md)** — symbol/term lookup | **Dynamic** — updated in Phase C |
+
+"Fixed" = verified transcription/intuition; change `01–03` only to fix a factual error
+against the paper, never to restyle. All dynamic facts (versions, issue states, module
+inventories) live **only** in `05`/`06`/`07` — see the single-source-of-truth rule in
+`../CLAUDE.md`.
+
+## Reading map — what to read for the task at hand
+
+| If you are… | Read exactly |
+|---|---|
+| Starting any session | `../CLAUDE.md` Phase A, then this table |
+| Implementing **#44 FindPivots** (Alg 1) | `02` §Algorithm 1 · `05` (`baseCase`/adjacency APIs to mirror) · `07` (`W`, `P`, `F`, tight edge) |
+| Implementing **#43 main BMSSP** (Alg 3) | `02` §Algorithm 3 · `03`-B (`D`'s contracts, `[Bi', Bi)` staging) · `06` §Parameter derivation · `05` (all module APIs) |
+| Touching the **BlockList** | `03`-B · `05` §blockList · issue #167 (deferred asymptotics) |
+| Touching the **heap / BaseCase** | `03`-A · `02` §Algorithm 2 · `05` §heap/§baseCase |
+| Writing **tests** | `02` §Correctness invariant · `03` §Minimal test ideas · `05` §Tests |
+| Deciding **what to build next** | `06` (build order + milestone tables) |
+| Unsure what a symbol means | `07` |
+| Explaining the project to a human | root `README.md` (kept current in Phase C) |
 
 ## One-paragraph summary
 

--- a/README.md
+++ b/README.md
@@ -1,23 +1,54 @@
 # BMSSP: Bounded Multi-Source Shortest Paths
+
 [![codecov](https://codecov.io/gh/sirivasv/bmssp-js/branch/main/graph/badge.svg)](https://codecov.io/gh/sirivasv/bmssp-js)
 [![npm version](https://img.shields.io/npm/v/bmssp.svg)](https://www.npmjs.com/package/bmssp)
 [![Docker Image Version](https://img.shields.io/docker/v/sirivasv/bmssp-js?label=docker&sort=semver)](https://hub.docker.com/r/sirivasv/bmssp-js)
 [![GitHub Repo stars](https://img.shields.io/github/stars/sirivasv/bmssp-js?style=social)](https://github.com/sirivasv/bmssp-js/stargazers)
 
-This repository provides a community-driven JavaScript implementation of the Tsinghua Single Source Shortest Paths algorithm, based on the paper ["Breaking the Sorting Barrier for Directed Single-Source Shortest Paths"](https://dl.acm.org/doi/10.1145/3717823.3718179) by Duan Ran et al. from Tsinghua University.
+A community-driven JavaScript (ES Modules) implementation of the Tsinghua single-source
+shortest-paths algorithm from the paper
+["Breaking the Sorting Barrier for Directed Single-Source Shortest Paths"](https://dl.acm.org/doi/10.1145/3717823.3718179)
+(Duan, Mao, Mao, Shu, Yin — 2025): a deterministic **O(m·log^(2/3) n)** SSSP algorithm, the
+first to beat Dijkstra's O(m + n·log n) bound on sparse directed graphs.
 
-BMSSP stands for Bounded Multi-Source Shortest Paths.
+**BMSSP** stands for **B**ounded **M**ulti-**S**ource **S**hortest **P**aths.
 
-## Project Overview
+## Project status
 
-- **Language:** JavaScript (ES Modules)
-- **Goal:** Provide an easy-to-use, modern implementation of the algorithm, published to [npmjs.com](https://www.npmjs.com/).
-- **Reference:** For more on ES modules, see the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules).
+The project is built piece by piece against the paper, with every building block shipped,
+tested, and released individually. Current focus: milestone
+[`1.0.0` — first end-to-end functional BMSSP](https://github.com/Sirivasv/bmssp-js/milestones).
 
+| Building block (paper) | Where | Status |
+| --- | --- | --- |
+| Reference Dijkstra oracle (ground truth for tests) | `src/dijkstra.mjs` | ✅ done |
+| O(1) adjacency map for edge relaxation ([#45](https://github.com/Sirivasv/bmssp-js/issues/45)) | `BMSSP` constructor | ✅ done |
+| Lemma 3.3 block-based partial-sort structure `D` ([#42](https://github.com/Sirivasv/bmssp-js/issues/42)) | `src/blockList.mjs` | ✅ done |
+| Indexed binary min-heap ([#41](https://github.com/Sirivasv/bmssp-js/issues/41)) | `src/heap.mjs` | ✅ done |
+| `BaseCase(B, S)` — Algorithm 2, bounded mini-Dijkstra ([#40](https://github.com/Sirivasv/bmssp-js/issues/40)) | `src/baseCase.mjs` | ✅ done |
+| `FindPivots(B, S)` — Algorithm 1, frontier shrinking ([#44](https://github.com/Sirivasv/bmssp-js/issues/44)) | — | 🔨 next up |
+| `BMSSP(l, B, S)` — Algorithm 3, the main recursion ([#43](https://github.com/Sirivasv/bmssp-js/issues/43)) | — | ⬜ open |
+
+> **Honest note:** until [#43](https://github.com/Sirivasv/bmssp-js/issues/43) lands,
+> `calculateShortestPaths()` computes distances with the reference Dijkstra implementation.
+> The shipped BMSSP building blocks (block list, heap, base case) are fully tested but not
+> yet wired into the public entry point.
+
+## How it works (in two ideas)
+
+1. **Shrink the frontier with pivots.** Instead of keeping every frontier vertex in a
+   priority queue like Dijkstra, run `k` rounds of Bellman-Ford-style relaxation and recurse
+   only on the "pivots" — roots of large shortest-path trees. Only ~1/k of the frontier
+   needs the expensive treatment.
+2. **Partial sorting instead of a heap.** A block-based structure keeps batches of vertices
+   ordered *between* blocks but unsorted *within* them — enough to repeatedly pull the next
+   closest batch without paying the Θ(log n)-per-vertex "sorting barrier."
+
+The asymptotic win is theoretical (the crossover point is astronomically large); this repo
+optimizes for a **correct, readable, well-tested** implementation, validated line-by-line
+against a Dijkstra oracle — not for raw speed.
 
 ## Installation
-
-To install this package, you can use npm:
 
 ```bash
 npm install bmssp
@@ -25,40 +56,70 @@ npm install bmssp
 
 ## Usage
 
-To use this package, you can import it in your JavaScript code as follows:
+The package is ESM-only (`.mjs`). Graphs are arrays of `[from, to, weight]` edges with
+numeric node IDs and non-negative weights:
 
 ```javascript
-// This is a WIP example
 import { BMSSP } from "bmssp";
 
-const myBMSSP = new BMSSP([
+const graph = new BMSSP([
   [0, 1, 50],
   [1, 2, 75],
   [0, 2, 25],
 ]);
 
-console.log(myBMSSP.graph);
+graph.calculateShortestPaths(0);
+console.log(graph.shortestPaths); // Map(3) { 0 => 0, 1 => 50, 2 => 25 }
 ```
 
-The file must use ECMAScript modules (ESM) syntax and have the `.mjs` file extension. Go to the `examples` directory for more usage examples.
+A reference `dijkstra` implementation is also exported. See the `examples/` directory for
+more.
 
-### Using the docker image
+### Using the Docker image
 
-You can also use the published docker image and run the example:
+Run the bundled example:
 
 ```bash
 docker run -it sirivasv/bmssp-js:latest
 ```
 
-Or your tests in a pre-configured environment (replace `folder-mytest/` with your tests folder and `index.mjs` with your test file):
+Or run your own tests in a pre-configured environment (replace `folder-mytest/` with your
+tests folder and `index.mjs` with your test file):
 
 ```bash
 docker run -it -v ./folder-mytest/:/bmssp-js/folder-mytest/ sirivasv/bmssp-js:latest node /bmssp-js/folder-mytest/index.mjs
 ```
 
-Other versions of the docker image can be found on [Docker Hub](https://hub.docker.com/r/sirivasv/bmssp-js/tags).
+Other image versions are on [Docker Hub](https://hub.docker.com/r/sirivasv/bmssp-js/tags).
 
-### Other Implementations in GitHub
+## Development
 
-https://github.com/search?q=bmssp&type=repositories
+```bash
+npm install
+npm test          # Jest suite, incl. BMSSP-vs-Dijkstra equivalence on a real road network
+npm run lint      # Prettier + ESLint
+npm run bench     # seeded micro-benchmarks (see benchmarks/README.md)
+```
 
+The test suite's core contract: for every node, BMSSP's distances must equal the Dijkstra
+oracle's — including on `test/roadNet-CA.txt`, a real road network from SNAP.
+
+## Roadmap
+
+| Milestone | Theme |
+| --- | --- |
+| [`1.0.0`](https://github.com/Sirivasv/bmssp-js/milestones) | First end-to-end functional BMSSP (issues #40–#45) |
+| `1.1.0` | Correctness hardening — fuzz tests, edge cases, tie-breaking, input validation |
+| `1.2.0` | Performance & ergonomics — exact Lemma 3.3 asymptotics, path reconstruction, BMSSP-vs-Dijkstra benchmarks |
+| `2.0.0` | API generalization — public multi-source/bounded entry point, flexible inputs |
+
+Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) and the
+[`help wanted` / `good first issue` labels](https://github.com/Sirivasv/bmssp-js/issues).
+
+## Other implementations on GitHub
+
+<https://github.com/search?q=bmssp&type=repositories>
+
+## License
+
+[MPL-2.0](LICENSE)


### PR DESCRIPTION
## Summary

Reshapes the agent workflow in `.claude/` and brings the public `README.md` up to date with the project's real state.

**Process change — the headline:** the knowledge-base refresh (the old on-request `RKB`) now runs **automatically before every PR** (Phase C of the new lifecycle in `.claude/CLAUDE.md`). One PR per issue carries everything — code, tests, version bump, refreshed `05`/`06`/`07`, and README — eliminating the manual RKB ask and follow-up sync PRs.

### `.claude/` changes

- **`CLAUDE.md`** — rewritten as a five-phase lifecycle (A session start → B implement → C automatic pre-PR sync → D single PR → E gated release) with explicit ground rules: single source of truth for dynamic facts (static files carry none — the old file still said "currently 0.15.0"), one-PR-per-issue, and the two hard gates kept intact (per-edit confirmation for GitHub issue/milestone writes; tag+release only after confirmed merge).
- **`knowledge/05`** — bookmark validation is now an explicit if/else algorithm with a new `PENDING-PR-BRANCH` marker: a map rewritten inside a PR fast-paths post-merge validation instead of triggering a full repo re-inspection.
- **`knowledge/06`** — three touch-points (read-reconcile at session start / proposals in Phase C / gated GitHub writes in Phase E) plus a standing **Roadmap proposals** holding area.
- **`knowledge/07` + `knowledge/README.md`** — Phase C lifecycle notes and a per-task reading map ("implementing #44 → read exactly this"), making the KB usable by any model.
- **`knowledge/01–04`** — reviewed, deliberately unchanged: they're a verified transcription of the paper; their contract is now "change only to fix a factual error."

### `README.md` changes

Now showcases the current state: building-block status table (#45/#42/#41/#40 ✅, #44 next, #43 open), an honest note that `calculateShortestPaths` delegates to Dijkstra until #43, a two-idea algorithm explanation, a working usage example, dev commands, and the milestone roadmap. Keeping it current is now Phase C, step 5.

## Version bump

None — this PR closes no issue (docs/process only).

## Roadmap proposals

None.

## Checks

- `npm run lint` — clean (Prettier + ESLint, incl. markdown)
- `npm test` — untouched code paths; no source changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)