### PR TITLE
feat(#44): FindPivots(B, S) frontier-shrink (Algorithm 1)

### DIFF
--- a/.claude/knowledge/05-codebase-map.md
+++ b/.claude/knowledge/05-codebase-map.md
@@ -1,10 +1,11 @@
 # 05 — Codebase Map (current state)
 
-<!-- BOOKMARK-COMMIT: 9a753b09d77d8b7b2f72118c17b74dafa5d0df0f -->
-<!-- PENDING-PR-BRANCH: chore/agent-process-v2 -->
-<!-- Last validated: 2026-07-16, on main. Version 0.18.0 (tagged + released; publish.yml
-     fired). #40 (BaseCase) closed via PR #178; remaining 1.0.0 issues: #44 (FindPivots,
-     fully specced on GitHub) then #43 (main recursion). No pending release work. -->
+<!-- BOOKMARK-COMMIT: 79b58f2636a05c88d5937966710d3d0a3f3b781d -->
+<!-- PENDING-PR-BRANCH: feat/44-find-pivots -->
+<!-- Last validated: 2026-07-16, rewritten in Phase C of the #44 PR (feat/44-find-pivots).
+     Describes the tree as it will exist once that PR merges. Version 0.19.0 (bumped in the
+     PR; tag + release pending the merge). #44 (FindPivots) done in this PR; the only
+     remaining 1.0.0 issue is #43 (main recursion). -->
 
 Snapshot of what exists in `bmssp-js` today, so you know what to build on vs. what's missing.
 
@@ -59,11 +60,13 @@ src/
   blockList.mjs           # NEW (#42, PR #175): Lemma 3.3 block-based partial-sort structure D
   heap.mjs                # NEW (#41): indexed binary min-heap (MinHeap) for BaseCase (Alg 2)
   baseCase.mjs            # NEW (#40): BaseCase(B, S) — Algorithm 2 bounded mini-Dijkstra
+  findPivots.mjs          # NEW (#44): FindPivots(B, S) — Algorithm 1 frontier shrink
 test/
   main.test.mjs           # Jest tests: constructor, nodeIDs, adjacency map, shortestPaths, BMSSP-vs-Dijkstra
   blockList.test.mjs      # NEW (#42): 18 BlockList tests incl. a seeded random stress test
   heap.test.mjs           # NEW (#41): 16 MinHeap tests incl. a seeded stress test vs. a naive queue
   baseCase.test.mjs       # NEW (#40): 13 BaseCase tests incl. seeded oracle-comparison stress
+  findPivots.test.mjs     # NEW (#44): 12 FindPivots tests incl. two seeded oracle stress tests
   roadNet-CA.txt          # real road-network edge list (SNAP roadNet-CA), weights randomized at load
   README.md
 benchmarks/               # NEW (#45 PR): dependency-free benchmark harness, `npm run bench`
@@ -177,6 +180,28 @@ never re-inserted into the heap (an equal-sum relaxation — e.g. a zero-weight 
 otherwise loop forever; with non-negative weights a settled vertex cannot strictly improve,
 so nothing is lost). Callers wire it as `Bi', Ui ← BaseCase(Bi, Si)` at level 0 of #43.
 
+## `src/findPivots.mjs` — `FindPivots(B, S)`, Algorithm 1 (#44)
+
+```js
+findPivots(B, S, dHat, adjacency, k)  // → { pivots, W }
+// B         : strict bound gating membership in W (Infinity OK); d̂ updates are NOT gated
+// S         : non-empty Set of complete frontier sources (throws if empty / any d̂ not finite)
+// dHat      : Map<nodeId, number> — the global d̂[·]; RELAXED IN PLACE
+// adjacency : Map<nodeId, [to, weight][]> — the class's this.adjacency
+// k         : rounds + tree-size threshold >= 1 (floored); throws otherwise
+export { findPivots };   // NOT re-exported from index.mjs — internal to the algorithm
+```
+
+`k` rounds of Bellman-Ford relaxation out of `S` (paper's `≤` test; `< B` gates only the
+membership in `W`, the d̂ write itself is unconditional). **Early exit:** as soon as
+`|W| > k·|S|`, returns `pivots = S` (copy) with the partial `W`. Otherwise builds the
+tight-edge forest `F` inside `W` — each vertex takes **at most one parent**, chosen
+deterministically in W-iteration order (ties/DAG caveat, see #163) — and returns as pivots
+the `S`-roots of trees with `≥ k` vertices. Vertices on tight cycles (zero-weight cycles)
+all receive parents, so they root no tree and can't be pivots (degenerate-tie behavior,
+documented in the tests). Guarantees `|pivots| ≤ |W|/k`. Callers wire it as
+`P, W ← FindPivots(B, S)` at the top of #43.
+
 ## `src/dijkstra.mjs` — the oracle (already done)
 
 `dijkstra(graph, nodeIDs, source) → Map<nodeId, distance>`. Standard array binary min-heap
@@ -195,12 +220,19 @@ implementation is tested against. Reuse its heap style / adjacency-list building
 - **Key one:** "BMSSP vs Dijkstra" — for a fixed source, `myBMSSP.shortestPaths` must equal
   `dijkstra(...)` for every node. **Any real BMSSP implementation must keep this passing.**
 - Current suite: **12 tests in `main.test.mjs` + 18 in `blockList.test.mjs` + 16 in
-  `heap.test.mjs` + 13 in `baseCase.test.mjs`, all passing (59).**
+  `heap.test.mjs` + 13 in `baseCase.test.mjs` + 12 in `findPivots.test.mjs`, all
+  passing (71).**
 - **BaseCase (#40):** validation (k, singleton S, complete source), full-success vs. finite/
   infinite B, partial k+1-cap boundary reporting (incl. ties excluded by the strict filter),
   zero-weight-cycle termination, and two seeded stress tests checking the Algorithm 2
   contract against the Dijkstra oracle (exact distances, completeness below B', d̂ never
   underestimates).
+- **FindPivots (#44):** validation (k, non-empty S, complete sources), both branches (early
+  exit incl. multi-source, forest roots with the `≥ k` size filter), `< B` gating W but not
+  d̂ writes, zero-weight tight-cycle termination, DAG-of-tight-edges determinism, and two
+  seeded oracle stress tests (k = n completes the reachable set exactly; bounded runs keep
+  the frontier-shrink contract: every `d(v) < B` vertex is complete-in-W or reachable
+  optimally through a pivot, `|P|·k ≤ |W|`, d̂ never underestimates).
 - **BlockList (#42):** init validation, `value < B` enforcement, drain-pull returns bound `B`,
   batch-sorted pulls of the M smallest, separator invariant, smallest-value-wins dedupe
   (insert and batchPrepend, vs. stored and within-batch), split correctness, re-insert after
@@ -226,7 +258,7 @@ lands. `benchmarks/README.md` holds the "when to use which" guidance.
 | Lemma 3.3 block-list `D` | `src/blockList.mjs` | #42 | ✅ done (PR #175) |
 | Binary min-heap module | `src/heap.mjs` | #41 | ✅ done (PR #177) |
 | Base case (bounded Dijkstra) | `src/baseCase.mjs` | #40 | ✅ done (PR #178) |
-| FindPivots | `src/findPivots.mjs` / method | #44 | ⬜ open |
-| Main `BMSSP(l, B, S)` recursion + `k,t` derivation | `src/bmssp.mjs` | #43 | ⬜ open |
+| FindPivots | `src/findPivots.mjs` | #44 | ✅ done (this PR) |
+| Main `BMSSP(l, B, S)` recursion + `k,t` derivation | `src/bmssp.mjs` | #43 | ⬜ open — **the last 1.0.0 piece** |
 
 See [06-milestones-roadmap.md](06-milestones-roadmap.md) for the recommended order and test strategy.

--- a/.claude/knowledge/06-milestones-roadmap.md
+++ b/.claude/knowledge/06-milestones-roadmap.md
@@ -1,7 +1,7 @@
 # 06 — Milestones Roadmap
 
-<!-- SYNCED-FROM-GITHUB: 2026-07-16 (PR #178 merged, #40 closed, 0.18.0 tagged + released) -->
-<!-- Current package version: 0.18.0 (tagged + released) -->
+<!-- SYNCED-FROM-GITHUB: 2026-07-16 (Phase C of the #44 PR, feat/44-find-pivots) -->
+<!-- Current package version: 0.19.0 (bumped in the #44 PR; tag + release pending merge) -->
 
 Maps GitHub **milestones** and **issues** (Sirivasv/bmssp-js) to the paper's building blocks,
 with a dependency-aware build order. This is the "intent" side of the knowledge base (what to
@@ -37,22 +37,31 @@ it runs the same Phase C reconciliation directly on `main`.
 
 ## 📋 Roadmap proposals (pending user approval)
 
-_None right now. Phase C writes proposed GitHub edits here (and in the PR body); Phase E
-executes the approved ones — one confirmation each — and clears them from this list._
+Written in Phase C of the #44 PR (2026-07-16); execute in Phase E, one confirmation each.
+
+1. **Edit #43 (main BMSSP recursion):** append the shipped FindPivots API to its wiring
+   contract — `findPivots(B, S, dHat, adjacency, k) → { pivots, W }` (`P, W ← FindPivots(B, S)`
+   maps to `const { pivots, W } = findPivots(B, S, dHat, adjacency, k)`). All three legs of
+   #43 (baseCase, BlockList, findPivots) now have concrete signatures in the issue body.
+2. **Edit #163 (deterministic tie-breaking):** add the third tie manifestation, found while
+   implementing #44 — vertices on a **tight (zero-weight) cycle** all receive parents in the
+   one-parent forest, so none of them is a root and none can be a pivot; harmless for
+   termination but worth revisiting when Assumption 2.1 tie-breaking is formalized.
 
 ---
 
 ## Current state (as synced)
 
-- **Package version:** `0.18.0` (pre-1.0; the algorithm is not yet functional end-to-end).
-  The `0.18.0` tag + GitHub Release are published (npm + Docker Hub CD fired).
+- **Package version:** `0.19.0`, bumped in the in-flight #44 PR (pre-1.0; the algorithm is
+  not yet functional end-to-end). Tag + GitHub Release happen after the merge (Phase E).
+  Last published release: `0.18.0`.
 - **Active milestone:** **`1.0.0` — "Have a first functional version of the whole algorithm."**
-  - GitHub progress: **9 closed / 2 open** issues (PR #178 merged, so #40 now counts closed).
-  - The 2 open issues (#44, #43) are the remaining algorithm pieces from §02–§03.
-- **Just merged:** **#40 — BaseCase(B, S), Algorithm 2 — PR #178 is now on `main`** (commit
-  `9a753b0`). See `05-codebase-map.md` for the shipped `src/baseCase.mjs` API. **#44
-  (FindPivots) is next** — fully specced in its GitHub issue body (RKB 2026-07-16) — and
-  then #43 wires everything together.
+  - GitHub progress once the #44 PR merges: **10 closed / 1 open**.
+  - The one open issue, **#43 (main recursion), is the last 1.0.0 piece**.
+- **In flight:** **#44 — FindPivots(B, S), Algorithm 1 — done in the `feat/44-find-pivots`
+  PR** (this branch). See `05-codebase-map.md` for the shipped `src/findPivots.mjs` API.
+  **#43 is next and last** — its issue body carries the wiring contract; all three legs
+  (baseCase #40, BlockList #42, findPivots #44) are now on `main` or in this PR.
 
 ## Milestone `1.0.0` — issues → paper
 
@@ -62,8 +71,8 @@ executes the approved ones — one confirmation each — and clears them from th
 | **41** | Implement a priority heap | Binary min-heap for the base case (Alg 2). §03-A | help wanted · good first issue | — | ✅ merged (PR #177) |
 | **40** | Implement the base case of the bmssp algorithm | `BaseCase(B, S)` bounded mini-Dijkstra. **Alg 2**, §02 | help wanted | #41 | ✅ merged (PR #178) |
 | **42** | Implement Lema 3.3 data structure | Block-based partial-sort list `D`. **Lemma 3.3**, §03-B | help wanted | — | ✅ merged (PR #175) |
-| **44** | Implement the findingPivots function | `FindPivots(B, S)` frontier shrink. **Alg 1**, §02 | help wanted | #45 (helpful) | ⬜ open |
-| **43** | Implement main bmssp algorithm | `BMSSP(l, B, S)` recursion + `k,t`. **Alg 3**, §02 | help wanted | #40, #42, #44 | ⬜ open |
+| **44** | Implement the findingPivots function | `FindPivots(B, S)` frontier shrink. **Alg 1**, §02 | help wanted | #45 (helpful) | ✅ done (this PR) |
+| **43** | Implement main bmssp algorithm | `BMSSP(l, B, S)` recursion + `k,t`. **Alg 3**, §02 | help wanted | #40, #42, #44 | ⬜ open — next & last |
 
 ### Closed (context)
 `#36` main `calculateShortestPaths` (currently delegates to Dijkstra — placeholder) ·
@@ -75,9 +84,9 @@ executes the approved ones — one confirmation each — and clears them from th
 Leaves first; two independent tracks converge on the main recursion:
 
 ```
-Track A (base case):     #45 adjacency map ─┬─▶ #41 heap ─▶ #40 BaseCase ─┐   (#45 ✅, #41 ✅)
-Track B (recursion core):    (✅ done)       └─▶ #44 FindPivots ───────────┼─▶ #43 BMSSP main
-                                                #42 BlockList (✅ done) ───┘
+Track A (base case):     #45 adjacency map ─┬─▶ #41 heap ─▶ #40 BaseCase ─┐   (all ✅ —
+Track B (recursion core):    (✅ done)       └─▶ #44 FindPivots (✅) ──────┼─▶ #43 BMSSP main
+                                                #42 BlockList (✅ done) ───┘    only #43 left)
 ```
 
 1. ~~**#45** adjacency map~~ — ✅ **done (PR #160):** `this.adjacency: Map<nodeId, [to,w][]>`
@@ -89,8 +98,9 @@ Track B (recursion core):    (✅ done)       └─▶ #44 FindPivots ───
 4. ~~**#40** BaseCase~~ — ✅ **done (PR #178):** `src/baseCase.mjs`
    `baseCase(B, S, dHat, adjacency, k)` + 13 tests (incl. seeded oracle stress); version
    0.18.0 released. The level-0 leg of #43 is ready.
-5. **#44** FindPivots — needs relaxation + adjacency (#45 ✅). Test both branches (`|W|>k|S|`
-   and forest roots).
+5. ~~**#44** FindPivots~~ — ✅ **done (this PR):** `src/findPivots.mjs`
+   `findPivots(B, S, dHat, adjacency, k) → { pivots, W }` + 12 tests (both branches, tie/DAG
+   determinism, two seeded oracle stress tests); version 0.19.0 bumped.
 6. **#43** BMSSP main — wires #40+#42+#44 with `k`/`t`; replaces the Dijkstra delegation in
    `calculateShortestPaths`. **Definition of done:** BMSSP computes distances via the paper's
    method and the "BMSSP vs Dijkstra" test still passes for every node.
@@ -115,7 +125,7 @@ Clamp `k`,`t` to `≥ 1` for tiny graphs; correctness must not depend on the asy
 
 ### `1.0.0` (milestone #1) — first end-to-end functional BMSSP
 Issues #40–#45. #45 done (PR #160), #42 done (PR #175), #41 done (PR #177), #40 done
-(PR #178); #44 and #43 open. See the tables above.
+(PR #178), #44 done (this PR); only #43 open. See the tables above.
 
 ### `1.1.0` (milestone #2) — correctness hardening
 | # | Issue | Labels |

--- a/.claude/knowledge/07-glossary.md
+++ b/.claude/knowledge/07-glossary.md
@@ -1,6 +1,6 @@
 # 07 — Glossary
 
-<!-- Updated on: 2026-07-16 (lifecycle note; terms last extended in the #40 PR) -->
+<!-- Updated on: 2026-07-16 (terms last extended in the #44 PR: findPivots) -->
 
 > **Lifecycle: dynamic — updated in Phase C of every PR.** When a PR introduces new symbols
 > or terms (module names, data-structure fields, paper notation newly used in code), add
@@ -103,6 +103,17 @@ Quick lookup for the symbols and terms used across the paper, the notes, and the
   in the same call: the paper's `≤` relaxation admits equal-sum re-relaxations (e.g.
   zero-weight cycles) that would loop forever, and with non-negative weights a settled
   vertex cannot strictly improve, so skipping it is loss-free.
+- **`findPivots(B, S, dHat, adjacency, k)`** (#44) — `src/findPivots.mjs`, Algorithm 1:
+  `k` rounds of Bellman-Ford out of the complete frontier `S`, relaxing the shared `dHat`
+  (`d̂[·]`) **in place**; `< B` gates membership in `W` only (the d̂ write is unconditional).
+  Returns `{ pivots, W }` (= the paper's `P, W`), with `|pivots| ≤ |W|/k`. Internal (not
+  re-exported from `index.mjs`).
+- **Early exit** (#44) — `findPivots`' first branch: as soon as `|W| > k·|S|` after a round,
+  return `pivots = S` — the frontier is already small relative to `W`.
+- **One-parent rule** (#44) — building the tight-edge forest `F`, each vertex accepts at
+  most one parent (the first tight edge in W-iteration order). Keeps tree sizes well-defined
+  when equal-length paths make `F` a DAG (tie caveat, #163). Corollary: vertices on a tight
+  (zero-weight) cycle all have parents, so none roots a tree and none can be a pivot.
 - **Benchmark harness** — `benchmarks/` (run via `npm run bench`): seeded graph
   **generators** + a `SCENARIOS` registry (sparse-random / dense-random / grid / chain /
   star), `timeMany` timing, and two benchmarks (adjacency-vs-scan, per-shape Dijkstra). Will

--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ tested, and released individually. Current focus: milestone
 | Lemma 3.3 block-based partial-sort structure `D` ([#42](https://github.com/Sirivasv/bmssp-js/issues/42)) | `src/blockList.mjs` | ✅ done |
 | Indexed binary min-heap ([#41](https://github.com/Sirivasv/bmssp-js/issues/41)) | `src/heap.mjs` | ✅ done |
 | `BaseCase(B, S)` — Algorithm 2, bounded mini-Dijkstra ([#40](https://github.com/Sirivasv/bmssp-js/issues/40)) | `src/baseCase.mjs` | ✅ done |
-| `FindPivots(B, S)` — Algorithm 1, frontier shrinking ([#44](https://github.com/Sirivasv/bmssp-js/issues/44)) | — | 🔨 next up |
-| `BMSSP(l, B, S)` — Algorithm 3, the main recursion ([#43](https://github.com/Sirivasv/bmssp-js/issues/43)) | — | ⬜ open |
+| `FindPivots(B, S)` — Algorithm 1, frontier shrinking ([#44](https://github.com/Sirivasv/bmssp-js/issues/44)) | `src/findPivots.mjs` | ✅ done |
+| `BMSSP(l, B, S)` — Algorithm 3, the main recursion ([#43](https://github.com/Sirivasv/bmssp-js/issues/43)) | — | 🔨 next up — the last piece |
 
 > **Honest note:** until [#43](https://github.com/Sirivasv/bmssp-js/issues/43) lands,
 > `calculateShortestPaths()` computes distances with the reference Dijkstra implementation.
-> The shipped BMSSP building blocks (block list, heap, base case) are fully tested but not
-> yet wired into the public entry point.
+> The shipped BMSSP building blocks (block list, heap, base case, pivot finding) are fully
+> tested but not yet wired into the public entry point.
 
 ## How it works (in two ideas)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bmssp",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bmssp",
-      "version": "0.18.0",
+      "version": "0.19.0",
       "license": "MPL-2.0",
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bmssp",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Javascript package implementation of the bmssp algorithm.",
   "main": "index.mjs",
   "keywords": [

--- a/src/findPivots.mjs
+++ b/src/findPivots.mjs
@@ -1,0 +1,113 @@
+/**
+ * FindPivots(B, S) — Algorithm 1 of "Breaking the Sorting Barrier for Directed
+ * Single-Source Shortest Paths". Shrinks the frontier S: runs k rounds of
+ * Bellman-Ford-style relaxation out of S, collecting every vertex relaxed
+ * below B into W, then identifies the pivots — the vertices of S that root a
+ * large (>= k vertices) tree in the forest of tight shortest-path edges. Only
+ * the pivots need to be carried into the deeper BMSSP recursion.
+ *
+ * Preconditions (guaranteed by the caller, Algorithm 3):
+ * - Every vertex in S is complete (dHat holds its true distance).
+ * - Every incomplete vertex v with d(v) < B has a shortest path through some
+ *   complete vertex in S.
+ *
+ * Distance estimates are read from and written into dHat in place — exactly
+ * like the paper's global d̂[·] labels, so improvements made here are visible
+ * to the levels above. The `<=` relaxation updates d̂ unconditionally; the
+ * `< B` test only gates membership in W.
+ *
+ * Two outcomes:
+ * - Early exit (|W| grows past k·|S|): the frontier is already small relative
+ *   to W, so every vertex of S is a pivot.
+ * - Forest case (k rounds complete with |W| <= k·|S|): pivots are the S-roots
+ *   of tight-edge trees with >= k vertices. Equal-length paths can make the
+ *   tight-edge graph a DAG (see #163); each vertex is assigned at most one
+ *   parent deterministically (first tight edge in W iteration order) so tree
+ *   sizes are well-defined. Guarantees |pivots| <= |W| / k either way.
+ *
+ * @param {number} B - Strict upper bound gating membership in W (Infinity is allowed)
+ * @param {Set<*>|Iterable<*>} S - Non-empty set of complete frontier sources
+ * @param {Map<*, number>} dHat - Global distance estimates d̂[·], updated in place
+ * @param {Map<*, Array<[*, number]>>} adjacency - nodeId -> outgoing [to, weight] edges
+ * @param {number} k - Relaxation rounds / tree-size threshold, >= 1 (floored);
+ *   the paper's ⌊log^(1/3) n⌋
+ * @returns {{ pivots: Set<*>, W: Set<*> }} The pivot subset of S and the set W
+ *   of vertices touched below B (W always contains S)
+ * @throws {Error} If k is not a number >= 1, S is empty, or any source has no
+ *   finite distance estimate
+ */
+function findPivots(B, S, dHat, adjacency, k) {
+  if (typeof k !== "number" || Number.isNaN(k) || k < 1) {
+    throw new Error("k must be a number >= 1");
+  }
+  const rounds = Math.floor(k);
+  const sources = [...S];
+  if (sources.length === 0) {
+    throw new Error("S must contain at least one source node");
+  }
+  for (const x of sources) {
+    const distance = dHat.get(x);
+    if (typeof distance !== "number" || !Number.isFinite(distance)) {
+      throw new Error("every source must have a finite distance estimate");
+    }
+  }
+
+  // W accumulates everything relaxed below B; layer is the paper's W_{i-1}
+  const W = new Set(sources);
+  let layer = new Set(sources);
+
+  for (let i = 1; i <= rounds; i += 1) {
+    const nextLayer = new Set();
+    for (const u of layer) {
+      for (const [v, weight] of adjacency.get(u) ?? []) {
+        const candidate = dHat.get(u) + weight;
+        // Paper relaxation: <= always updates d̂; < B gates the W membership
+        if (candidate <= (dHat.get(v) ?? Infinity)) {
+          dHat.set(v, candidate);
+          if (candidate < B) nextLayer.add(v);
+        }
+      }
+    }
+    for (const v of nextLayer) W.add(v);
+    layer = nextLayer;
+    if (W.size > rounds * sources.length) {
+      // Frontier already small relative to W: every source is a pivot
+      return { pivots: new Set(sources), W };
+    }
+  }
+
+  // Forest F of tight edges inside W. Each vertex takes at most one parent,
+  // chosen deterministically, so tree sizes stay well-defined even when ties
+  // make F a DAG. Vertices on tight cycles (zero-weight cycles) all end up
+  // with parents, so they belong to no root's tree.
+  const children = new Map();
+  const hasParent = new Set();
+  for (const u of W) {
+    const du = dHat.get(u);
+    for (const [v, weight] of adjacency.get(u) ?? []) {
+      if (v === u || !W.has(v) || hasParent.has(v)) continue;
+      if (dHat.get(v) === du + weight) {
+        hasParent.add(v);
+        if (!children.has(u)) children.set(u, []);
+        children.get(u).push(v);
+      }
+    }
+  }
+
+  // Pivots: sources that root a tight-edge tree with >= k vertices
+  const pivots = new Set();
+  for (const x of sources) {
+    if (hasParent.has(x)) continue;
+    let size = 0;
+    const stack = [x];
+    while (stack.length > 0) {
+      const u = stack.pop();
+      size += 1;
+      for (const child of children.get(u) ?? []) stack.push(child);
+    }
+    if (size >= rounds) pivots.add(x);
+  }
+  return { pivots, W };
+}
+
+export { findPivots };

--- a/test/findPivots.test.mjs
+++ b/test/findPivots.test.mjs
@@ -1,0 +1,279 @@
+import { describe, test, expect } from "@jest/globals";
+import { findPivots } from "../src/findPivots.mjs";
+import { BMSSP } from "../src/bmssp.mjs";
+import { dijkstra } from "../src/dijkstra.mjs";
+
+// Small deterministic PRNG so stress-test failures are reproducible
+function mulberry32(seed) {
+  let a = seed >>> 0;
+  return function () {
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// Build the shared state FindPivots runs against: the class's adjacency map
+// and d̂ labels, with every source marked complete at its given distance
+function setup(edges, sourceDistances) {
+  const bmssp = new BMSSP(edges);
+  for (const [source, distance] of Object.entries(sourceDistances)) {
+    bmssp.shortestPaths.set(Number(source), distance);
+  }
+  return bmssp;
+}
+
+// Seeded random directed graph with an edge out of node 0 guaranteed.
+// Large weight range keeps equal-length paths (ties) rare.
+function randomEdges(rand, n, m) {
+  const edges = [[0, 1 + Math.floor(rand() * (n - 1)), 1]];
+  for (let i = 1; i < m; i += 1) {
+    const from = Math.floor(rand() * n);
+    const to = Math.floor(rand() * n);
+    const weight = 1 + Math.floor(rand() * 1000);
+    edges.push([from, to, weight]);
+  }
+  return edges;
+}
+
+describe("findPivots validation", () => {
+  test("rejects k that is not a number >= 1", () => {
+    const { shortestPaths, adjacency } = setup([[0, 1, 1]], { 0: 0 });
+    expect(() =>
+      findPivots(Infinity, new Set([0]), shortestPaths, adjacency, 0),
+    ).toThrow("k must be a number >= 1");
+    expect(() =>
+      findPivots(Infinity, new Set([0]), shortestPaths, adjacency, NaN),
+    ).toThrow("k must be a number >= 1");
+  });
+
+  test("rejects an empty S", () => {
+    const { shortestPaths, adjacency } = setup([[0, 1, 1]], { 0: 0 });
+    expect(() =>
+      findPivots(Infinity, new Set(), shortestPaths, adjacency, 2),
+    ).toThrow("S must contain at least one source node");
+  });
+
+  test("rejects a source without a finite distance estimate", () => {
+    // Node 1 was never completed: its d̂ is still Infinity
+    const { shortestPaths, adjacency } = setup([[0, 1, 1]], { 0: 0 });
+    expect(() =>
+      findPivots(Infinity, new Set([0, 1]), shortestPaths, adjacency, 2),
+    ).toThrow("every source must have a finite distance estimate");
+  });
+});
+
+describe("findPivots early exit (|W| > k·|S|)", () => {
+  test("a star blowing past the cap returns every source as a pivot", () => {
+    const edges = [
+      [0, 1, 1],
+      [0, 2, 1],
+      [0, 3, 1],
+    ];
+    const { shortestPaths, adjacency } = setup(edges, { 0: 0 });
+    const result = findPivots(
+      Infinity,
+      new Set([0]),
+      shortestPaths,
+      adjacency,
+      1,
+    );
+    // Round 1 grows W to {0,1,2,3}: 4 > k·|S| = 1, so P = S
+    expect(result.pivots).toEqual(new Set([0]));
+    expect(result.W).toEqual(new Set([0, 1, 2, 3]));
+    expect(shortestPaths.get(1)).toBe(1);
+    expect(shortestPaths.get(2)).toBe(1);
+    expect(shortestPaths.get(3)).toBe(1);
+  });
+
+  test("multiple sources early-exit together", () => {
+    const edges = [
+      [0, 1, 1],
+      [4, 5, 1],
+    ];
+    const { shortestPaths, adjacency } = setup(edges, { 0: 0, 4: 0 });
+    const result = findPivots(
+      Infinity,
+      new Set([0, 4]),
+      shortestPaths,
+      adjacency,
+      1,
+    );
+    // Round 1: W = {0,4,1,5}, 4 > k·|S| = 2, so P = S
+    expect(result.pivots).toEqual(new Set([0, 4]));
+    expect(result.W).toEqual(new Set([0, 4, 1, 5]));
+  });
+});
+
+describe("findPivots relaxation semantics", () => {
+  test("d̂ is updated even at/above B, but W membership is gated by < B", () => {
+    const edges = [[0, 1, 5]];
+    const { shortestPaths, adjacency } = setup(edges, { 0: 0 });
+    const result = findPivots(3, new Set([0]), shortestPaths, adjacency, 2);
+    // The relaxation writes d̂(1) = 5, but 5 >= B keeps 1 out of W
+    expect(shortestPaths.get(1)).toBe(5);
+    expect(result.W).toEqual(new Set([0]));
+    // A 1-vertex tree is below the k = 2 threshold: no pivots at all
+    expect(result.pivots).toEqual(new Set());
+  });
+
+  test("a zero-weight cycle terminates (its vertices root no tree)", () => {
+    const edges = [
+      [0, 1, 0],
+      [1, 0, 0],
+      [1, 2, 1],
+    ];
+    const { shortestPaths, adjacency } = setup(edges, { 0: 0 });
+    const result = findPivots(
+      Infinity,
+      new Set([0]),
+      shortestPaths,
+      adjacency,
+      5,
+    );
+    expect(result.W).toEqual(new Set([0, 1, 2]));
+    expect(shortestPaths.get(1)).toBe(0);
+    expect(shortestPaths.get(2)).toBe(1);
+    // 0 and 1 give each other parents (tight cycle), so nothing is a root
+    expect(result.pivots).toEqual(new Set());
+  });
+});
+
+describe("findPivots forest case (pivots root large tight trees)", () => {
+  test("a chain exactly k long makes the source a pivot", () => {
+    const edges = [
+      [0, 1, 1],
+      [1, 2, 1],
+    ];
+    const { shortestPaths, adjacency } = setup(edges, { 0: 0 });
+    const result = findPivots(
+      Infinity,
+      new Set([0]),
+      shortestPaths,
+      adjacency,
+      3,
+    );
+    // W = {0,1,2} stays within k·|S| = 3; the tree at 0 has 3 >= k vertices
+    expect(result.pivots).toEqual(new Set([0]));
+    expect(result.W).toEqual(new Set([0, 1, 2]));
+  });
+
+  test("sources with small trees are dropped, large ones kept", () => {
+    const edges = [
+      [0, 1, 1],
+      [1, 2, 1],
+      [4, 5, 1],
+    ];
+    const { shortestPaths, adjacency } = setup(edges, { 0: 0, 4: 0 });
+    const result = findPivots(
+      Infinity,
+      new Set([0, 4]),
+      shortestPaths,
+      adjacency,
+      3,
+    );
+    // Tree at 0 = {0,1,2} (3 >= k) is a pivot; tree at 4 = {4,5} (2 < k) is not
+    expect(result.pivots).toEqual(new Set([0]));
+    expect(result.W).toEqual(new Set([0, 4, 1, 5, 2]));
+  });
+
+  test("equal-length paths (DAG of tight edges) keep tree sizes well-defined", () => {
+    const edges = [
+      [0, 1, 1],
+      [0, 2, 1],
+      [1, 3, 1],
+      [2, 3, 1],
+    ];
+    const { shortestPaths, adjacency } = setup(edges, { 0: 0 });
+    const result = findPivots(
+      Infinity,
+      new Set([0]),
+      shortestPaths,
+      adjacency,
+      4,
+    );
+    // Both 1->3 and 2->3 are tight; 3 gets exactly one parent, so the tree
+    // at 0 counts each vertex once: size 4 >= k = 4
+    expect(result.pivots).toEqual(new Set([0]));
+    expect(result.W).toEqual(new Set([0, 1, 2, 3]));
+  });
+});
+
+describe("findPivots vs Dijkstra oracle (seeded)", () => {
+  test("k = n rounds with B = Infinity complete every reachable vertex", () => {
+    const rand = mulberry32(44);
+    for (let round = 0; round < 20; round += 1) {
+      const edges = randomEdges(rand, 40, 160);
+      const bmssp = setup(edges, { 0: 0 });
+      const oracle = dijkstra(bmssp.graph, bmssp.nodeIDs, 0);
+      const n = bmssp.nodeIDs.size;
+      // k = n rounds of Bellman-Ford complete everything, and the early
+      // exit (|W| > n·1) can never fire since W has at most n vertices
+      const result = findPivots(
+        Infinity,
+        new Set([0]),
+        bmssp.shortestPaths,
+        bmssp.adjacency,
+        n,
+      );
+      const reachable = new Set(
+        [...oracle].filter(([, d]) => d < Infinity).map(([v]) => v),
+      );
+      expect(result.W).toEqual(reachable);
+      for (const v of result.W) {
+        expect(bmssp.shortestPaths.get(v)).toBe(oracle.get(v));
+      }
+    }
+  });
+
+  test("bounded runs keep the Algorithm 1 contract", () => {
+    const rand = mulberry32(45);
+    for (let round = 0; round < 25; round += 1) {
+      const edges = randomEdges(rand, 30, 90);
+      const bmssp = setup(edges, { 0: 0 });
+      const oracle = dijkstra(bmssp.graph, bmssp.nodeIDs, 0);
+      const finite = [...oracle.values()]
+        .filter((d) => d < Infinity)
+        .sort((a, b) => a - b);
+      // A bound somewhere inside the distance distribution, and a small k
+      const B = finite[Math.floor(finite.length * 0.6)] + 0.5;
+      const k = 1 + Math.floor(rand() * 5);
+      const result = findPivots(
+        B,
+        new Set([0]),
+        bmssp.shortestPaths,
+        bmssp.adjacency,
+        k,
+      );
+
+      // Pivots are a subset of S, and |P| <= |W| / k
+      for (const p of result.pivots) {
+        expect(p).toBe(0);
+      }
+      expect(result.pivots.size * k).toBeLessThanOrEqual(result.W.size);
+
+      // d̂ never underestimates the true distance anywhere
+      for (const [v, d] of bmssp.shortestPaths) {
+        expect(d).toBeGreaterThanOrEqual(oracle.get(v));
+      }
+
+      // The frontier-shrink contract: every vertex with d(v) < B is either
+      // complete in W, or some shortest path to it visits a pivot
+      const pivotOracles = new Map(
+        [...result.pivots].map((p) => [
+          p,
+          dijkstra(bmssp.graph, bmssp.nodeIDs, p),
+        ]),
+      );
+      for (const [v, d] of oracle) {
+        if (d >= B) continue;
+        const completeInW = result.W.has(v) && bmssp.shortestPaths.get(v) === d;
+        const throughPivot = [...pivotOracles].some(
+          ([p, fromP]) => oracle.get(p) + fromP.get(v) === d,
+        );
+        expect(completeInW || throughPivot).toBe(true);
+      }
+    }
+  });
+});


### PR DESCRIPTION
Closes #44

## Summary

Implements **Algorithm 1 — FindPivots(B, S)** from the paper, the frontier-shrink step of the BMSSP recursion, as `src/findPivots.mjs` mirroring the shape of `baseCase` (#40):

- `findPivots(B, S, dHat, adjacency, k) → { pivots, W }`, relaxing the shared `d̂` **in place** with the paper's `≤` test; `< B` gates membership in `W` only (the `d̂` write is unconditional, per the Algorithm 1 pseudocode).
- `k` rounds of Bellman-Ford out of `S`, with the **early exit** returning `pivots = S` as soon as `|W| > k·|S|`.
- Otherwise builds the **tight-edge forest** (`d̂[v] === d̂[u] + w(u,v)`, both endpoints in `W`) with a **deterministic one-parent rule** (first tight edge in W-iteration order) so tree sizes stay well-defined when equal-length paths make the forest a DAG (tie caveat, #163). Pivots = `S`-roots of trees with `≥ k` vertices; `|pivots| ≤ |W|/k` holds on both branches.
- Degenerate-tie behavior documented + tested: vertices on a tight (zero-weight) cycle all receive parents, so none roots a tree and none can be a pivot.
- Internal module — deliberately **not** re-exported from `index.mjs`.

With this, all three legs of #43 (baseCase #40, BlockList #42, findPivots #44) are in place; **#43 (main recursion) is the last 1.0.0 issue**.

## Tests / lint

- 12 new tests in `test/findPivots.test.mjs`: validation, both branches (incl. multi-source early exit), `< B` gating, zero-weight-cycle termination, DAG-of-tight-edges determinism, and two seeded Dijkstra-oracle stress tests (k = n completes the reachable set exactly; bounded runs keep the frontier-shrink contract — every `d(v) < B` vertex is complete-in-W or optimally reachable through a pivot; `|P|·k ≤ |W|`; `d̂` never underestimates).
- Full suite: **71/71 passing** (`npm test`); `npm run lint` clean.

## Version / docs (Phase C sync, in this PR)

- `npm version minor` → **0.19.0** (tag + release after merge, gated on confirmation).
- `05-codebase-map.md` rewritten for the post-merge tree (`PENDING-PR-BRANCH: feat/44-find-pivots`); `06` reconciled (#44 done-pending-merge, #43 next & last); `07` extended (findPivots, early exit, one-parent rule); `README.md` status table updated.

## Roadmap proposals

1. **Edit #43:** append the shipped FindPivots API to its wiring contract — `findPivots(B, S, dHat, adjacency, k) → { pivots, W }` — so all three legs of #43 have concrete signatures in the issue body.
2. **Edit #163:** add the third tie manifestation found here — vertices on a tight (zero-weight) cycle all receive parents under the one-parent rule, so none can be a pivot; revisit when Assumption 2.1 tie-breaking is formalized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)