### PR TITLE
feat(#43): BMSSP(l, B, S) main recursion (Algorithm 3) — 1.0.0

### DIFF
--- a/.claude/knowledge/05-codebase-map.md
+++ b/.claude/knowledge/05-codebase-map.md
@@ -1,11 +1,11 @@
 # 05 — Codebase Map (current state)
 
-<!-- BOOKMARK-COMMIT: 79b58f2636a05c88d5937966710d3d0a3f3b781d -->
-<!-- PENDING-PR-BRANCH: feat/44-find-pivots -->
-<!-- Last validated: 2026-07-16, rewritten in Phase C of the #44 PR (feat/44-find-pivots).
-     Describes the tree as it will exist once that PR merges. Version 0.19.0 (bumped in the
-     PR; tag + release pending the merge). #44 (FindPivots) done in this PR; the only
-     remaining 1.0.0 issue is #43 (main recursion). -->
+<!-- BOOKMARK-COMMIT: bccc78d56a6433050238b7f54f8871e37a5cd79b -->
+<!-- PENDING-PR-BRANCH: (none) -->
+<!-- Last validated: 2026-07-16, Phase E after PR #180 (feat/44-find-pivots) merged as
+     bccc78d. Version 0.19.0 (tagged + released; publish.yml fired). #44 (FindPivots)
+     closed; the only remaining 1.0.0 issue is #43 (main recursion). Commits after the
+     bookmark touch only .claude/knowledge (Phase E bookkeeping). -->
 
 Snapshot of what exists in `bmssp-js` today, so you know what to build on vs. what's missing.
 

--- a/.claude/knowledge/05-codebase-map.md
+++ b/.claude/knowledge/05-codebase-map.md
@@ -1,11 +1,14 @@
 # 05 — Codebase Map (current state)
 
 <!-- BOOKMARK-COMMIT: bccc78d56a6433050238b7f54f8871e37a5cd79b -->
-<!-- PENDING-PR-BRANCH: (none) -->
-<!-- Last validated: 2026-07-16, Phase E after PR #180 (feat/44-find-pivots) merged as
-     bccc78d. Version 0.19.0 (tagged + released; publish.yml fired). #44 (FindPivots)
-     closed; the only remaining 1.0.0 issue is #43 (main recursion). Commits after the
-     bookmark touch only .claude/knowledge (Phase E bookkeeping). -->
+<!-- PENDING-PR-BRANCH: feat/43-bmssp-main -->
+<!-- Last validated: 2026-07-16, Phase C of the #43 PR (feat/43-bmssp-main). Describes the
+     tree as it will exist once that PR merges: the main BMSSP recursion (Algorithm 3) is
+     implemented and calculateShortestPaths no longer delegates to Dijkstra. Version bumped
+     to 1.0.0 (major — the PR closes the last 1.0.0-milestone issue). Note: the branch also
+     carries main's un-pushable Phase E bookkeeping commit 56a19fb (docs-only) — origin/main
+     now has branch-protection rules (PRs only, verified signatures, CodeQL), so it rides in
+     this PR instead of being pushed directly. -->
 
 Snapshot of what exists in `bmssp-js` today, so you know what to build on vs. what's missing.
 
@@ -55,21 +58,22 @@ feature branch name. Step 2 above then fast-paths the post-merge session start.
 ```
 index.mjs                 # re-exports { BMSSP } and { dijkstra }
 src/
-  bmssp.mjs               # BMSSP class — scaffolding + #45 adjacency map (no real algorithm yet)
+  bmssp.mjs               # BMSSP class — full Algorithm 3 recursion (#43); wires the pieces below
   dijkstra.mjs            # reference Dijkstra (array binary-heap) — DONE, used as oracle
-  blockList.mjs           # NEW (#42, PR #175): Lemma 3.3 block-based partial-sort structure D
-  heap.mjs                # NEW (#41): indexed binary min-heap (MinHeap) for BaseCase (Alg 2)
-  baseCase.mjs            # NEW (#40): BaseCase(B, S) — Algorithm 2 bounded mini-Dijkstra
-  findPivots.mjs          # NEW (#44): FindPivots(B, S) — Algorithm 1 frontier shrink
+  blockList.mjs           # #42: Lemma 3.3 block-based partial-sort structure D
+  heap.mjs                # #41: indexed binary min-heap (MinHeap) for BaseCase (Alg 2)
+  baseCase.mjs            # #40: BaseCase(B, S) — Algorithm 2 bounded mini-Dijkstra
+  findPivots.mjs          # #44: FindPivots(B, S) — Algorithm 1 frontier shrink
 test/
-  main.test.mjs           # Jest tests: constructor, nodeIDs, adjacency map, shortestPaths, BMSSP-vs-Dijkstra
-  blockList.test.mjs      # NEW (#42): 18 BlockList tests incl. a seeded random stress test
-  heap.test.mjs           # NEW (#41): 16 MinHeap tests incl. a seeded stress test vs. a naive queue
-  baseCase.test.mjs       # NEW (#40): 13 BaseCase tests incl. seeded oracle-comparison stress
-  findPivots.test.mjs     # NEW (#44): 12 FindPivots tests incl. two seeded oracle stress tests
+  main.test.mjs           # Jest tests: constructor, nodeIDs, adjacency, shortestPaths, BMSSP-vs-Dijkstra (roadNet-CA)
+  bmssp.test.mjs          # NEW (#43): 15 recursion tests — params, hand graphs, ties, Lemma 3.1 contract, seeded stress
+  blockList.test.mjs      # #42: 18 BlockList tests incl. a seeded random stress test
+  heap.test.mjs           # #41: 16 MinHeap tests incl. a seeded stress test vs. a naive queue
+  baseCase.test.mjs       # #40: 13 BaseCase tests incl. seeded oracle-comparison stress
+  findPivots.test.mjs     # #44: 12 FindPivots tests incl. two seeded oracle stress tests
   roadNet-CA.txt          # real road-network edge list (SNAP roadNet-CA), weights randomized at load
   README.md
-benchmarks/               # NEW (#45 PR): dependency-free benchmark harness, `npm run bench`
+benchmarks/               # dependency-free benchmark harness, `npm run bench`
   generators.mjs          #   seeded graph builders + SCENARIOS registry (sparse/dense/grid/chain/star)
   bench-util.mjs          #   timing (timeMany) + markdown-table helpers
   adjacency.bench.mjs     #   adjacency map (#45) vs. linear edge scan
@@ -84,10 +88,13 @@ docs/index.html           # published docs page
 
 Tooling: Jest (`npm test`, needs `--experimental-vm-modules`, already in the `test` script),
 ESLint + Prettier (`npm run lint` / `npm run format`), Dockerfile, GitHub Actions (dependabot
-bumps dominate recent history). `eslint.config.js` now **ignores `.claude/**`** so the agent
+bumps dominate recent history). `eslint.config.js` **ignores `.claude/**`** so the agent
 knowledge base (markdown with pseudocode fences) isn't linted as shippable code.
+**`main` now has branch-protection rules**: changes land through PRs only, commits must have
+verified signatures (squash-merge via the GitHub UI signs for you), and CodeQL must pass —
+direct `git push origin main` is rejected, including for docs-only bookkeeping commits.
 
-## `src/bmssp.mjs` — what the class does now
+## `src/bmssp.mjs` — the BMSSP class (Algorithm 3 wired in, #43)
 
 ```js
 class BMSSP {
@@ -96,27 +103,46 @@ class BMSSP {
   //   this.nodeIDs        : Set of all node IDs (from both endpoints)
   //   this.shortestPaths  : Map<nodeId, distance>, initialized to Infinity  ← this is d̂[·]
   //   this.adjacency      : Map<nodeId, Array<[to, weight]>>  ← #45, built in constructor
+  //   this.k, this.t, this.topLevel : paper parameters, derived in the constructor
   initializeShortestPaths()        // (re)set every nodeId's distance to Infinity
-  buildAdjacency()                 // #45: (re)build adjacency from this.graph; every node gets an entry ([] for sinks)
-  getEdges(nodeId)                 // #45: O(1) outgoing-edge lookup; returns [] for unknown nodes
-  calculateShortestPaths(startNode)// validates startNode, then DELEGATES TO dijkstra()
+  buildAdjacency()                 // #45: (re)build adjacency from this.graph
+  getEdges(nodeId)                 // #45: O(1) outgoing-edge lookup; [] for unknown nodes
+  deriveParameters()               // #43: k = max(1,⌊(log₂n)^⅓⌋), t = max(1,⌊(log₂n)^⅔⌋),
+                                   //      topLevel = max(1,⌈log₂n / t⌉) — from this.nodeIDs.size
+  bmssp(l, B, S)                   // #43: Algorithm 3 → { bound, vertices } (the paper's B', U)
+  calculateShortestPaths(startNode)// #43: validates, sets d̂[start] = 0, runs
+                                   //      bmssp(topLevel, Infinity, {startNode}) — NO Dijkstra
 }
 ```
 
-**#45 (DONE, in PR #160):** the constructor now builds `this.adjacency`, a
-`Map<nodeId, [to, weight][]>`, so fetching a node's outgoing edges is O(1) instead of an O(m)
-scan of the edge array. `buildAdjacency()` gives **every** known node an entry (empty array
-for sinks), so callers can rely on `.get(node)` / `getEdges(node)` returning an array. This is
-the inner-loop primitive every BMSSP stage (BaseCase #40, FindPivots #44, main recursion #43)
-needs to relax edges out of frontier nodes.
+**`bmssp(l, B, S)` (#43):** level 0 delegates to `baseCase`. At level ≥ 1: `findPivots`
+shrinks the frontier; pivots seed a `BlockList(M = 2^((l-1)·t), B)`; the loop pulls
+`Bi, Si ← D.pull()`, recurses `bmssp(l-1, Bi, Si)`, relaxes edges out of the returned `Ui`
+(band `[Bi, B)` → `D.insert`, band `[Bi', Bi)` → staged `K` → `D.batchPrepend` together with
+the uncompleted `Si` members), and stops when `D` empties (success, `bound === B`) or
+`|U| ≥ k·2^(l·t)` trips (partial, `bound < B`). Finally folds in the `W` vertices below the
+returned bound. Since `k·2^(topLevel·t) ≥ n`, the top call is always a successful execution.
 
-**Still a placeholder:** `calculateShortestPaths` currently just calls the reference
-`dijkstra()` and copies the result into `shortestPaths`. The real BMSSP algorithm (base case →
-FindPivots → block list → main recursion) has **not** been written yet — that's issues
-#40–#44. The eventual BMSSP entry point should reproduce Dijkstra's answers via the paper's
-method, not by calling Dijkstra.
+**Degenerate-tie guards (Assumption 2.1 violations — context in #163).** Three deliberate
+deviations from the paper's literal text, each needed only when equal path lengths (e.g.
+zero-weight edges) occur; all are covered by tests in `test/bmssp.test.mjs`:
+1. **Completed-vertex guard:** a vertex already in this call's `U` is never re-queued by an
+   equal-sum relaxation (mirrors `baseCase`'s settled guard; prevents ping-pong loops).
+2. **Out-of-scope pivot gate:** a pull can return a key tied with its separator, so a pivot
+   can arrive with `d̂ ≥ B`; it is skipped when seeding `D` (`BlockList.insert` requires
+   `value < B`) — the ancestor whose band covers it is responsible for it.
+3. **Stall escape hatch:** if a child returns zero vertices (only possible when everything
+   it settled tied exactly at its boundary), the batch would be re-pulled forever; instead
+   each batch member is settled with an uncapped `baseCase` run bounded by `Bi` — correct,
+   just not sublinear. Boundary-tied `Si` members (`d̂ == Bi < B`) re-enter `D` via a regular
+   insert rather than being dropped.
 
-## `src/blockList.mjs` — Lemma 3.3 structure `D` (#42, DONE in PR #175)
+**Performance (measured 2026-07-16, Apple Silicon, node 24):** full roadNet-CA
+(n = 1,965,206, m = 5,533,214): construct ~1.9 s, Dijkstra ~3.8 s, BMSSP ~7.8 s (≈2.1×
+Dijkstra), 0 mismatches. The two roadNet tests in `main.test.mjs` carry explicit 120 s Jest
+timeouts (the default 5 s is not enough for a real BMSSP run under CI).
+
+## `src/blockList.mjs` — Lemma 3.3 structure `D` (#42)
 
 ```js
 class BlockList {
@@ -136,7 +162,9 @@ Implementation notes (matches §03-B including its documented shortcuts):
 - Overfull `d1` block splits around the median via sort (O(M log M), not linear-time selection).
 - Big `batchPrepend` batches are sorted and chunked into blocks of ≤ ⌈M/2⌉, prepended to `d0`.
 - Last `d1` block (bound `B`) is kept even when empty so every `insert` finds a home.
-- API surface for Algorithm 3: `Bi, Si ← D.Pull()` maps to `const { keys, bound } = d.pull()`.
+- **Tie caveat (seen in #43):** with equal values across a pull boundary, `pull()`'s bound can
+  equal a pulled key's value (the paper's `max(S') < x` is strict only under Assumption 2.1).
+  Callers must tolerate batch members with `d̂ == Bi` — `bmssp()` does (guards above).
 
 ## `src/heap.mjs` — indexed binary min-heap (#41)
 
@@ -157,8 +185,6 @@ export { MinHeap };        // NOT re-exported from index.mjs — internal to the
 The **true indexed heap** from §03-A (entries array + `position` Map for O(log n)
 `decreaseKey`), matching Algorithm 2 literally — deliberately not the lazy duplicate-and-skip
 variant `src/dijkstra.mjs` uses internally. An extracted key may be re-inserted later.
-16 tests in `test/heap.test.mjs` (contracts, ordering, decreaseKey, the BaseCase
-insert-or-decrease relaxation pattern, seeded stress vs. a naive linear-scan queue).
 
 ## `src/baseCase.mjs` — `BaseCase(B, S)`, Algorithm 2 (#40)
 
@@ -175,10 +201,9 @@ export { baseCase };     // NOT re-exported from index.mjs — internal to the a
 Bounded mini-Dijkstra from `x` on the `MinHeap`, stopping after settling `k+1` vertices.
 Full success (heap exhausted at ≤ k settled) → `{ bound: B, vertices: U0 }`; partial (cap
 hit) → `bound` = max settled `d̂`, `vertices` = the strictly-closer ones. Relaxation uses
-the paper's `≤` + `< B` test, with one guard: a vertex already settled **in this call** is
-never re-inserted into the heap (an equal-sum relaxation — e.g. a zero-weight cycle — would
-otherwise loop forever; with non-negative weights a settled vertex cannot strictly improve,
-so nothing is lost). Callers wire it as `Bi', Ui ← BaseCase(Bi, Si)` at level 0 of #43.
+the paper's `≤` + `< B` test, with the settled-vertex guard against equal-sum re-insertion.
+`bmssp()` calls it at level 0, and also re-uses it (with `k = n`, uncapped) as the
+degenerate-tie stall escape hatch.
 
 ## `src/findPivots.mjs` — `FindPivots(B, S)`, Algorithm 1 (#44)
 
@@ -193,72 +218,59 @@ export { findPivots };   // NOT re-exported from index.mjs — internal to the a
 ```
 
 `k` rounds of Bellman-Ford relaxation out of `S` (paper's `≤` test; `< B` gates only the
-membership in `W`, the d̂ write itself is unconditional). **Early exit:** as soon as
-`|W| > k·|S|`, returns `pivots = S` (copy) with the partial `W`. Otherwise builds the
-tight-edge forest `F` inside `W` — each vertex takes **at most one parent**, chosen
-deterministically in W-iteration order (ties/DAG caveat, see #163) — and returns as pivots
-the `S`-roots of trees with `≥ k` vertices. Vertices on tight cycles (zero-weight cycles)
-all receive parents, so they root no tree and can't be pivots (degenerate-tie behavior,
-documented in the tests). Guarantees `|pivots| ≤ |W|/k`. Callers wire it as
-`P, W ← FindPivots(B, S)` at the top of #43.
+membership in `W`). **Early exit:** as soon as `|W| > k·|S|`, returns `pivots = S` (copy)
+with the partial `W`. Otherwise builds the tight-edge forest `F` inside `W` — each vertex
+takes **at most one parent** (ties/DAG caveat, see #163) — and returns as pivots the
+`S`-roots of trees with `≥ k` vertices. Guarantees `|pivots| ≤ |W|/k`. Note: a source with
+`d̂ ≥ B` can be returned as a pivot (early exit copies all of `S`); `bmssp()` filters those
+out when seeding `D`.
 
 ## `src/dijkstra.mjs` — the oracle (already done)
 
 `dijkstra(graph, nodeIDs, source) → Map<nodeId, distance>`. Standard array binary min-heap
 with lazy stale-entry skipping (no `DecreaseKey`). Builds its own adjacency list from the edge
 array (independent of the class's `this.adjacency`). This is the **ground truth** the BMSSP
-implementation is tested against. Reuse its heap style / adjacency-list building.
+implementation is tested against — and, since #43, no longer part of the BMSSP code path.
 
-## Tests (`test/main.test.mjs`) — the contract
+## Tests — the contract
 
-- Constructor stores `graph` verbatim; `nodeIDs` = unique endpoints; `shortestPaths` all ∞.
-- **Adjacency map (#45):** edges grouped by source; sinks get `[]`; one entry per unique node;
-  total edge count preserved across all lists; `getEdges` returns a node's edges and `[]` for
-  unknown nodes.
-- `calculateShortestPaths(start)` sets `d̂[start] = 0` and throws on an unknown start node.
-- `dijkstra` throws on a source not in `nodeIDs`.
-- **Key one:** "BMSSP vs Dijkstra" — for a fixed source, `myBMSSP.shortestPaths` must equal
-  `dijkstra(...)` for every node. **Any real BMSSP implementation must keep this passing.**
-- Current suite: **12 tests in `main.test.mjs` + 18 in `blockList.test.mjs` + 16 in
-  `heap.test.mjs` + 13 in `baseCase.test.mjs` + 12 in `findPivots.test.mjs`, all
-  passing (71).**
-- **BaseCase (#40):** validation (k, singleton S, complete source), full-success vs. finite/
-  infinite B, partial k+1-cap boundary reporting (incl. ties excluded by the strict filter),
-  zero-weight-cycle termination, and two seeded stress tests checking the Algorithm 2
-  contract against the Dijkstra oracle (exact distances, completeness below B', d̂ never
-  underestimates).
-- **FindPivots (#44):** validation (k, non-empty S, complete sources), both branches (early
-  exit incl. multi-source, forest roots with the `≥ k` size filter), `< B` gating W but not
-  d̂ writes, zero-weight tight-cycle termination, DAG-of-tight-edges determinism, and two
-  seeded oracle stress tests (k = n completes the reachable set exactly; bounded runs keep
-  the frontier-shrink contract: every `d(v) < B` vertex is complete-in-W or reachable
-  optimally through a pivot, `|P|·k ≤ |W|`, d̂ never underestimates).
-- **BlockList (#42):** init validation, `value < B` enforcement, drain-pull returns bound `B`,
-  batch-sorted pulls of the M smallest, separator invariant, smallest-value-wins dedupe
-  (insert and batchPrepend, vs. stored and within-batch), split correctness, re-insert after
-  pull, chunked large prepends, and a seeded random stress test checking global sorted order.
+- `test/main.test.mjs` (12): constructor/nodeIDs/adjacency/shortestPaths contracts, plus the
+  **key one** — "BMSSP vs Dijkstra" on roadNet-CA: for a fixed source, `myBMSSP.shortestPaths`
+  must equal `dijkstra(...)` for every node. **Now exercises the real algorithm** (120 s
+  timeouts on the two tests that run it on the road network).
+- `test/bmssp.test.mjs` (15, NEW in #43): parameter derivation (clamps, paper formulas,
+  `k·2^(topLevel·t) ≥ n` guard), end-to-end hand-built graphs (README example, multi-hop vs
+  direct, unreachable ⇒ Infinity, self-loop, source switch), degenerate ties (zero-weight
+  cycles/clusters, layered equal-length paths, seeded 0–2-weight stress), the Lemma 3.1
+  recursion contract (bounded call: complete-below-boundary, exact membership, d̂ never
+  underestimates; unbounded call: successful execution returning exactly the reachable set),
+  and seeded full-map-vs-oracle stress across sizes (up to n = 2000).
+- `test/blockList.test.mjs` (18), `test/heap.test.mjs` (16), `test/baseCase.test.mjs` (13),
+  `test/findPivots.test.mjs` (12): per-module contracts incl. seeded stress — see the
+  module sections above.
+- Current suite: **86 tests, all passing**, 100% statement coverage.
 
 Graph data: `roadNet-CA.txt` is a large real directed road network; edge weights are assigned
 a random integer in `[1, 1e8]` at load time (so weights differ per run, but BMSSP and Dijkstra
 see the same array within a run).
 
-## Benchmarks (`benchmarks/`, `npm run bench`) — NEW
+## Benchmarks (`benchmarks/`, `npm run bench`)
 
 Deterministic (seeded) micro-benchmarks. `adjacency.bench.mjs` shows the #45 map is
-~thousands× faster per-node than a linear scan (gap scales with `m`). `scenarios.bench.mjs`
-times construction + a Dijkstra run across five graph shapes (sparse-random, dense-random,
-grid, chain, star) — the harness that will become the BMSSP-vs-Dijkstra head-to-head once #43
-lands. `benchmarks/README.md` holds the "when to use which" guidance.
+~thousands× faster per-node than a linear scan. `scenarios.bench.mjs` times construction +
+a Dijkstra run across five graph shapes. **#43 unblocks #170** (the BMSSP-vs-Dijkstra
+head-to-head column); first ad-hoc measurement above (~2.1× Dijkstra on roadNet-CA).
 
 ## Gaps to fill (the actual work)
 
-| Missing piece | Lives where (suggested) | Issue | Status |
+| Missing piece | Lives where | Issue | Status |
 |---|---|---|---|
 | Per-node edge adjacency map | `BMSSP` constructor | #45 | ✅ done (PR #160) |
 | Lemma 3.3 block-list `D` | `src/blockList.mjs` | #42 | ✅ done (PR #175) |
 | Binary min-heap module | `src/heap.mjs` | #41 | ✅ done (PR #177) |
 | Base case (bounded Dijkstra) | `src/baseCase.mjs` | #40 | ✅ done (PR #178) |
-| FindPivots | `src/findPivots.mjs` | #44 | ✅ done (this PR) |
-| Main `BMSSP(l, B, S)` recursion + `k,t` derivation | `src/bmssp.mjs` | #43 | ⬜ open — **the last 1.0.0 piece** |
+| FindPivots | `src/findPivots.mjs` | #44 | ✅ done (PR #180) |
+| Main `BMSSP(l, B, S)` recursion + `k,t` derivation | `src/bmssp.mjs` | #43 | ✅ done (this PR) — **1.0.0 milestone complete** |
 
-See [06-milestones-roadmap.md](06-milestones-roadmap.md) for the recommended order and test strategy.
+**The 1.0.0 milestone is done once this PR merges.** Next work comes from milestone `1.1.0`
+(correctness hardening) — see [06-milestones-roadmap.md](06-milestones-roadmap.md).

--- a/.claude/knowledge/06-milestones-roadmap.md
+++ b/.claude/knowledge/06-milestones-roadmap.md
@@ -1,7 +1,7 @@
 # 06 — Milestones Roadmap
 
-<!-- SYNCED-FROM-GITHUB: 2026-07-16 (Phase C of the #44 PR, feat/44-find-pivots) -->
-<!-- Current package version: 0.19.0 (bumped in the #44 PR; tag + release pending merge) -->
+<!-- SYNCED-FROM-GITHUB: 2026-07-16 (Phase E after PR #180 merged; #44 closed, 0.19.0 released) -->
+<!-- Current package version: 0.19.0 (tagged + released) -->
 
 Maps GitHub **milestones** and **issues** (Sirivasv/bmssp-js) to the paper's building blocks,
 with a dependency-aware build order. This is the "intent" side of the knowledge base (what to
@@ -37,31 +37,24 @@ it runs the same Phase C reconciliation directly on `main`.
 
 ## 📋 Roadmap proposals (pending user approval)
 
-Written in Phase C of the #44 PR (2026-07-16); execute in Phase E, one confirmation each.
-
-1. **Edit #43 (main BMSSP recursion):** append the shipped FindPivots API to its wiring
-   contract — `findPivots(B, S, dHat, adjacency, k) → { pivots, W }` (`P, W ← FindPivots(B, S)`
-   maps to `const { pivots, W } = findPivots(B, S, dHat, adjacency, k)`). All three legs of
-   #43 (baseCase, BlockList, findPivots) now have concrete signatures in the issue body.
-2. **Edit #163 (deterministic tie-breaking):** add the third tie manifestation, found while
-   implementing #44 — vertices on a **tight (zero-weight) cycle** all receive parents in the
-   one-parent forest, so none of them is a root and none can be a pivot; harmless for
-   termination but worth revisiting when Assumption 2.1 tie-breaking is formalized.
+_None right now. Phase C writes proposed GitHub edits here (and in the PR body); Phase E
+executes the approved ones — one confirmation each — and clears them from this list._
+_(The two #44-PR proposals — FindPivots API into #43, tight-cycle tie note into #163 —
+were approved and executed on GitHub in Phase E, 2026-07-16.)_
 
 ---
 
 ## Current state (as synced)
 
-- **Package version:** `0.19.0`, bumped in the in-flight #44 PR (pre-1.0; the algorithm is
-  not yet functional end-to-end). Tag + GitHub Release happen after the merge (Phase E).
-  Last published release: `0.18.0`.
+- **Package version:** `0.19.0` (pre-1.0; the algorithm is not yet functional end-to-end).
+  The `0.19.0` tag + GitHub Release are published (npm + Docker Hub CD fired).
 - **Active milestone:** **`1.0.0` — "Have a first functional version of the whole algorithm."**
-  - GitHub progress once the #44 PR merges: **10 closed / 1 open**.
+  - GitHub progress: **10 closed / 1 open** (PR #180 merged, so #44 now counts closed).
   - The one open issue, **#43 (main recursion), is the last 1.0.0 piece**.
-- **In flight:** **#44 — FindPivots(B, S), Algorithm 1 — done in the `feat/44-find-pivots`
-  PR** (this branch). See `05-codebase-map.md` for the shipped `src/findPivots.mjs` API.
-  **#43 is next and last** — its issue body carries the wiring contract; all three legs
-  (baseCase #40, BlockList #42, findPivots #44) are now on `main` or in this PR.
+- **Just merged:** **#44 — FindPivots(B, S), Algorithm 1 — PR #180 is now on `main`**
+  (commit `bccc78d`). See `05-codebase-map.md` for the shipped `src/findPivots.mjs` API.
+  **#43 is next and last** — its issue body carries the full wiring contract (baseCase #40,
+  BlockList #42, findPivots #44 signatures all appended on GitHub, Phase E 2026-07-16).
 
 ## Milestone `1.0.0` — issues → paper
 

--- a/.claude/knowledge/06-milestones-roadmap.md
+++ b/.claude/knowledge/06-milestones-roadmap.md
@@ -1,7 +1,7 @@
 # 06 — Milestones Roadmap
 
-<!-- SYNCED-FROM-GITHUB: 2026-07-16 (Phase E after PR #180 merged; #44 closed, 0.19.0 released) -->
-<!-- Current package version: 0.19.0 (tagged + released) -->
+<!-- SYNCED-FROM-GITHUB: 2026-07-16 (Phase C of the #43 PR, feat/43-bmssp-main) -->
+<!-- Current package version: 1.0.0 (bumped in the #43 PR; NOT tagged/released yet) -->
 
 Maps GitHub **milestones** and **issues** (Sirivasv/bmssp-js) to the paper's building blocks,
 with a dependency-aware build order. This is the "intent" side of the knowledge base (what to
@@ -37,100 +37,88 @@ it runs the same Phase C reconciliation directly on `main`.
 
 ## 📋 Roadmap proposals (pending user approval)
 
-_None right now. Phase C writes proposed GitHub edits here (and in the PR body); Phase E
-executes the approved ones — one confirmation each — and clears them from this list._
-_(The two #44-PR proposals — FindPivots API into #43, tight-cycle tie note into #163 —
-were approved and executed on GitHub in Phase E, 2026-07-16.)_
+_Written in Phase C of the #43 PR (2026-07-16). Phase E executes the approved ones — one
+confirmation each — and clears them from this list._
+
+1. **Close milestone `1.0.0` (milestone #1)** once this PR merges and #43 auto-closes —
+   all 11 of its issues will then be closed. (`gh api -X PATCH` on the milestone,
+   `state: closed`.)
+2. **Append the #43 tie findings to #163** (deterministic tie-breaking): implementing the
+   main recursion surfaced three concrete Assumption 2.1 violations, each now handled by a
+   documented guard in `bmssp()`: (a) `BlockList.pull()` can return a key tied with its
+   separator, so a frontier member can arrive at a level with `d̂ == B` — out-of-scope
+   pivots are filtered at seeding; (b) batch members with `d̂ == Bi < B` must be re-queued
+   via a regular insert or they are silently dropped; (c) a child call can return zero
+   vertices when everything it settled tied at its boundary — without an escape hatch the
+   batch is re-pulled forever. A principled tie-break (Assumption 2.1 in code) would make
+   all three guards unnecessary; until then they define the behavior tests rely on
+   (`test/bmssp.test.mjs`, "degenerate ties" describe block).
+3. **Update #170** (BMSSP-vs-Dijkstra benchmark): now unblocked by #43. Record the first
+   ad-hoc baseline — full roadNet-CA (n ≈ 1.97 M, m ≈ 5.5 M): BMSSP ≈ 7.8 s vs
+   Dijkstra ≈ 3.8 s (≈ 2.1×, Apple Silicon, node 24) — and scope the issue to adding the
+   BMSSP column to `benchmarks/scenarios.bench.mjs` + a fresh `RESULTS.md` capture.
+4. **Re-scope #161** (property/fuzz tests): `test/bmssp.test.mjs` already ships seeded
+   random-graph stress (full-map oracle equality across sizes, tiny-weight tie stress,
+   bounded-call Lemma 3.1 contract checks). #161's remaining value: much higher volume, more
+   graph shapes (grids, DAGs, stars, disconnected forests), extreme weight regimes (0, huge,
+   mixed magnitudes), and multi-source `bmssp()` calls — as a dedicated slow/fuzz suite.
+5. **Note on #162** (disconnected/unreachable edge cases): partially covered by #43's tests
+   (unreachable ⇒ Infinity). Keep the issue for systematic coverage (multiple components,
+   source in a small component, empty-adjacency corner cases), pointing at the existing test
+   as the pattern.
 
 ---
 
 ## Current state (as synced)
 
-- **Package version:** `0.19.0` (pre-1.0; the algorithm is not yet functional end-to-end).
-  The `0.19.0` tag + GitHub Release are published (npm + Docker Hub CD fired).
-- **Active milestone:** **`1.0.0` — "Have a first functional version of the whole algorithm."**
-  - GitHub progress: **10 closed / 1 open** (PR #180 merged, so #44 now counts closed).
-  - The one open issue, **#43 (main recursion), is the last 1.0.0 piece**.
-- **Just merged:** **#44 — FindPivots(B, S), Algorithm 1 — PR #180 is now on `main`**
-  (commit `bccc78d`). See `05-codebase-map.md` for the shipped `src/findPivots.mjs` API.
-  **#43 is next and last** — its issue body carries the full wiring contract (baseCase #40,
-  BlockList #42, findPivots #44 signatures all appended on GitHub, Phase E 2026-07-16).
+- **Package version:** `1.0.0` in `package.json` on the PR branch — the **major** bump for
+  closing the `1.0.0` milestone. Tag + GitHub Release happen in Phase E after the user
+  confirms the merge (gate 3). Last released version: `0.19.0`.
+- **Milestone `1.0.0`:** **complete pending this PR's merge** — #43 was the last open issue.
+- **Just built:** **#43 — `BMSSP(l, B, S)` main recursion (Algorithm 3), this PR.**
+  `calculateShortestPaths` now runs the paper's method end-to-end (no Dijkstra delegation);
+  the "BMSSP vs Dijkstra" test passes on the full road network. See `05-codebase-map.md`
+  for the shipped API and the degenerate-tie guards.
+- **Next milestone:** **`1.1.0` — correctness hardening** (6 open issues). Recommended next
+  issue: **#161** (fuzz suite — cheapest way to protect everything else), then #162, #163.
 
-## Milestone `1.0.0` — issues → paper
+## Milestone `1.0.0` — issues → paper (all done pending merge)
 
-| # | Title | What it is (paper) | Labels | Depends on | Status |
-|---|---|---|---|---|---|
-| **45** | Add a map of arrays for edges of each node | Adjacency map so edge lookups aren't O(m). §05 | help wanted · good first issue | — | ✅ merged (PR #160) |
-| **41** | Implement a priority heap | Binary min-heap for the base case (Alg 2). §03-A | help wanted · good first issue | — | ✅ merged (PR #177) |
-| **40** | Implement the base case of the bmssp algorithm | `BaseCase(B, S)` bounded mini-Dijkstra. **Alg 2**, §02 | help wanted | #41 | ✅ merged (PR #178) |
-| **42** | Implement Lema 3.3 data structure | Block-based partial-sort list `D`. **Lemma 3.3**, §03-B | help wanted | — | ✅ merged (PR #175) |
-| **44** | Implement the findingPivots function | `FindPivots(B, S)` frontier shrink. **Alg 1**, §02 | help wanted | #45 (helpful) | ✅ done (this PR) |
-| **43** | Implement main bmssp algorithm | `BMSSP(l, B, S)` recursion + `k,t`. **Alg 3**, §02 | help wanted | #40, #42, #44 | ⬜ open — next & last |
+| # | Title | What it is (paper) | Depends on | Status |
+|---|---|---|---|---|
+| **45** | Add a map of arrays for edges of each node | Adjacency map. §05 | — | ✅ merged (PR #160) |
+| **41** | Implement a priority heap | Binary min-heap (Alg 2). §03-A | — | ✅ merged (PR #177) |
+| **40** | Implement the base case of the bmssp algorithm | `BaseCase(B, S)`. **Alg 2**, §02 | #41 | ✅ merged (PR #178) |
+| **42** | Implement Lema 3.3 data structure | Block-list `D`. **Lemma 3.3**, §03-B | — | ✅ merged (PR #175) |
+| **44** | Implement the findingPivots function | `FindPivots(B, S)`. **Alg 1**, §02 | #45 | ✅ merged (PR #180) |
+| **43** | Implement main bmssp algorithm | `BMSSP(l, B, S)` + `k,t`. **Alg 3**, §02 | #40, #42, #44 | ✅ done (**this PR**) |
 
 ### Closed (context)
-`#36` main `calculateShortestPaths` (currently delegates to Dijkstra — placeholder) ·
-`#35` Dijkstra oracle + BMSSP-vs-Dijkstra test · `#28` `shortestPaths` output map (∞ init) ·
-`#27` `nodeIDs` vertex index · `#24` datasets research (roadNet-CA).
+`#36` main `calculateShortestPaths` · `#35` Dijkstra oracle + BMSSP-vs-Dijkstra test ·
+`#28` `shortestPaths` output map (∞ init) · `#27` `nodeIDs` vertex index ·
+`#24` datasets research (roadNet-CA).
 
-## Recommended build order (within 1.0.0)
+### Definition of done for `1.0.0` — ✅ met by this PR
+- `calculateShortestPaths(source)` computes distances **via BMSSP** (not by calling
+  `dijkstra`), and the "BMSSP vs Dijkstra" test passes for every node. ✅
+- Each sub-piece (#40/#41/#42/#44/#45) shipped with focused unit tests. ✅
+- `npm run lint` clean; ESM + Prettier style preserved. ✅
 
-Leaves first; two independent tracks converge on the main recursion:
+## Milestone `1.1.0` (milestone #2) — correctness hardening — NEXT
 
-```
-Track A (base case):     #45 adjacency map ─┬─▶ #41 heap ─▶ #40 BaseCase ─┐   (all ✅ —
-Track B (recursion core):    (✅ done)       └─▶ #44 FindPivots (✅) ──────┼─▶ #43 BMSSP main
-                                                #42 BlockList (✅ done) ───┘    only #43 left)
-```
+Recommended order (cheapest protection first, then the deep work):
 
-1. ~~**#45** adjacency map~~ — ✅ **done (PR #160):** `this.adjacency: Map<nodeId, [to,w][]>`
-   + `getEdges()`, built in the constructor. Unblocks #40 and #44.
-2. ~~**#42** block-list `D`~~ — ✅ **done (PR #175):** `src/blockList.mjs` + 18 tests
-   (§03-B contracts incl. seeded stress). Bound index is a sorted array for now (#167).
-3. ~~**#41** binary min-heap~~ — ✅ **done (PR #177):** `src/heap.mjs` indexed `MinHeap`
-   (insert/extractMin/decreaseKey/has) + 16 tests; version 0.17.0 released. Unblocks #40.
-4. ~~**#40** BaseCase~~ — ✅ **done (PR #178):** `src/baseCase.mjs`
-   `baseCase(B, S, dHat, adjacency, k)` + 13 tests (incl. seeded oracle stress); version
-   0.18.0 released. The level-0 leg of #43 is ready.
-5. ~~**#44** FindPivots~~ — ✅ **done (this PR):** `src/findPivots.mjs`
-   `findPivots(B, S, dHat, adjacency, k) → { pivots, W }` + 12 tests (both branches, tie/DAG
-   determinism, two seeded oracle stress tests); version 0.19.0 bumped.
-6. **#43** BMSSP main — wires #40+#42+#44 with `k`/`t`; replaces the Dijkstra delegation in
-   `calculateShortestPaths`. **Definition of done:** BMSSP computes distances via the paper's
-   method and the "BMSSP vs Dijkstra" test still passes for every node.
+| Order | # | Issue | Labels | Notes after #43 |
+|---|---|---|---|---|
+| 1 | 161 | Property/fuzz tests: BMSSP vs Dijkstra on random graphs | enhancement · help wanted | Extend the seeded stress already in `test/bmssp.test.mjs` (see proposal 4) |
+| 2 | 162 | Edge-case tests: disconnected graphs and unreachable nodes | enhancement · help wanted | Partially covered by #43 tests (see proposal 5) |
+| 3 | 163 | Deterministic tie-breaking for equal-length paths (Assumption 2.1) | enhancement · help wanted | Three concrete manifestations found in #43 (see proposal 2) |
+| 4 | 165 | Input validation for the BMSSP constructor | good first issue · help wanted | — |
+| 5 | 164 | Optional constant-degree transform (in/out-degree ≤ 2) | enhancement · help wanted | — |
+| 6 | 166 | JSDoc / API docs for the new modules | documentation · good first issue | `bmssp()` / `deriveParameters()` ship with JSDoc already |
 
-### Parameter derivation (for #43)
-```js
-const n = this.nodeIDs.size;
-const logn = Math.log2(n);
-const k = Math.max(1, Math.floor(logn ** (1 / 3)));
-const t = Math.max(1, Math.floor(logn ** (2 / 3)));
-const topLevel = Math.ceil(logn / t);   // top call: BMSSP(topLevel, Infinity, new Set([source]))
-```
-Clamp `k`,`t` to `≥ 1` for tiny graphs; correctness must not depend on the asymptotic regime.
+## Milestone `1.2.0` (milestone #3) — performance & ergonomics
 
----
-
-## Forward-looking version plan (created on GitHub)
-
-> These milestones and their issues were created on GitHub during an `RKB` two-way sync
-> (after user confirmation). All four milestones now exist; keep this section reconciled with
-> GitHub going forward.
-
-### `1.0.0` (milestone #1) — first end-to-end functional BMSSP
-Issues #40–#45. #45 done (PR #160), #42 done (PR #175), #41 done (PR #177), #40 done
-(PR #178), #44 done (this PR); only #43 open. See the tables above.
-
-### `1.1.0` (milestone #2) — correctness hardening
-| # | Issue | Labels |
-|---|---|---|
-| 161 | Property/fuzz tests: BMSSP vs Dijkstra on random graphs | enhancement · help wanted |
-| 162 | Edge-case tests: disconnected graphs and unreachable nodes | enhancement · help wanted |
-| 163 | Deterministic tie-breaking for equal-length paths (Assumption 2.1) | enhancement · help wanted |
-| 164 | Optional constant-degree transform (in/out-degree ≤ 2) | enhancement · help wanted |
-| 165 | Input validation for the BMSSP constructor | good first issue · help wanted |
-| 166 | JSDoc / API docs for the new modules | documentation · good first issue |
-
-### `1.2.0` (milestone #3) — performance & ergonomics
 | # | Issue | Labels |
 |---|---|---|
 | 167 | Restore Lemma 3.3's exact asymptotics in BlockList (balanced-BST bound index + linear-time selection) | enhancement · help wanted |
@@ -138,29 +126,20 @@ Issues #40–#45. #45 done (PR #160), #42 done (PR #175), #41 done (PR #177), #4
 | 169 | Optional shortest-path reconstruction (`Pred[]` → paths) | enhancement · help wanted |
 | 170 | BMSSP-vs-Dijkstra benchmark comparison | enhancement · help wanted |
 
-_Note:_ the seeded **benchmark harness already landed early** with #45 (`benchmarks/`,
-`npm run bench`); #170 just adds the BMSSP column once #43 is done.
+_Note:_ the seeded **benchmark harness already exists** (`benchmarks/`, `npm run bench`);
+#170 is unblocked by #43 and has a first baseline (see proposal 3).
 
-_RKB 2026-07-16 (post #40) — issue bodies updated on GitHub:_ #44 rewritten as a full
-FindPivots spec (signature mirroring `baseCase`, early exit, tight-edge forest, tie caveat,
-test plan); #43 gained the concrete wiring contract (baseCase/BlockList APIs, `k`/`t`
-derivation, workload guard, definition of done); #163 gained the two tie manifestations
-found in #40 (settled-vertex guard vs zero-weight cycles; forest-DAG ambiguity in
-FindPivots); #169 noted that `Pred[]` must be wired into all three relaxation sites.
-Milestone slicing unchanged — 1.0.0 (#44 → #43 after #40 merges) still the right shape.
+## Milestone `2.0.0` (milestone #4) — API-breaking generalization
 
-_RKB 2026-07-15 (post #42/#41) — issue bodies updated on GitHub:_ #167 widened to both
-BlockList shortcuts (bound index **and** sort-based median selection); #168 widened with the
-indexed-vs-lazy **heap strategy** benchmark/consolidation; #166 re-scoped to the older doc
-surface (new modules ship with JSDoc already); #173 gained the explicit internal-vs-public
-exposure decision (BlockList/MinHeap are not re-exported from `index.mjs`).
-
-### `2.0.0` (milestone #4) — API-breaking generalization
 | # | Issue | Labels |
 |---|---|---|
 | 171 | Public multi-source / bounded BMSSP entrypoint | enhancement · help wanted |
 | 172 | Typed / flexible graph inputs | enhancement · help wanted |
 | 173 | Stabilize the public API surface for 1.0 → 2.0 | documentation · enhancement |
+
+_Note after #43:_ `bmssp(l, B, S)` already **is** a bounded multi-source call internally —
+#171 is mostly about designing the public API around it (initial per-source distances,
+returning `{ bound, vertices }` sensibly) rather than new algorithm work.
 
 ---
 
@@ -169,24 +148,21 @@ exposure decision (BlockList/MinHeap are not re-exported from `index.mjs`).
 Closing an issue bumps the package version and, after the PR merges, ships a release:
 
 1. **In the PR that closes the issue** — `npm version minor --no-git-tag-version` (keeps
-   `package.json` + `package-lock.json` in sync; historical cadence is a **minor** `0.N.0` bump
-   per issue). The `1.0.0` milestone close is the `major` bump to `1.0.0`.
-2. **After the user confirms the merge** — tag `main` with the bare version (no `v` prefix) and
-   `gh release create` it; publishing the release fires `publish.yml` → **npm + Docker Hub**.
+   `package.json` + `package-lock.json` in sync; historical cadence is a **minor** `0.N.0`
+   bump per issue). **This PR used `npm version major`** — the `1.0.0` milestone close is
+   the major bump, per convention.
+2. **After the user confirms the merge** — tag `main` with the bare version (no `v` prefix)
+   and `gh release create` it; publishing the release fires `publish.yml` → **npm + Docker
+   Hub**.
 
 Full procedure + exact commands live in **`../CLAUDE.md` → "Version bump & release"**. The
 release step is an outward-facing publish and is **gated on explicit user confirmation**.
 
-## Definition of done for `1.0.0`
-
-- `calculateShortestPaths(source)` computes distances **via BMSSP** (not by calling
-  `dijkstra`), and the "BMSSP vs Dijkstra" test in `test/main.test.mjs` passes for every node.
-- Each sub-piece (#40/#41/#42/#44/#45) ships with focused unit tests.
-- `npm run lint` clean; ESM + Prettier style preserved.
-
 ## Testing tips
 - Small hand-built graphs with known distances for unit tests; `roadNet-CA.txt` for the big
-  equivalence test.
-- Any `BMSSP(l, B, S)` call's completed vertices+distances must equal
-  `{ v : d_dijkstra(v) < B', shortest path visits S }`.
-- Break distance ties deterministically (Assumption 2.1, §01) so `Pred[]` stays a tree.
+  equivalence test (120 s Jest timeouts on the two tests that run BMSSP on it).
+- Any `bmssp(l, B, S)` call's completed vertices+distances must equal
+  `{ v : d_dijkstra(v) < B', shortest path visits S }` — `test/bmssp.test.mjs` has the
+  pattern ("recursion contract" describe block).
+- Ties (equal path lengths) are the #1 source of subtle bugs — see the degenerate-tie
+  guards in `05-codebase-map.md` and the notes headed for #163.

--- a/.claude/knowledge/07-glossary.md
+++ b/.claude/knowledge/07-glossary.md
@@ -1,6 +1,6 @@
 # 07 — Glossary
 
-<!-- Updated on: 2026-07-16 (terms last extended in the #44 PR: findPivots) -->
+<!-- Updated on: 2026-07-16 (terms last extended in the #43 PR: main bmssp recursion) -->
 
 > **Lifecycle: dynamic — updated in Phase C of every PR.** When a PR introduces new symbols
 > or terms (module names, data-structure fields, paper notation newly used in code), add
@@ -114,6 +114,32 @@ Quick lookup for the symbols and terms used across the paper, the notes, and the
   most one parent (the first tight edge in W-iteration order). Keeps tree sizes well-defined
   when equal-length paths make `F` a DAG (tie caveat, #163). Corollary: vertices on a tight
   (zero-weight) cycle all have parents, so none roots a tree and none can be a pivot.
+- **`bmssp(l, B, S)`** (#43) — method on the `BMSSP` class, Algorithm 3: the main bounded
+  multi-source recursion. Level 0 delegates to `baseCase`; level ≥ 1 wires `findPivots` →
+  `BlockList` → recursive `bmssp(l-1, Bi, Si)` calls with band-routed relaxation. Returns
+  `{ bound, vertices }` (= the paper's `B', U`). `calculateShortestPaths(start)` runs
+  `bmssp(topLevel, Infinity, {start})` after setting `d̂[start] = 0`.
+- **`deriveParameters()`** (#43) — class method (called by the constructor) that derives and
+  stores `this.k`, `this.t`, `this.topLevel` from `n = nodeIDs.size`, each clamped to ≥ 1:
+  `k = ⌊(log₂n)^(1/3)⌋`, `t = ⌊(log₂n)^(2/3)⌋`, `topLevel = ⌈log₂n / t⌉`. The clamp keeps
+  tiny graphs out of degenerate regimes; `k·2^(topLevel·t) ≥ n` makes the top call a
+  successful execution.
+- **Workload guard / cap** (#43) — Algorithm 3's `|U| < k·2^(l·t)` loop condition: trips on
+  partial executions (`bound < B`); can never trip below `n` at the top level.
+- **Completed-vertex guard** (#43) — `bmssp()` never re-queues a vertex already in the
+  current call's `U` on an equal-sum relaxation (the level-≥1 mirror of `baseCase`'s
+  settled-vertex guard; prevents zero-weight ping-pong loops).
+- **Out-of-scope pivot gate** (#43) — a pivot arriving with `d̂ ≥ B` (possible when a pull
+  returns a key tied with its separator) is skipped when seeding `D`; the ancestor whose
+  band covers its distance handles it. Tie caveat, #163.
+- **Stall escape hatch** (#43) — when a child `bmssp`/`baseCase` call returns zero vertices
+  (everything it settled tied exactly at its boundary — zero-weight paths, #163), each batch
+  member is settled with an uncapped `baseCase` run (`k = n`) bounded by `Bi` so the loop
+  always makes progress. Correct, just not sublinear; only reachable on Assumption 2.1
+  violations.
+- **Boundary-tied re-queue** (#43) — an `Si` member left at `d̂ == Bi < B` after the child
+  returns re-enters `D` via a regular `insert` (the paper's `[Bi', Bi)` band would silently
+  drop it). Tie caveat, #163.
 - **Benchmark harness** — `benchmarks/` (run via `npm run bench`): seeded graph
   **generators** + a `SCENARIOS` registry (sparse-random / dense-random / grid / chain /
   star), `timeMany` timing, and two benchmarks (adjacency-vs-scan, per-shape Dijkstra). Will

--- a/README.md
+++ b/README.md
@@ -15,9 +15,11 @@ first to beat Dijkstra's O(m + n·log n) bound on sparse directed graphs.
 
 ## Project status
 
-The project is built piece by piece against the paper, with every building block shipped,
-tested, and released individually. Current focus: milestone
-[`1.0.0` — first end-to-end functional BMSSP](https://github.com/Sirivasv/bmssp-js/milestones).
+**The algorithm is functional end-to-end as of `1.0.0`** 🎉 — `calculateShortestPaths()`
+computes distances via the paper's method (FindPivots → block list → recursive BMSSP with
+the bounded base case), validated node-by-node against a Dijkstra oracle, including on a
+real 2-million-node road network. The project was built piece by piece against the paper,
+with every building block shipped, tested, and released individually:
 
 | Building block (paper) | Where | Status |
 | --- | --- | --- |
@@ -27,12 +29,15 @@ tested, and released individually. Current focus: milestone
 | Indexed binary min-heap ([#41](https://github.com/Sirivasv/bmssp-js/issues/41)) | `src/heap.mjs` | ✅ done |
 | `BaseCase(B, S)` — Algorithm 2, bounded mini-Dijkstra ([#40](https://github.com/Sirivasv/bmssp-js/issues/40)) | `src/baseCase.mjs` | ✅ done |
 | `FindPivots(B, S)` — Algorithm 1, frontier shrinking ([#44](https://github.com/Sirivasv/bmssp-js/issues/44)) | `src/findPivots.mjs` | ✅ done |
-| `BMSSP(l, B, S)` — Algorithm 3, the main recursion ([#43](https://github.com/Sirivasv/bmssp-js/issues/43)) | — | 🔨 next up — the last piece |
+| `BMSSP(l, B, S)` — Algorithm 3, the main recursion ([#43](https://github.com/Sirivasv/bmssp-js/issues/43)) | `src/bmssp.mjs` | ✅ done — **1.0.0** |
 
-> **Honest note:** until [#43](https://github.com/Sirivasv/bmssp-js/issues/43) lands,
-> `calculateShortestPaths()` computes distances with the reference Dijkstra implementation.
-> The shipped BMSSP building blocks (block list, heap, base case, pivot finding) are fully
-> tested but not yet wired into the public entry point.
+> **Honest note:** the paper's win is asymptotic, and this repo optimizes for correctness
+> and readability, not raw speed. On the full California road network (~2 M nodes, ~5.5 M
+> edges) this implementation currently runs about 2× slower than its own reference
+> Dijkstra — consistent with published experimental studies of the algorithm. Where inputs
+> violate the paper's distinct-path-lengths assumption (e.g. zero-weight edges), documented
+> tie guards keep the results correct
+> ([#163](https://github.com/Sirivasv/bmssp-js/issues/163) tracks a principled tie-break).
 
 ## How it works (in two ideas)
 
@@ -106,12 +111,12 @@ oracle's — including on `test/roadNet-CA.txt`, a real road network from SNAP.
 
 ## Roadmap
 
-| Milestone | Theme |
-| --- | --- |
-| [`1.0.0`](https://github.com/Sirivasv/bmssp-js/milestones) | First end-to-end functional BMSSP (issues #40–#45) |
-| `1.1.0` | Correctness hardening — fuzz tests, edge cases, tie-breaking, input validation |
-| `1.2.0` | Performance & ergonomics — exact Lemma 3.3 asymptotics, path reconstruction, BMSSP-vs-Dijkstra benchmarks |
-| `2.0.0` | API generalization — public multi-source/bounded entry point, flexible inputs |
+| Milestone | Theme | Status |
+| --- | --- | --- |
+| [`1.0.0`](https://github.com/Sirivasv/bmssp-js/milestones) | First end-to-end functional BMSSP (issues #40–#45) | ✅ done |
+| `1.1.0` | Correctness hardening — fuzz tests, edge cases, tie-breaking, input validation | 🔨 current focus |
+| `1.2.0` | Performance & ergonomics — exact Lemma 3.3 asymptotics, path reconstruction, BMSSP-vs-Dijkstra benchmarks | planned |
+| `2.0.0` | API generalization — public multi-source/bounded entry point, flexible inputs | planned |
 
 Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) and the
 [`help wanted` / `good first issue` labels](https://github.com/Sirivasv/bmssp-js/issues).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bmssp",
-  "version": "0.19.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bmssp",
-      "version": "0.19.0",
+      "version": "1.0.0",
       "license": "MPL-2.0",
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bmssp",
-  "version": "0.19.0",
+  "version": "1.0.0",
   "description": "Javascript package implementation of the bmssp algorithm.",
   "main": "index.mjs",
   "keywords": [

--- a/src/bmssp.mjs
+++ b/src/bmssp.mjs
@@ -1,4 +1,6 @@
-import { dijkstra } from "./dijkstra.mjs";
+import { baseCase } from "./baseCase.mjs";
+import { findPivots } from "./findPivots.mjs";
+import { BlockList } from "./blockList.mjs";
 
 class BMSSP {
   constructor(inputGraph) {
@@ -27,6 +29,9 @@ class BMSSP {
 
     // Initialize shortest paths map
     this.initializeShortestPaths();
+
+    // Derive the paper's k / t parameters and the top recursion level
+    this.deriveParameters();
   }
 
   // Method to (re)build the adjacency map from this.graph.
@@ -59,7 +64,162 @@ class BMSSP {
     }
   }
 
-  // Method to calculate shortest paths from startNode using Dijkstra
+  /**
+   * Derive the paper's parameters from n = |V| and store them on the
+   * instance:
+   * - k = max(1, ⌊(log₂ n)^(1/3)⌋) — Bellman-Ford rounds in FindPivots and
+   *   the BaseCase settle cap,
+   * - t = max(1, ⌊(log₂ n)^(2/3)⌋) — branching / level sizing,
+   * - topLevel = max(1, ⌈log₂ n / t⌉) — level of the top BMSSP call.
+   * Everything is clamped to >= 1 so tiny graphs stay out of degenerate
+   * regimes: correctness never depends on the asymptotics.
+   */
+  deriveParameters() {
+    const logn = Math.log2(Math.max(2, this.nodeIDs.size));
+    this.k = Math.max(1, Math.floor(logn ** (1 / 3)));
+    this.t = Math.max(1, Math.floor(logn ** (2 / 3)));
+    this.topLevel = Math.max(1, Math.ceil(logn / this.t));
+  }
+
+  /**
+   * BMSSP(l, B, S) — Algorithm 3 of "Breaking the Sorting Barrier for
+   * Directed Single-Source Shortest Paths": the main bounded multi-source
+   * recursion, wiring FindPivots (Algorithm 1), the Lemma 3.3 BlockList and
+   * BaseCase (Algorithm 2) together.
+   *
+   * Preconditions (the top-level call satisfies them trivially):
+   * - Every vertex in S is complete (this.shortestPaths holds its true
+   *   distance), and every incomplete vertex v with d(v) < B has a shortest
+   *   path through some complete vertex of S.
+   *
+   * Distance estimates live in this.shortestPaths (the paper's d̂[·]) and
+   * are relaxed in place at every level.
+   *
+   * Two outcomes (Lemma 3.1):
+   * - Successful execution: the block list emptied — bound === B and
+   *   vertices holds every v with d(v) < B reachable through S.
+   * - Partial execution: the k·2^(l·t) workload guard tripped — bound < B
+   *   and vertices holds exactly the v with d(v) < bound.
+   *   Every returned vertex is complete either way.
+   *
+   * @param {number} l - Recursion level; 0 delegates to baseCase
+   * @param {number} B - Strict upper bound on the distances in scope (Infinity is allowed)
+   * @param {Set<*>} S - Non-empty set of complete frontier sources
+   * @returns {{ bound: number, vertices: Set<*> }} The boundary B' <= B and
+   *   the set U of vertices completed below it
+   */
+  bmssp(l, B, S) {
+    const dHat = this.shortestPaths;
+    if (l === 0) {
+      return baseCase(B, S, dHat, this.adjacency, this.k);
+    }
+
+    // Shrink the frontier: only the pivots are worth recursing on, and W
+    // is a batch of already-completed vertices folded in at the end
+    const { pivots, W } = findPivots(B, S, dHat, this.adjacency, this.k);
+
+    // Seed the Lemma 3.3 block list with the pivots. lastBound tracks the
+    // paper's Bi': B when P is empty, min d̂ over P before the first pull,
+    // then the boundary returned by the latest recursive call.
+    // A pivot with d̂ >= B is out of scope at this level (only possible
+    // when equal path lengths violate Assumption 2.1 and a pull returned
+    // a key tied with its separator): skip it — the ancestor whose band
+    // covers its distance is responsible for it.
+    const D = new BlockList(2 ** ((l - 1) * this.t), B);
+    let lastBound = B;
+    for (const x of pivots) {
+      const dx = dHat.get(x);
+      if (dx < B) {
+        D.insert(x, dx);
+        if (dx < lastBound) lastBound = dx;
+      }
+    }
+
+    const U = new Set();
+    const workloadCap = this.k * 2 ** (l * this.t);
+
+    while (U.size < workloadCap && !D.isEmpty()) {
+      // Bi, Si <- D.Pull(): the next-closest small batch and its separator
+      const { keys: Si, bound: Bi } = D.pull();
+      let { bound: BiPrime, vertices: Ui } = this.bmssp(l - 1, Bi, Si);
+
+      if (Ui.size === 0) {
+        // Degenerate tie stall: the child settled only vertices tied
+        // exactly at its boundary (possible only through zero-weight
+        // paths, which violate the paper's Assumption 2.1 — see #163),
+        // so its strict d̂ < B' filter returned nothing and this batch
+        // would be re-pulled forever. Escape hatch: settle everything
+        // below Bi reachable through the batch with an uncapped bounded
+        // Dijkstra per member — correct, just not sublinear.
+        Ui = new Set();
+        for (const x of Si) {
+          const { vertices } = baseCase(
+            Bi,
+            new Set([x]),
+            dHat,
+            this.adjacency,
+            Math.max(1, this.nodeIDs.size),
+          );
+          for (const v of vertices) Ui.add(v);
+        }
+        BiPrime = Bi;
+      }
+
+      lastBound = BiPrime;
+      for (const v of Ui) U.add(v);
+
+      // Relax out of the newly-completed Ui, routing improved neighbors
+      // by distance band: [Bi, B) re-enters the block list, [Bi', Bi) is
+      // staged for a batch prepend (closer than the current batch's floor)
+      const K = [];
+      for (const u of Ui) {
+        const du = dHat.get(u);
+        for (const [v, weight] of this.adjacency.get(u) ?? []) {
+          const candidate = du + weight;
+          // Paper relaxation: d̂[u] + w(u,v) <= d̂[v] always updates d̂
+          if (candidate <= (dHat.get(v) ?? Infinity)) {
+            dHat.set(v, candidate);
+            // A vertex already completed at this level cannot strictly
+            // improve (non-negative weights), so an equal-sum relaxation
+            // — which the <= allows, e.g. via a zero-weight cycle — must
+            // not be re-queued (mirrors the baseCase settled guard)
+            if (U.has(v)) continue;
+            if (candidate >= Bi && candidate < B) {
+              D.insert(v, candidate);
+            } else if (candidate >= BiPrime && candidate < Bi) {
+              K.push([v, candidate]);
+            }
+          }
+        }
+      }
+      // Batch members the child did not complete (d̂ still in [Bi', Bi))
+      // go back in front of everything else. A member tied exactly at the
+      // separator (d̂ == Bi < B, an Assumption 2.1 violation) is still in
+      // scope at this level and re-enters through a regular insert.
+      for (const x of Si) {
+        if (U.has(x)) continue;
+        const dx = dHat.get(x);
+        if (dx >= BiPrime && dx < Bi) {
+          K.push([x, dx]);
+        } else if (dx === Bi && Bi < B) {
+          D.insert(x, dx);
+        }
+      }
+      if (K.length > 0) D.batchPrepend(K);
+    }
+
+    // B' <- min(last Bi', B); fold in the FindPivots batch below it
+    const bound = Math.min(lastBound, B);
+    for (const x of W) {
+      if (dHat.get(x) < bound) U.add(x);
+    }
+    return { bound, vertices: U };
+  }
+
+  // Method to calculate shortest paths from startNode via the BMSSP
+  // recursion (Algorithm 3). The top-level call BMSSP(topLevel, ∞, {start})
+  // is always a successful execution, so it completes every reachable
+  // vertex; unreachable ones keep their Infinity estimate.
   calculateShortestPaths(startNode) {
     // To clean the state before calculation
     this.initializeShortestPaths();
@@ -69,10 +229,9 @@ class BMSSP {
       throw new Error("Start node not found in the graph");
     }
 
-    const result = dijkstra(this.graph, this.nodeIDs, startNode);
-    result.forEach((distance, nodeId) => {
-      this.shortestPaths.set(nodeId, distance);
-    });
+    // The source is complete at distance 0; everything else is Infinity
+    this.shortestPaths.set(startNode, 0);
+    this.bmssp(this.topLevel, Infinity, new Set([startNode]));
   }
 }
 

--- a/test/bmssp.test.mjs
+++ b/test/bmssp.test.mjs
@@ -1,0 +1,255 @@
+import { describe, test, expect } from "@jest/globals";
+import { BMSSP } from "../src/bmssp.mjs";
+import { dijkstra } from "../src/dijkstra.mjs";
+
+// Small deterministic PRNG so stress-test failures are reproducible
+function mulberry32(seed) {
+  let a = seed >>> 0;
+  return function () {
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// Seeded random directed graph with an edge out of node 0 guaranteed
+function randomEdges(rand, n, m, maxWeight) {
+  const edges = [[0, 1 + Math.floor(rand() * (n - 1)), 1]];
+  for (let i = 1; i < m; i += 1) {
+    const from = Math.floor(rand() * n);
+    const to = Math.floor(rand() * n);
+    const weight = 1 + Math.floor(rand() * maxWeight);
+    edges.push([from, to, weight]);
+  }
+  return edges;
+}
+
+// Run BMSSP and the Dijkstra oracle from the same source and require the
+// full distance maps to be identical
+function expectMatchesOracle(edges, source) {
+  const bmssp = new BMSSP(edges);
+  bmssp.calculateShortestPaths(source);
+  const oracle = dijkstra(bmssp.graph, bmssp.nodeIDs, source);
+  expect(bmssp.shortestPaths.size).toBe(oracle.size);
+  for (const [v, d] of oracle) {
+    expect(bmssp.shortestPaths.get(v)).toBe(d);
+  }
+  return bmssp;
+}
+
+describe("BMSSP parameter derivation", () => {
+  test("clamps k, t and topLevel to >= 1 on tiny graphs", () => {
+    const tiny = new BMSSP([[0, 0, 5]]);
+    expect(tiny.k).toBeGreaterThanOrEqual(1);
+    expect(tiny.t).toBeGreaterThanOrEqual(1);
+    expect(tiny.topLevel).toBeGreaterThanOrEqual(1);
+  });
+
+  test("matches the paper's formulas once n is large enough", () => {
+    // 1024 nodes in a chain: log2(n) = 10, k = ⌊10^(1/3)⌋ = 2,
+    // t = ⌊10^(2/3)⌋ = 4, topLevel = ⌈10 / 4⌉ = 3
+    const edges = [];
+    for (let i = 0; i < 1023; i += 1) edges.push([i, i + 1, 1]);
+    const chain = new BMSSP(edges);
+    expect(chain.nodeIDs.size).toBe(1024);
+    expect(chain.k).toBe(2);
+    expect(chain.t).toBe(4);
+    expect(chain.topLevel).toBe(3);
+  });
+
+  test("the top-level workload guard can never trip below n", () => {
+    // k·2^(topLevel·t) >= n guarantees the top call is a successful
+    // execution (Lemma 3.1), so every reachable vertex gets completed
+    for (const n of [2, 3, 10, 100, 5000, 1 << 20]) {
+      const bmssp = new BMSSP([[0, 1, 1]]);
+      bmssp.nodeIDs = new Set(Array.from({ length: n }, (_, i) => i));
+      bmssp.deriveParameters();
+      expect(bmssp.k * 2 ** (bmssp.topLevel * bmssp.t)).toBeGreaterThanOrEqual(
+        n,
+      );
+    }
+  });
+});
+
+describe("BMSSP end-to-end on hand-built graphs", () => {
+  test("computes the README example distances", () => {
+    const bmssp = expectMatchesOracle(
+      [
+        [0, 1, 50],
+        [1, 2, 75],
+        [0, 2, 25],
+      ],
+      0,
+    );
+    expect(bmssp.shortestPaths.get(0)).toBe(0);
+    expect(bmssp.shortestPaths.get(1)).toBe(50);
+    expect(bmssp.shortestPaths.get(2)).toBe(25);
+  });
+
+  test("takes the cheaper multi-hop path over the direct edge", () => {
+    const bmssp = expectMatchesOracle(
+      [
+        [0, 1, 1],
+        [1, 2, 1],
+        [2, 3, 1],
+        [0, 3, 10],
+      ],
+      0,
+    );
+    expect(bmssp.shortestPaths.get(3)).toBe(3);
+  });
+
+  test("leaves unreachable vertices at Infinity", () => {
+    const bmssp = expectMatchesOracle(
+      [
+        [0, 1, 2],
+        [3, 4, 1],
+      ],
+      0,
+    );
+    expect(bmssp.shortestPaths.get(3)).toBe(Infinity);
+    expect(bmssp.shortestPaths.get(4)).toBe(Infinity);
+  });
+
+  test("handles a single-node graph (self-loop)", () => {
+    const bmssp = expectMatchesOracle([[0, 0, 5]], 0);
+    expect(bmssp.shortestPaths.get(0)).toBe(0);
+  });
+
+  test("recomputes cleanly from a different source", () => {
+    const edges = [
+      [0, 1, 4],
+      [1, 2, 3],
+      [2, 0, 2],
+    ];
+    const bmssp = new BMSSP(edges);
+    bmssp.calculateShortestPaths(0);
+    bmssp.calculateShortestPaths(2);
+    const oracle = dijkstra(bmssp.graph, bmssp.nodeIDs, 2);
+    for (const [v, d] of oracle) {
+      expect(bmssp.shortestPaths.get(v)).toBe(d);
+    }
+  });
+});
+
+describe("BMSSP degenerate ties (Assumption 2.1 violated, #163)", () => {
+  test("terminates on zero-weight cycles and clusters", () => {
+    // 0, 1, 2 form a zero-weight cluster (all at distance 0): a BaseCase
+    // partial execution settles only tied vertices and returns none of
+    // them, which without the stall escape hatch would loop forever
+    expectMatchesOracle(
+      [
+        [0, 1, 0],
+        [1, 0, 0],
+        [1, 2, 0],
+        [2, 3, 1],
+        [3, 4, 2],
+      ],
+      0,
+    );
+  });
+
+  test("terminates when many equal-length paths tie mid-graph", () => {
+    // A layered graph where every vertex of a layer sits at the same
+    // distance: boundary ties are the norm rather than the exception
+    const edges = [];
+    for (let layer = 0; layer < 6; layer += 1) {
+      for (let i = 0; i < 4; i += 1) {
+        for (let j = 0; j < 4; j += 1) {
+          edges.push([1 + layer * 4 + i, 1 + (layer + 1) * 4 + j, 1]);
+        }
+      }
+    }
+    for (let i = 0; i < 4; i += 1) edges.push([0, 1 + i, 1]);
+    expectMatchesOracle(edges, 0);
+  });
+
+  test("seeded stress with tiny weights (0-2) keeps matching the oracle", () => {
+    const rand = mulberry32(431);
+    for (let round = 0; round < 25; round += 1) {
+      const n = 20 + Math.floor(rand() * 20);
+      const edges = [[0, 1 + Math.floor(rand() * (n - 1)), 1]];
+      for (let i = 0; i < n * 4; i += 1) {
+        edges.push([
+          Math.floor(rand() * n),
+          Math.floor(rand() * n),
+          Math.floor(rand() * 3),
+        ]);
+      }
+      expectMatchesOracle(edges, 0);
+    }
+  });
+});
+
+describe("BMSSP recursion contract (Lemma 3.1)", () => {
+  test("a bounded top call returns a complete set below its boundary", () => {
+    const rand = mulberry32(432);
+    for (let round = 0; round < 25; round += 1) {
+      const edges = randomEdges(rand, 30, 120, 1000);
+      const bmssp = new BMSSP(edges);
+      const oracle = dijkstra(bmssp.graph, bmssp.nodeIDs, 0);
+      const finite = [...oracle.values()]
+        .filter((d) => d < Infinity)
+        .sort((a, b) => a - b);
+      const B = finite[Math.floor(finite.length * 0.6)] + 0.5;
+
+      bmssp.initializeShortestPaths();
+      bmssp.shortestPaths.set(0, 0);
+      const { bound, vertices } = bmssp.bmssp(bmssp.topLevel, B, new Set([0]));
+
+      // B' <= B, every returned vertex is complete, and U holds exactly
+      // the vertices with true distance below B' (all paths go through
+      // the single source, so "reachable through S" is just "reachable")
+      expect(bound).toBeLessThanOrEqual(B);
+      for (const v of vertices) {
+        expect(bmssp.shortestPaths.get(v)).toBe(oracle.get(v));
+        expect(oracle.get(v)).toBeLessThan(bound);
+      }
+      for (const [v, d] of oracle) {
+        if (d < bound) expect(vertices.has(v)).toBe(true);
+      }
+      // d̂ never underestimates the true distance anywhere
+      for (const [v, d] of bmssp.shortestPaths) {
+        expect(d).toBeGreaterThanOrEqual(oracle.get(v));
+      }
+    }
+  });
+
+  test("an unbounded top call is a successful execution (B' = B)", () => {
+    const rand = mulberry32(433);
+    const edges = randomEdges(rand, 40, 160, 1000);
+    const bmssp = new BMSSP(edges);
+    bmssp.initializeShortestPaths();
+    bmssp.shortestPaths.set(0, 0);
+    const { bound, vertices } = bmssp.bmssp(
+      bmssp.topLevel,
+      Infinity,
+      new Set([0]),
+    );
+    const oracle = dijkstra(bmssp.graph, bmssp.nodeIDs, 0);
+    expect(bound).toBe(Infinity);
+    const reachable = new Set(
+      [...oracle].filter(([, d]) => d < Infinity).map(([v]) => v),
+    );
+    expect(vertices).toEqual(reachable);
+  });
+});
+
+describe("BMSSP vs Dijkstra oracle (seeded stress)", () => {
+  test("full distance maps match on random graphs across sizes", () => {
+    const rand = mulberry32(434);
+    for (let round = 0; round < 30; round += 1) {
+      const n = 10 + Math.floor(rand() * 90);
+      const m = n * (2 + Math.floor(rand() * 3));
+      const edges = randomEdges(rand, n, m, 1000);
+      expectMatchesOracle(edges, 0);
+    }
+  });
+
+  test("full distance maps match on a larger sparse graph", () => {
+    const rand = mulberry32(435);
+    const edges = randomEdges(rand, 2000, 6000, 100000);
+    expectMatchesOracle(edges, 0);
+  });
+});

--- a/test/main.test.mjs
+++ b/test/main.test.mjs
@@ -105,7 +105,7 @@ describe("BMSSP initialize calculateShortestPaths", () => {
     const startNode = [...myBMSSP.nodeIDs][0];
     myBMSSP.calculateShortestPaths(startNode);
     expect(myBMSSP.shortestPaths.get(startNode)).toBe(0);
-  });
+  }, 120000); // A real BMSSP run over the full road network takes a few seconds
   test("throws an error if the start node is not in the graph", () => {
     const invalidStartNode = -1; // Assuming -1 is not a valid node ID in the graph
     expect(() => {
@@ -135,5 +135,5 @@ describe("BMSSP vs Dijkstra shortest paths", () => {
     for (const [nodeId, distance] of myBMSSP.shortestPaths) {
       expect(dijkstraPaths.get(nodeId)).toBe(distance);
     }
-  });
+  }, 120000); // A real BMSSP run + a Dijkstra oracle run over the full road network
 });


### PR DESCRIPTION
Closes #43 — the last open issue of the **1.0.0** milestone.

## Summary

Implements Algorithm 3, the main BMSSP recursion, in `src/bmssp.mjs`, wiring together the previously shipped pieces (`baseCase` #40, `BlockList` #42, `findPivots` #44):

- `deriveParameters()` (constructor): `k = max(1, ⌊(log₂n)^(1/3)⌋)`, `t = max(1, ⌊(log₂n)^(2/3)⌋)`, `topLevel = max(1, ⌈log₂n / t⌉)` — clamped so correctness never depends on the asymptotic regime, and `k·2^(topLevel·t) ≥ n` makes the top call a successful execution (Lemma 3.1).
- `bmssp(l, B, S)` → `{ bound, vertices }`: level 0 delegates to `baseCase`; level ≥ 1 runs `findPivots`, seeds a `BlockList(M = 2^((l−1)·t), B)` with the pivots, then pulls batches, recurses one level down, and band-routes relaxed neighbors (`[Bi, B)` → `insert`, `[Bi′, Bi)` → staged `batchPrepend` together with uncompleted batch members) until the block list drains (success) or the `k·2^(l·t)` workload guard trips (partial).
- `calculateShortestPaths(start)` now runs `bmssp(topLevel, ∞, {start})` after setting `d̂[start] = 0` — **the Dijkstra delegation is gone**; `src/dijkstra.mjs` remains solely the test oracle.

### Degenerate-tie guards (Assumption 2.1 violations — context in #163)

Real inputs (zero-weight edges, equal path sums) violate the paper's distinct-path-lengths assumption. Three documented guards keep the recursion correct and terminating: a completed-vertex guard against equal-sum re-queueing; an out-of-scope pivot gate (a pull can return a key tied with its separator, so a pivot can arrive with `d̂ ≥ B`); and a stall escape hatch when a child returns zero vertices (all settled tied at its boundary), plus explicit re-queueing of batch members left at `d̂ == Bi`. All three are exercised by tests.

## Tests / lint

- **86 tests passing** (71 existing + 15 new in `test/bmssp.test.mjs`), 100% statement coverage. New coverage: parameter derivation, hand-built graphs, zero-weight cycles/clusters, layered tie graphs, tiny-weight seeded stress, the Lemma 3.1 bounded/unbounded call contract, and seeded full-map oracle equality up to n = 2000.
- The "BMSSP vs Dijkstra" equivalence test now exercises the real algorithm on the full roadNet-CA (n ≈ 1.97 M): **0 mismatches**, ≈ 7.8 s vs Dijkstra's ≈ 3.8 s locally (the two roadNet tests carry explicit 120 s Jest timeouts).
- `npm run lint` clean.

## Version

`npm version major` → **1.0.0** (the milestone-closing major bump per convention). Tag + Release only after merge confirmation (gate 3).

Note: the branch also carries `main`'s local docs-only bookkeeping commit from the previous session (56a19fb) — direct pushes to `main` are now blocked by branch protection, so it lands through this PR instead.

## Roadmap proposals (for Phase E, one confirmation each)

1. Close milestone `1.0.0` once this PR merges and #43 auto-closes.
2. Append the three tie findings above to #163 (they define the guards a principled tie-break would replace).
3. Update #170: unblocked by #43; record the first baseline (roadNet-CA: BMSSP ≈ 7.8 s vs Dijkstra ≈ 3.8 s, ≈ 2.1×) and scope it to the BMSSP column in `benchmarks/scenarios.bench.mjs`.
4. Re-scope #161 to a dedicated high-volume fuzz suite (more shapes, extreme weight regimes, multi-source `bmssp()` calls) extending the seeded stress that now exists in `test/bmssp.test.mjs`.
5. Annotate #162 as partially covered (unreachable ⇒ Infinity test exists); keep it for systematic multi-component coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)