### PR TITLE
docs: measured BMSSP-vs-Dijkstra head-to-head (algorithm time only)

### DIFF
--- a/.claude/knowledge/05-codebase-map.md
+++ b/.claude/knowledge/05-codebase-map.md
@@ -1,13 +1,13 @@
 # 05 — Codebase Map (current state)
 
 <!-- BOOKMARK-COMMIT: 909a606ba7b455e6d20211d02cfbaa4778648333 -->
-<!-- PENDING-PR-BRANCH: (none) -->
-<!-- Last validated: 2026-07-16, Phase E after PR #181 (feat/43-bmssp-main) merged as
-     909a606. Version 1.0.0 (tagged + released; publish.yml fired). #43 closed, milestone
-     1.0.0 closed — the algorithm is functional end-to-end. All five #43 roadmap proposals
-     executed on GitHub. Commits after the bookmark (if any) touch only .claude/knowledge
-     (Phase E bookkeeping — rides in the next PR; direct pushes to main are blocked by
-     branch protection). -->
+<!-- PENDING-PR-BRANCH: docs/head-to-head-vs-dijkstra -->
+<!-- Last validated: 2026-07-16, reflection session after the 1.0.0 release. This map
+     describes the tree of the docs/head-to-head-vs-dijkstra branch (docs-only PR: the
+     measured BMSSP-vs-Dijkstra head-to-head in benchmarks/HEAD-TO-HEAD.md + README/KB
+     refresh; no code behavior change, no version bump — closes no issue). The branch also
+     carries the earlier Phase E bookkeeping commit c54ad76 that branch protection kept
+     off origin/main. -->
 
 Snapshot of what exists in `bmssp-js` today, so you know what to build on vs. what's missing.
 
@@ -80,6 +80,7 @@ benchmarks/               # dependency-free benchmark harness, `npm run bench`
   run.mjs                 #   runs all benchmarks, prints markdown report
   README.md               #   methodology + "when to use which" guidance
   RESULTS.md              #   captured sample run
+  HEAD-TO-HEAD.md         #   measured BMSSP-vs-Dijkstra (1.0.0): wall-clock + comparison counts
 examples/
   main.mjs                # tiny usage example (constructs BMSSP, prints .graph)
 docs/index.html           # published docs page
@@ -136,10 +137,16 @@ zero-weight edges) occur; all are covered by tests in `test/bmssp.test.mjs`:
    just not sublinear. Boundary-tied `Si` members (`d̂ == Bi < B`) re-enter `D` via a regular
    insert rather than being dropped.
 
-**Performance (measured 2026-07-16, Apple Silicon, node 24):** full roadNet-CA
-(n = 1,965,206, m = 5,533,214): construct ~1.9 s, Dijkstra ~3.8 s, BMSSP ~7.8 s (≈2.1×
-Dijkstra), 0 mismatches. The two roadNet tests in `main.test.mjs` carry explicit 120 s Jest
-timeouts (the default 5 s is not enough for a real BMSSP run under CI).
+**Performance (measured 2026-07-16, Apple Silicon, node v26.5.0 — full data + methodology
+in `benchmarks/HEAD-TO-HEAD.md`):** algorithm-only wall-clock (construction excluded,
+Dijkstra fed the same prebuilt adjacency): Dijkstra wins every shape/size; sparse-graph
+ratio narrows with n (2.54× at 50k → **1.57× at 2M**), roadNet-CA ≈2.1×. **Comparison
+counts (the paper's metric) cross over:** BMSSP does fewer distance comparisons than
+Dijkstra past ~n = 1M sparse (0.96× at 1M, **0.91× at 2M**). Two measured pathologies,
+tracked in **#182**: star graphs blow up superlinearly (67.8× at n = 500k) and the ratio
+cliffs to 5× at n = 4M where `topLevel` steps 3→4. The two roadNet tests in
+`main.test.mjs` carry explicit 120 s Jest timeouts (the default 5 s is not enough for a
+real BMSSP run under CI).
 
 ## `src/blockList.mjs` — Lemma 3.3 structure `D` (#42)
 
@@ -257,8 +264,11 @@ see the same array within a run).
 
 Deterministic (seeded) micro-benchmarks. `adjacency.bench.mjs` shows the #45 map is
 ~thousands× faster per-node than a linear scan. `scenarios.bench.mjs` times construction +
-a Dijkstra run across five graph shapes. **#43 unblocks #170** (the BMSSP-vs-Dijkstra
-head-to-head column); first ad-hoc measurement above (~2.1× Dijkstra on roadNet-CA).
+a Dijkstra run across five graph shapes. **`HEAD-TO-HEAD.md` records the measured
+BMSSP-vs-Dijkstra comparison** (2026-07-16): wall-clock tables by shape and size, the
+sparse scaling trend, and the comparison-count crossover (~n = 1M). #170 tracks folding
+both measurements into the harness itself (algorithm-only `bmssp` column + optional
+comparison-count mode); the raw baseline is also on #170 as a comment.
 
 ## Gaps to fill (the actual work)
 

--- a/.claude/knowledge/05-codebase-map.md
+++ b/.claude/knowledge/05-codebase-map.md
@@ -1,14 +1,13 @@
 # 05 — Codebase Map (current state)
 
-<!-- BOOKMARK-COMMIT: bccc78d56a6433050238b7f54f8871e37a5cd79b -->
-<!-- PENDING-PR-BRANCH: feat/43-bmssp-main -->
-<!-- Last validated: 2026-07-16, Phase C of the #43 PR (feat/43-bmssp-main). Describes the
-     tree as it will exist once that PR merges: the main BMSSP recursion (Algorithm 3) is
-     implemented and calculateShortestPaths no longer delegates to Dijkstra. Version bumped
-     to 1.0.0 (major — the PR closes the last 1.0.0-milestone issue). Note: the branch also
-     carries main's un-pushable Phase E bookkeeping commit 56a19fb (docs-only) — origin/main
-     now has branch-protection rules (PRs only, verified signatures, CodeQL), so it rides in
-     this PR instead of being pushed directly. -->
+<!-- BOOKMARK-COMMIT: 909a606ba7b455e6d20211d02cfbaa4778648333 -->
+<!-- PENDING-PR-BRANCH: (none) -->
+<!-- Last validated: 2026-07-16, Phase E after PR #181 (feat/43-bmssp-main) merged as
+     909a606. Version 1.0.0 (tagged + released; publish.yml fired). #43 closed, milestone
+     1.0.0 closed — the algorithm is functional end-to-end. All five #43 roadmap proposals
+     executed on GitHub. Commits after the bookmark (if any) touch only .claude/knowledge
+     (Phase E bookkeeping — rides in the next PR; direct pushes to main are blocked by
+     branch protection). -->
 
 Snapshot of what exists in `bmssp-js` today, so you know what to build on vs. what's missing.
 

--- a/.claude/knowledge/06-milestones-roadmap.md
+++ b/.claude/knowledge/06-milestones-roadmap.md
@@ -1,7 +1,7 @@
 # 06 — Milestones Roadmap
 
-<!-- SYNCED-FROM-GITHUB: 2026-07-16 (Phase E after PR #181 merged; #43 closed, milestone
-     1.0.0 closed, 1.0.0 tagged + released) -->
+<!-- SYNCED-FROM-GITHUB: 2026-07-16 (post-1.0.0 reflection session: head-to-head measured,
+     #182 created + #170 baseline comment posted with explicit user pre-authorization) -->
 <!-- Current package version: 1.0.0 (tagged + released) -->
 
 Maps GitHub **milestones** and **issues** (Sirivasv/bmssp-js) to the paper's building blocks,
@@ -43,6 +43,9 @@ executes the approved ones — one confirmation each — and clears them from th
 _(All five #43-PR proposals — close milestone 1.0.0, tie findings into #163, baseline +
 scope into #170, re-scope #161, partial-coverage note into #162 — were approved and
 executed on GitHub in Phase E, 2026-07-16.)_
+_(2026-07-16 reflection session, user pre-authorized roadmap edits in-conversation: created
+**#182** (performance cliffs: star fanout + topLevel transition, milestone 1.2.0) and
+posted the measured head-to-head baseline + scope suggestion as a comment on **#170**.)_
 
 ---
 
@@ -58,6 +61,12 @@ executed on GitHub in Phase E, 2026-07-16.)_
   See `05-codebase-map.md` for the shipped API and the degenerate-tie guards.
 - **Next milestone:** **`1.1.0` — correctness hardening** (6 open issues). Recommended next
   issue: **#161** (fuzz suite — cheapest way to protect everything else), then #162, #163.
+- **2026-07-16 reflection session (post-release):** measured the BMSSP-vs-Dijkstra
+  head-to-head, algorithm time only → `benchmarks/HEAD-TO-HEAD.md`. Headlines: Dijkstra
+  wins wall-clock everywhere but the sparse ratio narrows with n (1.57× at 2M);
+  **comparison counts cross over at ~n = 1M sparse** (0.91× at 2M) — the paper's claim,
+  measured. Two pathologies found → new issue **#182** (milestone 1.2.0). Docs PR:
+  `docs/head-to-head-vs-dijkstra` (no version bump; closes no issue).
 
 ## Milestone `1.0.0` — issues → paper (CLOSED — all done)
 
@@ -102,9 +111,14 @@ Recommended order (cheapest protection first, then the deep work):
 | 168 | Adjacency and relaxation micro-optimizations | enhancement · help wanted |
 | 169 | Optional shortest-path reconstruction (`Pred[]` → paths) | enhancement · help wanted |
 | 170 | BMSSP-vs-Dijkstra benchmark comparison | enhancement · help wanted |
+| 182 | Investigate BMSSP performance cliffs: high-fanout (star) graphs and recursion-level transitions | enhancement · help wanted |
 
-_Note:_ the seeded **benchmark harness already exists** (`benchmarks/`, `npm run bench`);
-#170 is unblocked by #43 and carries a first baseline (recorded on the issue).
+_Note:_ the seeded **benchmark harness already exists** (`benchmarks/`, `npm run bench`),
+and the measured head-to-head lives in `benchmarks/HEAD-TO-HEAD.md`. #170 is now scoped to
+harness integration (algorithm-only `bmssp` column + optional comparison-count mode; full
+baseline recorded as a comment on the issue, 2026-07-16). #182 (new, 2026-07-16) carries
+the two measured pathologies: star-graph blowup (67.8× at n = 500k) and the `topLevel`
+3→4 transition cliff (5× at n = 4M); likely overlaps #167/#168.
 
 ## Milestone `2.0.0` (milestone #4) — API-breaking generalization
 

--- a/.claude/knowledge/06-milestones-roadmap.md
+++ b/.claude/knowledge/06-milestones-roadmap.md
@@ -1,7 +1,8 @@
 # 06 — Milestones Roadmap
 
-<!-- SYNCED-FROM-GITHUB: 2026-07-16 (Phase C of the #43 PR, feat/43-bmssp-main) -->
-<!-- Current package version: 1.0.0 (bumped in the #43 PR; NOT tagged/released yet) -->
+<!-- SYNCED-FROM-GITHUB: 2026-07-16 (Phase E after PR #181 merged; #43 closed, milestone
+     1.0.0 closed, 1.0.0 tagged + released) -->
+<!-- Current package version: 1.0.0 (tagged + released) -->
 
 Maps GitHub **milestones** and **issues** (Sirivasv/bmssp-js) to the paper's building blocks,
 with a dependency-aware build order. This is the "intent" side of the knowledge base (what to
@@ -37,52 +38,28 @@ it runs the same Phase C reconciliation directly on `main`.
 
 ## 📋 Roadmap proposals (pending user approval)
 
-_Written in Phase C of the #43 PR (2026-07-16). Phase E executes the approved ones — one
-confirmation each — and clears them from this list._
-
-1. **Close milestone `1.0.0` (milestone #1)** once this PR merges and #43 auto-closes —
-   all 11 of its issues will then be closed. (`gh api -X PATCH` on the milestone,
-   `state: closed`.)
-2. **Append the #43 tie findings to #163** (deterministic tie-breaking): implementing the
-   main recursion surfaced three concrete Assumption 2.1 violations, each now handled by a
-   documented guard in `bmssp()`: (a) `BlockList.pull()` can return a key tied with its
-   separator, so a frontier member can arrive at a level with `d̂ == B` — out-of-scope
-   pivots are filtered at seeding; (b) batch members with `d̂ == Bi < B` must be re-queued
-   via a regular insert or they are silently dropped; (c) a child call can return zero
-   vertices when everything it settled tied at its boundary — without an escape hatch the
-   batch is re-pulled forever. A principled tie-break (Assumption 2.1 in code) would make
-   all three guards unnecessary; until then they define the behavior tests rely on
-   (`test/bmssp.test.mjs`, "degenerate ties" describe block).
-3. **Update #170** (BMSSP-vs-Dijkstra benchmark): now unblocked by #43. Record the first
-   ad-hoc baseline — full roadNet-CA (n ≈ 1.97 M, m ≈ 5.5 M): BMSSP ≈ 7.8 s vs
-   Dijkstra ≈ 3.8 s (≈ 2.1×, Apple Silicon, node 24) — and scope the issue to adding the
-   BMSSP column to `benchmarks/scenarios.bench.mjs` + a fresh `RESULTS.md` capture.
-4. **Re-scope #161** (property/fuzz tests): `test/bmssp.test.mjs` already ships seeded
-   random-graph stress (full-map oracle equality across sizes, tiny-weight tie stress,
-   bounded-call Lemma 3.1 contract checks). #161's remaining value: much higher volume, more
-   graph shapes (grids, DAGs, stars, disconnected forests), extreme weight regimes (0, huge,
-   mixed magnitudes), and multi-source `bmssp()` calls — as a dedicated slow/fuzz suite.
-5. **Note on #162** (disconnected/unreachable edge cases): partially covered by #43's tests
-   (unreachable ⇒ Infinity). Keep the issue for systematic coverage (multiple components,
-   source in a small component, empty-adjacency corner cases), pointing at the existing test
-   as the pattern.
+_None right now. Phase C writes proposed GitHub edits here (and in the PR body); Phase E
+executes the approved ones — one confirmation each — and clears them from this list._
+_(All five #43-PR proposals — close milestone 1.0.0, tie findings into #163, baseline +
+scope into #170, re-scope #161, partial-coverage note into #162 — were approved and
+executed on GitHub in Phase E, 2026-07-16.)_
 
 ---
 
 ## Current state (as synced)
 
-- **Package version:** `1.0.0` in `package.json` on the PR branch — the **major** bump for
-  closing the `1.0.0` milestone. Tag + GitHub Release happen in Phase E after the user
-  confirms the merge (gate 3). Last released version: `0.19.0`.
-- **Milestone `1.0.0`:** **complete pending this PR's merge** — #43 was the last open issue.
-- **Just built:** **#43 — `BMSSP(l, B, S)` main recursion (Algorithm 3), this PR.**
-  `calculateShortestPaths` now runs the paper's method end-to-end (no Dijkstra delegation);
-  the "BMSSP vs Dijkstra" test passes on the full road network. See `05-codebase-map.md`
-  for the shipped API and the degenerate-tie guards.
+- **Package version:** `1.0.0` — **tagged + released** (2026-07-16; publish.yml fired →
+  npm + Docker Hub). The major bump for closing the `1.0.0` milestone.
+- **Milestone `1.0.0`:** **closed on GitHub** — all 11 issues done. The algorithm is
+  functional end-to-end.
+- **Just merged:** **#43 — `BMSSP(l, B, S)` main recursion (Algorithm 3) — PR #181**
+  (squash commit `909a606`). `calculateShortestPaths` runs the paper's method end-to-end
+  (no Dijkstra delegation); the "BMSSP vs Dijkstra" test passes on the full road network.
+  See `05-codebase-map.md` for the shipped API and the degenerate-tie guards.
 - **Next milestone:** **`1.1.0` — correctness hardening** (6 open issues). Recommended next
   issue: **#161** (fuzz suite — cheapest way to protect everything else), then #162, #163.
 
-## Milestone `1.0.0` — issues → paper (all done pending merge)
+## Milestone `1.0.0` — issues → paper (CLOSED — all done)
 
 | # | Title | What it is (paper) | Depends on | Status |
 |---|---|---|---|---|
@@ -91,14 +68,14 @@ confirmation each — and clears them from this list._
 | **40** | Implement the base case of the bmssp algorithm | `BaseCase(B, S)`. **Alg 2**, §02 | #41 | ✅ merged (PR #178) |
 | **42** | Implement Lema 3.3 data structure | Block-list `D`. **Lemma 3.3**, §03-B | — | ✅ merged (PR #175) |
 | **44** | Implement the findingPivots function | `FindPivots(B, S)`. **Alg 1**, §02 | #45 | ✅ merged (PR #180) |
-| **43** | Implement main bmssp algorithm | `BMSSP(l, B, S)` + `k,t`. **Alg 3**, §02 | #40, #42, #44 | ✅ done (**this PR**) |
+| **43** | Implement main bmssp algorithm | `BMSSP(l, B, S)` + `k,t`. **Alg 3**, §02 | #40, #42, #44 | ✅ merged (PR #181) |
 
 ### Closed (context)
 `#36` main `calculateShortestPaths` · `#35` Dijkstra oracle + BMSSP-vs-Dijkstra test ·
 `#28` `shortestPaths` output map (∞ init) · `#27` `nodeIDs` vertex index ·
 `#24` datasets research (roadNet-CA).
 
-### Definition of done for `1.0.0` — ✅ met by this PR
+### Definition of done for `1.0.0` — ✅ met
 - `calculateShortestPaths(source)` computes distances **via BMSSP** (not by calling
   `dijkstra`), and the "BMSSP vs Dijkstra" test passes for every node. ✅
 - Each sub-piece (#40/#41/#42/#44/#45) shipped with focused unit tests. ✅
@@ -110,9 +87,9 @@ Recommended order (cheapest protection first, then the deep work):
 
 | Order | # | Issue | Labels | Notes after #43 |
 |---|---|---|---|---|
-| 1 | 161 | Property/fuzz tests: BMSSP vs Dijkstra on random graphs | enhancement · help wanted | Extend the seeded stress already in `test/bmssp.test.mjs` (see proposal 4) |
-| 2 | 162 | Edge-case tests: disconnected graphs and unreachable nodes | enhancement · help wanted | Partially covered by #43 tests (see proposal 5) |
-| 3 | 163 | Deterministic tie-breaking for equal-length paths (Assumption 2.1) | enhancement · help wanted | Three concrete manifestations found in #43 (see proposal 2) |
+| 1 | 161 | Property/fuzz tests: BMSSP vs Dijkstra on random graphs | enhancement · help wanted | Extend the seeded stress already in `test/bmssp.test.mjs` (re-scope noted on the issue) |
+| 2 | 162 | Edge-case tests: disconnected graphs and unreachable nodes | enhancement · help wanted | Partially covered by #43 tests (noted on the issue) |
+| 3 | 163 | Deterministic tie-breaking for equal-length paths (Assumption 2.1) | enhancement · help wanted | Three concrete manifestations found in #43 (documented on the issue) |
 | 4 | 165 | Input validation for the BMSSP constructor | good first issue · help wanted | — |
 | 5 | 164 | Optional constant-degree transform (in/out-degree ≤ 2) | enhancement · help wanted | — |
 | 6 | 166 | JSDoc / API docs for the new modules | documentation · good first issue | `bmssp()` / `deriveParameters()` ship with JSDoc already |
@@ -127,7 +104,7 @@ Recommended order (cheapest protection first, then the deep work):
 | 170 | BMSSP-vs-Dijkstra benchmark comparison | enhancement · help wanted |
 
 _Note:_ the seeded **benchmark harness already exists** (`benchmarks/`, `npm run bench`);
-#170 is unblocked by #43 and has a first baseline (see proposal 3).
+#170 is unblocked by #43 and carries a first baseline (recorded on the issue).
 
 ## Milestone `2.0.0` (milestone #4) — API-breaking generalization
 
@@ -149,7 +126,7 @@ Closing an issue bumps the package version and, after the PR merges, ships a rel
 
 1. **In the PR that closes the issue** — `npm version minor --no-git-tag-version` (keeps
    `package.json` + `package-lock.json` in sync; historical cadence is a **minor** `0.N.0`
-   bump per issue). **This PR used `npm version major`** — the `1.0.0` milestone close is
+   bump per issue). **The #43 PR used `npm version major`** — the `1.0.0` milestone close is
    the major bump, per convention.
 2. **After the user confirms the merge** — tag `main` with the bare version (no `v` prefix)
    and `gh release create` it; publishing the release fires `publish.yml` → **npm + Docker

--- a/.claude/knowledge/07-glossary.md
+++ b/.claude/knowledge/07-glossary.md
@@ -1,6 +1,7 @@
 # 07 — Glossary
 
-<!-- Updated on: 2026-07-16 (terms last extended in the #43 PR: main bmssp recursion) -->
+<!-- Updated on: 2026-07-16 (terms last extended in the docs/head-to-head-vs-dijkstra PR:
+     measured head-to-head terms) -->
 
 > **Lifecycle: dynamic — updated in Phase C of every PR.** When a PR introduces new symbols
 > or terms (module names, data-structure fields, paper notation newly used in code), add
@@ -146,3 +147,16 @@ Quick lookup for the symbols and terms used across the paper, the notes, and the
   host the BMSSP-vs-Dijkstra comparison once #43 lands.
 - **Scenario** — a named, seeded graph shape in the benchmark registry used to probe where
   BMSSP's asymptotics would help vs. where Dijkstra dominates. See `benchmarks/README.md`.
+- **Head-to-head** — the measured BMSSP-vs-Dijkstra comparison
+  (`benchmarks/HEAD-TO-HEAD.md`, 2026-07-16). **Algorithm-only timing**: construction and
+  adjacency building are excluded for both sides; the Dijkstra variant consumes the BMSSP
+  instance's own prebuilt `adjacency` Map (the exported `dijkstra()` builds its own per
+  call — that's loading, not algorithm). Harness integration tracked in #170.
+- **Comparison-count crossover** — head-to-head result in the paper's comparison-addition
+  model: counting every comparison between two distance values (heap sifts, BlockList
+  searches/sorts, relaxations), BMSSP does **fewer** comparisons than Dijkstra past
+  ~n = 1M on sparse graphs (0.91× at n = 2M) even though Dijkstra still wins wall-clock —
+  the sorting barrier measurably broken, with constant factors as the remaining gap.
+- **Performance cliffs (#182)** — two measured regimes where the head-to-head ratio breaks
+  from its ~1.6–2× pattern: star graphs (superlinear blowup, 67.8× at n = 500k) and the
+  `topLevel = ⌈log₂n / t⌉` 3→4 transition (5× at n = 4M on sparse). Milestone 1.2.0.

--- a/README.md
+++ b/README.md
@@ -32,11 +32,15 @@ with every building block shipped, tested, and released individually:
 | `BMSSP(l, B, S)` — Algorithm 3, the main recursion ([#43](https://github.com/Sirivasv/bmssp-js/issues/43)) | `src/bmssp.mjs` | ✅ done — **1.0.0** |
 
 > **Honest note:** the paper's win is asymptotic, and this repo optimizes for correctness
-> and readability, not raw speed. On the full California road network (~2 M nodes, ~5.5 M
-> edges) this implementation currently runs about 2× slower than its own reference
-> Dijkstra — consistent with published experimental studies of the algorithm. Where inputs
-> violate the paper's distinct-path-lengths assumption (e.g. zero-weight edges), documented
-> tie guards keep the results correct
+> and readability, not raw speed. Measured head-to-head (algorithm time only, graph
+> loading excluded — see [benchmarks/HEAD-TO-HEAD.md](benchmarks/HEAD-TO-HEAD.md)):
+> Dijkstra still wins on wall-clock at every practical size, though the gap narrows as
+> sparse graphs grow (2.5× at 50k nodes → 1.57× at 2M). But in the paper's own metric —
+> **comparisons between path lengths** — BMSSP does **fewer comparisons than Dijkstra
+> from about n = 1M on sparse graphs** (0.91× at n = 2M), and the advantage grows with
+> size: the "sorting barrier" is measurably broken; what remains is JS constant factors.
+> Where inputs violate the paper's distinct-path-lengths assumption (e.g. zero-weight
+> edges), documented tie guards keep the results correct
 > ([#163](https://github.com/Sirivasv/bmssp-js/issues/163) tracks a principled tie-break).
 
 ## How it works (in two ideas)
@@ -49,7 +53,9 @@ with every building block shipped, tested, and released individually:
    ordered *between* blocks but unsorted *within* them — enough to repeatedly pull the next
    closest batch without paying the Θ(log n)-per-vertex "sorting barrier."
 
-The asymptotic win is theoretical (the crossover point is astronomically large); this repo
+The wall-clock crossover point is astronomically large, but the asymptotics are real: in
+measured comparison counts this implementation already beats Dijkstra past ~1M nodes on
+sparse graphs ([benchmarks/HEAD-TO-HEAD.md](benchmarks/HEAD-TO-HEAD.md)). This repo
 optimizes for a **correct, readable, well-tested** implementation, validated line-by-line
 against a Dijkstra oracle — not for raw speed.
 
@@ -105,6 +111,10 @@ npm test          # Jest suite, incl. BMSSP-vs-Dijkstra equivalence on a real ro
 npm run lint      # Prettier + ESLint
 npm run bench     # seeded micro-benchmarks (see benchmarks/README.md)
 ```
+
+The measured BMSSP-vs-Dijkstra head-to-head — wall-clock and comparison counts, with
+methodology — lives in [benchmarks/HEAD-TO-HEAD.md](benchmarks/HEAD-TO-HEAD.md)
+([#170](https://github.com/Sirivasv/bmssp-js/issues/170) tracks harness integration).
 
 The test suite's core contract: for every node, BMSSP's distances must equal the Dijkstra
 oracle's — including on `test/roadNet-CA.txt`, a real road network from SNAP.

--- a/benchmarks/HEAD-TO-HEAD.md
+++ b/benchmarks/HEAD-TO-HEAD.md
@@ -1,0 +1,113 @@
+# BMSSP vs. Dijkstra — the 1.0.0 head-to-head
+
+The question this repo exists to answer: now that the full Algorithm 3 recursion is
+functional (`1.0.0`), **does BMSSP actually beat Dijkstra?** Measured 2026-07-16 on
+node v26.5.0, darwin/arm64, with the seeded generators from
+[`generators.mjs`](./generators.mjs). Two answers, both honest:
+
+- **Wall-clock: no.** Dijkstra wins at every size that fits in memory — but the gap
+  *narrows* as sparse graphs grow (2.5× at 50k nodes → 1.57× at 2M).
+- **Comparison counts — the paper's own metric: yes.** On sparse graphs BMSSP performs
+  **fewer distance comparisons than Dijkstra from about n = 1M**, and the advantage grows
+  with n. The "sorting barrier" is measurably broken; the wall-clock loss is JS constant
+  factors (Map churn, allocation), not algorithmic work.
+
+## Methodology — algorithm time only
+
+Timing starts when the algorithm starts and stops when it finishes. Everything that is
+*loading*, not *algorithm*, sits outside the timed window, identically for both sides:
+
+- Graph construction (edge-array copy, `nodeIDs`, the #45 adjacency map, parameter
+  derivation) happens once, untimed, in the `BMSSP` constructor.
+- The Dijkstra variant used here consumes the **same prebuilt `adjacency` Map** the BMSSP
+  instance uses. (The exported `dijkstra()` builds its own adjacency list inside the call —
+  that would bill graph loading to Dijkstra, so it is excluded.)
+- Timed regions: `graph.calculateShortestPaths(source)` vs. the Dijkstra heap traversal.
+  Median of 3 runs after a warm-up (2 runs for n ≥ 2M). Outputs verified node-by-node
+  identical every run.
+
+## Result 1 — wall-clock by graph shape
+
+| case | n | m | dijkstra ms | bmssp ms | bmssp/dijkstra |
+| --- | --- | --- | --- | --- | --- |
+| sparse d3 n=50k | 50,000 | 150,000 | 36.3 | 90.3 | 2.49× |
+| sparse d3 n=200k | 200,000 | 600,000 | 230.5 | 438.7 | 1.90× |
+| sparse d3 n=1M | 1,000,000 | 3,000,000 | 2,180 | 4,020 | 1.84× |
+| sparse d2 n=1M | 1,000,000 | 2,000,000 | 1,694 | 2,971 | 1.75× |
+| dense d32 n=8k | 8,000 | 256,000 | 16.8 | 48.4 | 2.88× |
+| grid 200x200 | 40,000 | 159,200 | 24.2 | 81.7 | 3.38× |
+| grid 700x700 | 490,000 | 1,957,200 | 513 | 1,362 | 2.65× |
+| chain n=50k | 50,000 | 49,999 | 9.3 | 45.1 | 4.83× |
+| star n=50k | 50,000 | 99,998 | 46.0 | 284.5 | 6.18× |
+| star n=500k | 500,000 | 999,998 | 901 | 61,090 | **67.8×** ([#182](https://github.com/Sirivasv/bmssp-js/issues/182)) |
+
+Dijkstra wins everywhere, and the shapes rank exactly as the theory predicts: sparse
+random graphs (BMSSP's home regime) are closest; dense, chain, and star graphs — where
+there is little sorting to save — are worst. The star blow-up is superlinear and tracked
+as a real defect in [#182](https://github.com/Sirivasv/bmssp-js/issues/182).
+
+## Result 2 — the sparse scaling trend (and a cliff)
+
+Sparse random, out-degree 3, one row per size (`k`, `t`, `topLevel` from
+`deriveParameters()`):
+
+| n | m | topLevel | dijkstra ms | bmssp ms | ratio |
+| --- | --- | --- | --- | --- | --- |
+| 50,000 | 150,000 | 3 | 35 | 89 | 2.54× |
+| 200,000 | 600,000 | 3 | 220 | 366 | 1.67× |
+| 500,000 | 1,500,000 | 3 | 782 | 1,513 | 1.94× |
+| 1,000,000 | 3,000,000 | 3 | 2,000 | 3,398 | 1.70× |
+| 2,000,000 | 6,000,000 | 3 | 5,249 | 8,217 | **1.57×** |
+| 4,000,000 | 12,000,000 | **4** | 11,475 | 57,353 | 5.00× |
+
+The ratio narrows steadily with n — the asymptotic advantage showing through — until
+n = 4M, where `topLevel = ⌈log₂n / t⌉` steps from 3 to 4 and the ratio jumps 3× worse
+(GC/memory pressure at 12M edges may contribute). The cliff is part of
+[#182](https://github.com/Sirivasv/bmssp-js/issues/182).
+
+## Result 3 — comparison counts: the sorting barrier, measured
+
+The paper's claim lives in the **comparison-addition model**: only `+` and `<` on path
+lengths count. So count them. Instrumented copies of the five algorithm modules increment
+a counter at every comparison between two distance values — heap sift comparisons,
+BlockList binary searches, block-split and batch sorts, and every relaxation test — on
+both sides (same counting rules for the Dijkstra variant).
+
+| case | dijkstra cmps | bmssp cmps | bmssp/dijkstra |
+| --- | --- | --- | --- |
+| sparse d3 n=50k | 1,653,644 | 1,957,387 | 1.18× |
+| sparse d3 n=200k | 7,509,518 | 7,568,672 | 1.01× |
+| sparse d3 n=1M | 42,837,183 | 41,292,114 | **0.96×** |
+| sparse d3 n=2M | 90,023,950 | 81,843,075 | **0.91×** |
+| grid 700x700 | 15,269,647 | 19,355,165 | 1.27× |
+
+**On sparse graphs, BMSSP crosses below Dijkstra between n = 200k and n = 1M, and keeps
+pulling away** — with this implementation's shortcuts (array bound index, O(M log M)
+splits, #167) still in place. This is the O(m·log^(2/3) n) vs. O(m + n·log n) separation
+showing up in real operation counts. Dijkstra's comparisons grow with the n·log n sorting
+term; BMSSP replaces that with partial sorting, and past the crossover it simply does
+less ordering work per vertex.
+
+## Reading the two results together
+
+- **Use Dijkstra for wall-clock speed** at any practical size in JS. Its inner loop is a
+  tight array-heap; BMSSP's recursion pays for Map/Set traffic, block bookkeeping, and
+  FindPivots' repeated Bellman-Ford passes on every level.
+- **The algorithm itself is doing less work** (Result 3) exactly where the theory says it
+  should — large sparse graphs. A constant-factor-focused implementation (typed arrays,
+  #167's exact Lemma 3.3 asymptotics, #168's micro-optimizations) is what would move the
+  wall-clock crossover from "astronomical" toward "large".
+- Independent experimental studies of this algorithm report the same shape of outcome:
+  asymptotics visible in operation counts, wall-clock wins rare-to-absent at practical
+  sizes. This repo's numbers are consistent with the literature.
+
+## Reproducing
+
+[#170](https://github.com/Sirivasv/bmssp-js/issues/170) tracks integrating both
+measurements into the `npm run bench` harness (an algorithm-only `bmssp` column in
+`scenarios.bench.mjs` plus an optional comparison-count mode). Until then, the recipe:
+build the `BMSSP` instance untimed; time `calculateShortestPaths(source)` against a
+Dijkstra traversal fed the instance's own `adjacency` Map; for comparison counts, add a
+shared counter to every distance-comparison site in `src/*.mjs` and the Dijkstra variant.
+The raw numbers above are also recorded on
+[#170](https://github.com/Sirivasv/bmssp-js/issues/170#issuecomment-4991749542).

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -2,8 +2,9 @@
 
 Deterministic, dependency-free micro-benchmarks for `bmssp-js`. They exist to
 (1) justify the adjacency map added in issue #45, and (2) stand up the harness
-that will drive the eventual **BMSSP vs. Dijkstra** comparison across graph
-shapes — the "when to use which" question.
+that drives the **BMSSP vs. Dijkstra** comparison across graph shapes — the
+"when to use which" question. The measured 1.0.0 head-to-head (wall-clock *and*
+comparison counts) lives in [`HEAD-TO-HEAD.md`](./HEAD-TO-HEAD.md).
 
 ## Running
 
@@ -26,6 +27,7 @@ warm-up run and the median of several iterations.
 | `adjacency.bench.mjs` | Adjacency map (#45) vs. linear edge scan |
 | `scenarios.bench.mjs` | Construct + Dijkstra timings per graph shape |
 | `run.mjs` | Runs everything, prints the report |
+| `HEAD-TO-HEAD.md` | Measured BMSSP-vs-Dijkstra results (1.0.0), methodology + tables |
 
 ---
 
@@ -53,11 +55,11 @@ whole algorithm. #45 is a prerequisite, not an optimization.
 ## Result 2 — graph-shape scenarios (Dijkstra baseline)
 
 `scenarios.bench.mjs` times construction (which now includes building the #45
-map) and one single-source Dijkstra run per shape. **Today
-`calculateShortestPaths` delegates to the Dijkstra oracle**, so this is a pure
-Dijkstra baseline — deliberately so. When the real BMSSP recursion lands
-(#40–#44) the same harness gains a second column and this table becomes the
-head-to-head.
+map) and one single-source Dijkstra run per shape — the Dijkstra baseline
+column of the head-to-head. The real BMSSP recursion landed in `1.0.0` (#43);
+integrating an algorithm-only `bmssp` column (and an optional comparison-count
+mode) into this harness is tracked in #170. The measured results so far are in
+[`HEAD-TO-HEAD.md`](./HEAD-TO-HEAD.md).
 
 The five shapes are chosen to stress the axes that separate the two algorithms:
 
@@ -71,30 +73,28 @@ The five shapes are chosen to stress the axes that separate the two algorithms:
 
 ---
 
-## When to use which (current guidance)
+## When to use which (measured guidance, 1.0.0)
 
-BMSSP's advantage is **asymptotic and narrow**. Its bound is
-`O(m · log^(2/3) n)` vs. Dijkstra's `O(m + n · log n)`, so it can only win where
-the `n · log n` sorting term actually dominates and `n` is enormous. Concretely:
+BMSSP's advantage is **asymptotic and narrow**: `O(m · log^(2/3) n)` vs.
+Dijkstra's `O(m + n · log n)`. With the full algorithm now functional, the
+question is measured rather than asserted — see
+[`HEAD-TO-HEAD.md`](./HEAD-TO-HEAD.md) for methodology and tables:
 
-- **Use Dijkstra (default, today):** essentially always in practice. It wins on
-  every graph size you can hold in memory in JS, on dense graphs (the `m` term
-  dominates and there is little sorting to save), on small/medium graphs, and
-  wherever you also want vertices emitted in sorted distance order. `bmssp-js`
-  itself uses Dijkstra as the oracle precisely because it is correct and fast.
-- **Where BMSSP is designed to win (theory):** very large, **sparse** directed
-  graphs (`m = O(n)`, the `sparse-random`/`grid` shapes) where the sorting
-  barrier — the `n · log n` term — is the bottleneck and you only need
-  distances, not their order. The crossover `n` is astronomically large;
-  independent studies find real speedups far smaller than theory and often
-  negative at practical sizes.
+- **Use Dijkstra for wall-clock speed:** it wins on every shape and size
+  measured so far (algorithm-only timing, ~1.6–2× faster on large sparse
+  graphs, more on dense/chain/star). `bmssp-js` itself uses Dijkstra as the
+  oracle precisely because it is correct and fast.
+- **BMSSP's asymptotics are real and visible:** on sparse graphs the wall-clock
+  gap narrows steadily with n (2.5× at 50k nodes → 1.57× at 2M), and in the
+  paper's own metric — comparisons between path lengths — **BMSSP does fewer
+  comparisons than Dijkstra from about n = 1M**, improving with size. The
+  sorting barrier is measurably broken; the remaining loss is constant factors.
 - **Shapes that blunt BMSSP's edge:** `dense-random` (relaxation-bound, nothing
-  to save), `chain` (depth, not sorting, is the cost — frontier tricks don't
-  help), and `star` (one node dominates degree; the frontier never gets wide).
+  to save), `chain` (depth, not sorting, is the cost), and `star` (extreme
+  fanout — currently a real performance defect, tracked in #182).
 
 **Bottom line for this repo:** BMSSP is implemented here for **correctness and
-readability** — a faithful, tested rendering of the 2025 result — not to beat
-Dijkstra on wall-clock time. Pick Dijkstra for real workloads; reach for BMSSP
-to study the algorithm or when you have a provably huge sparse instance and only
-need distances. These benchmarks make that trade-off measurable rather than
-asserted, and will show the real crossover (if any) once #43 is done.
+readability** — a faithful, tested rendering of the 2025 result. Pick Dijkstra
+for real workloads; reach for BMSSP to study the algorithm. The measured
+crossover in comparison counts (#170 tracks putting it in the harness) is the
+honest demonstration of the paper's claim.

--- a/benchmarks/scenarios.bench.mjs
+++ b/benchmarks/scenarios.bench.mjs
@@ -4,10 +4,10 @@
 //   - construct: building the BMSSP instance (includes the #45 adjacency map)
 //   - dijkstra: one full single-source shortest-path run from node 0
 //
-// Today calculateShortestPaths delegates to the Dijkstra oracle, so this is a
-// Dijkstra baseline. Once the real BMSSP recursion lands (issues #40-#44), the
-// same harness will contrast BMSSP against this column shape-by-shape — which
-// is exactly where the "when to use which" guidance gets its evidence.
+// This is the Dijkstra baseline column of the head-to-head. The real BMSSP
+// recursion landed in 1.0.0 (#43); adding an algorithm-only bmssp column (and
+// an optional comparison-count mode) is tracked in #170. Measured results so
+// far: benchmarks/HEAD-TO-HEAD.md.
 
 import { BMSSP } from "../src/bmssp.mjs";
 import { dijkstra } from "../src/dijkstra.mjs";


### PR DESCRIPTION
## Summary

Post-1.0.0 reflection: now that the algorithm is functional end-to-end, this PR documents the measured answer to the project's founding question — **does BMSSP beat Dijkstra?** — measuring **algorithm time only** (graph construction/adjacency building excluded for both sides; the Dijkstra variant consumes the same prebuilt adjacency Map the BMSSP instance uses).

**New: [`benchmarks/HEAD-TO-HEAD.md`](../blob/docs/head-to-head-vs-dijkstra/benchmarks/HEAD-TO-HEAD.md)** with methodology + three result tables:

1. **Wall-clock by shape** — Dijkstra wins everywhere; sparse graphs are closest, dense/chain/star worst.
2. **Sparse scaling trend** — the ratio narrows steadily with n (2.54× at 50k → **1.57× at 2M**), then cliffs at 4M where `topLevel` steps 3→4.
3. **Comparison counts (the paper's own metric)** — **BMSSP does fewer distance comparisons than Dijkstra past ~n = 1M sparse (0.91× at 2M)**, and the advantage grows with n. The sorting barrier is measurably broken; the wall-clock gap is JS constant factors, not algorithmic work.

Also refreshed:
- `benchmarks/README.md` + `scenarios.bench.mjs` header — stale pre-#43 wording ("calculateShortestPaths delegates to Dijkstra"); "when to use which" now cites measured facts.
- Root `README.md` — honest note upgraded from "about 2× slower" to the full measured story with the comparison-count crossover.
- Knowledge base `05`/`06`/`07` — performance section, roadmap state, new glossary terms.
- Carries the earlier Phase E bookkeeping commit (`c54ad76`) that branch protection kept off `main`.

Closes no issue; **no version bump** (docs only, per convention).

## Test/lint status

- `npm test`: 86/86 passing (full suite incl. roadNet-CA equivalence, 80s)
- `npm run lint`: clean (Prettier + ESLint)

## Roadmap proposals

Executed in-session with explicit user pre-authorization ("feel free to add/remove/edit"), recorded in `06`:
- **Created #182** — performance cliffs: star-graph superlinear blowup (67.8× at n = 500k) and the `topLevel` 3→4 transition cliff (5× at n = 4M). Milestone 1.2.0.
- **Commented on #170** — full measured baseline + suggested scope (algorithm-only `bmssp` column in `scenarios.bench.mjs` + optional comparison-count mode + star/level-transition coverage).

No further pending proposals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)