### PR TITLE
test(#161): high-volume property/fuzz suite vs the Dijkstra oracle — 1.0.1

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -93,9 +93,10 @@ existing APIs to build on. Ship focused unit tests with every piece. Before Phas
 
 **Run this on the feature branch, before opening any PR. Do not wait to be asked.**
 
-1. **Version bump** (only if the PR closes an issue — see "Version bump & release" below):
+1. **Version bump** (only if the PR closes an issue — see "Version bump & release" below
+   for which of patch/minor/major applies):
    ```bash
-   npm version minor --no-git-tag-version
+   npm version patch --no-git-tag-version
    ```
 2. **Rewrite `05`** to describe the tree **as it will exist once this PR merges** (the
    branch's own tree). Set the `PENDING-PR-BRANCH:` marker to the feature branch name and
@@ -160,11 +161,13 @@ changes deploy Pages via `static.yml` — no action needed for those.)
 hand-edit:
 
 ```bash
-npm version minor --no-git-tag-version   # e.g. 0.18.0 → 0.19.0
+npm version patch --no-git-tag-version   # e.g. 1.0.0 → 1.0.1
 ```
 
-Convention: one **minor** bump (`0.N.0`) per closed issue while pre-1.0, unless the user
-directs otherwise (the `1.0.0` milestone close is the `major` bump).
+Convention (post-1.0, user-confirmed 2026-07-16): one **patch** bump per closed issue; the
+PR that closes a milestone's **last** issue bumps **minor** instead (`major` for the
+`2.0.0` milestone), so released versions land exactly on the milestone names. Deviate only
+when the user directs otherwise.
 
 **Phase 2 — tag + release, only after the user confirms the merge:**
 

--- a/.claude/knowledge/05-codebase-map.md
+++ b/.claude/knowledge/05-codebase-map.md
@@ -1,13 +1,11 @@
 # 05 — Codebase Map (current state)
 
-<!-- BOOKMARK-COMMIT: 909a606ba7b455e6d20211d02cfbaa4778648333 -->
-<!-- PENDING-PR-BRANCH: docs/head-to-head-vs-dijkstra -->
-<!-- Last validated: 2026-07-16, reflection session after the 1.0.0 release. This map
-     describes the tree of the docs/head-to-head-vs-dijkstra branch (docs-only PR: the
-     measured BMSSP-vs-Dijkstra head-to-head in benchmarks/HEAD-TO-HEAD.md + README/KB
-     refresh; no code behavior change, no version bump — closes no issue). The branch also
-     carries the earlier Phase E bookkeeping commit c54ad76 that branch protection kept
-     off origin/main. -->
+<!-- BOOKMARK-COMMIT: 29de94bba02bf5ce6d342ace5a179660ead0a547 -->
+<!-- PENDING-PR-BRANCH: test/161-property-fuzz-suite -->
+<!-- Last validated: 2026-07-16, inside the #161 PR (high-volume property/fuzz suite,
+     version 1.0.0 → 1.0.1). This map describes the tree of the
+     test/161-property-fuzz-suite branch: new test/fuzz.test.mjs (15 tests), no src/
+     changes. Also carries the session-start marker flip after PR #183 merged. -->
 
 Snapshot of what exists in `bmssp-js` today, so you know what to build on vs. what's missing.
 
@@ -65,7 +63,8 @@ src/
   findPivots.mjs          # #44: FindPivots(B, S) — Algorithm 1 frontier shrink
 test/
   main.test.mjs           # Jest tests: constructor, nodeIDs, adjacency, shortestPaths, BMSSP-vs-Dijkstra (roadNet-CA)
-  bmssp.test.mjs          # NEW (#43): 15 recursion tests — params, hand graphs, ties, Lemma 3.1 contract, seeded stress
+  bmssp.test.mjs          # #43: 15 recursion tests — params, hand graphs, ties, Lemma 3.1 contract, seeded stress
+  fuzz.test.mjs           # NEW (#161): 15 high-volume fuzz tests — shapes × weight regimes × multi-source; FUZZ_ROUNDS env multiplier
   blockList.test.mjs      # #42: 18 BlockList tests incl. a seeded random stress test
   heap.test.mjs           # #41: 16 MinHeap tests incl. a seeded stress test vs. a naive queue
   baseCase.test.mjs       # #40: 13 BaseCase tests incl. seeded oracle-comparison stress
@@ -136,6 +135,13 @@ zero-weight edges) occur; all are covered by tests in `test/bmssp.test.mjs`:
    each batch member is settled with an uncapped `baseCase` run bounded by `Bi` — correct,
    just not sublinear. Boundary-tied `Si` members (`d̂ == Bi < B`) re-enter `D` via a regular
    insert rather than being dropped.
+4. **Boundary-tied return (fuzz-found in #161, seed 163066):** through the escape hatch, a
+   bounded **partial** execution can return a vertex whose true distance **equals** the
+   returned `B'` (the paper's Lemma 3.1 states strict `d(v) < B'`, but that strictness
+   assumes Assumption 2.1). Returning it is required — it is complete and the parent must
+   relax out of it; dropping it would re-queue the same batch forever. Callers of
+   `bmssp(l, B, S)` must treat the returned-vertex contract as `d(v) ≤ B'` under ties
+   (the completeness direction stays strict: every `v` with `d(v) < B'` is returned).
 
 **Performance (measured 2026-07-16, Apple Silicon, node v26.5.0 — full data + methodology
 in `benchmarks/HEAD-TO-HEAD.md`):** algorithm-only wall-clock (construction excluded,
@@ -254,7 +260,18 @@ implementation is tested against — and, since #43, no longer part of the BMSSP
 - `test/blockList.test.mjs` (18), `test/heap.test.mjs` (16), `test/baseCase.test.mjs` (13),
   `test/findPivots.test.mjs` (12): per-module contracts incl. seeded stress — see the
   module sections above.
-- Current suite: **86 tests, all passing**, 100% statement coverage.
+- `test/fuzz.test.mjs` (15, NEW in #161): the high-volume property/fuzz suite. Full-map
+  oracle equality across 8 shapes (the 5 benchmark generators reused, plus local random-DAG,
+  disconnected-forest and uniform-multigraph generators; 2 sources per graph; a
+  thousands-of-nodes round), 4 extreme weight regimes (all-zero, zero-or-huge, tiny-int
+  0–2, dyadic floats — multiples of 1/256 so every path sum is exact in float64 and oracle
+  equality stays bit-exact), and direct multi-source `bmssp(topLevel, B, S)` fuzzing:
+  random source sets (1–4) with initial distances, ground truth = per-source Dijkstra
+  oracles (`trueDist(v) = min_s(d0[s] + dist_s(v))`), checking the Lemma 3.1 contract for
+  bounded (incl. boundary-tie `B` choices) and unbounded calls. Every failure message
+  carries the round's seed for reproduction. **`FUZZ_ROUNDS=<x>`** multiplies all round
+  counts (default 1 ≈ 0.5 s; 25 ≈ 5 s, several thousand graphs).
+- Current suite: **101 tests, all passing**, 100% statement coverage.
 
 Graph data: `roadNet-CA.txt` is a large real directed road network; edge weights are assigned
 a random integer in `[1, 1e8]` at load time (so weights differ per run, but BMSSP and Dijkstra
@@ -279,7 +296,8 @@ comparison-count mode); the raw baseline is also on #170 as a comment.
 | Binary min-heap module | `src/heap.mjs` | #41 | ✅ done (PR #177) |
 | Base case (bounded Dijkstra) | `src/baseCase.mjs` | #40 | ✅ done (PR #178) |
 | FindPivots | `src/findPivots.mjs` | #44 | ✅ done (PR #180) |
-| Main `BMSSP(l, B, S)` recursion + `k,t` derivation | `src/bmssp.mjs` | #43 | ✅ done (this PR) — **1.0.0 milestone complete** |
+| Main `BMSSP(l, B, S)` recursion + `k,t` derivation | `src/bmssp.mjs` | #43 | ✅ done (PR #181) — **1.0.0 milestone complete** |
+| Property/fuzz suite vs. the oracle | `test/fuzz.test.mjs` | #161 | ✅ done (this PR, 1.0.1) |
 
-**The 1.0.0 milestone is done once this PR merges.** Next work comes from milestone `1.1.0`
-(correctness hardening) — see [06-milestones-roadmap.md](06-milestones-roadmap.md).
+Milestone `1.1.0` (correctness hardening) is in progress: #161 lands with this PR; next up
+are #162, #163 — see [06-milestones-roadmap.md](06-milestones-roadmap.md).

--- a/.claude/knowledge/06-milestones-roadmap.md
+++ b/.claude/knowledge/06-milestones-roadmap.md
@@ -1,8 +1,8 @@
 # 06 — Milestones Roadmap
 
-<!-- SYNCED-FROM-GITHUB: 2026-07-16 (post-1.0.0 reflection session: head-to-head measured,
-     #182 created + #170 baseline comment posted with explicit user pre-authorization) -->
-<!-- Current package version: 1.0.0 (tagged + released) -->
+<!-- SYNCED-FROM-GITHUB: 2026-07-16 (Phase A of the #161 session: GitHub matched this file
+     exactly; Phase C update inside the test/161-property-fuzz-suite PR) -->
+<!-- Current package version: 1.0.1 (bumped in the #161 PR; 1.0.0 is the latest release) -->
 
 Maps GitHub **milestones** and **issues** (Sirivasv/bmssp-js) to the paper's building blocks,
 with a dependency-aware build order. This is the "intent" side of the knowledge base (what to
@@ -38,29 +38,39 @@ it runs the same Phase C reconciliation directly on `main`.
 
 ## 📋 Roadmap proposals (pending user approval)
 
-_None right now. Phase C writes proposed GitHub edits here (and in the PR body); Phase E
-executes the approved ones — one confirmation each — and clears them from this list._
-_(All five #43-PR proposals — close milestone 1.0.0, tie findings into #163, baseline +
-scope into #170, re-scope #161, partial-coverage note into #162 — were approved and
-executed on GitHub in Phase E, 2026-07-16.)_
-_(2026-07-16 reflection session, user pre-authorized roadmap edits in-conversation: created
-**#182** (performance cliffs: star fanout + topLevel transition, milestone 1.2.0) and
-posted the measured head-to-head baseline + scope suggestion as a comment on **#170**.)_
+From the #161 PR (test/161-property-fuzz-suite), 2026-07-16:
+
+1. **Comment on #163** documenting the fourth tie manifestation, fuzz-found at seed
+   163066: through the stall escape hatch, a bounded **partial** execution can return a
+   vertex whose true distance **equals** the returned `B'` — Lemma 3.1's strict
+   `d(v) < B'` only holds under Assumption 2.1. The honest internal contract under ties
+   is `d(v) ≤ B'` (completeness below `B'` stays strict). A principled tie-break (#163's
+   goal) would restore the strict form.
+2. **Comment on #162** noting partial coverage from #161: the fuzz suite now generates
+   disconnected forests (2–6 components) and checks unreachable-stays-Infinity across
+   random sources and shapes every run. #162's remaining value is small deterministic
+   hand-built edge cases (isolated source, single-node components, empty adjacency) —
+   or closing it as covered if that residue isn't worth an issue.
+
+_(Earlier batches — the five #43-PR proposals and the two reflection-session edits
+(#182 created, #170 baseline comment) — were all approved and executed on GitHub in
+Phase E, 2026-07-16.)_
 
 ---
 
 ## Current state (as synced)
 
-- **Package version:** `1.0.0` — **tagged + released** (2026-07-16; publish.yml fired →
-  npm + Docker Hub). The major bump for closing the `1.0.0` milestone.
+- **Package version:** `1.0.1` — bumped in the in-flight #161 PR (**patch** per the
+  post-1.0 cadence below). Latest release: `1.0.0` (2026-07-16, npm + Docker Hub).
 - **Milestone `1.0.0`:** **closed on GitHub** — all 11 issues done. The algorithm is
   functional end-to-end.
-- **Just merged:** **#43 — `BMSSP(l, B, S)` main recursion (Algorithm 3) — PR #181**
-  (squash commit `909a606`). `calculateShortestPaths` runs the paper's method end-to-end
-  (no Dijkstra delegation); the "BMSSP vs Dijkstra" test passes on the full road network.
-  See `05-codebase-map.md` for the shipped API and the degenerate-tie guards.
-- **Next milestone:** **`1.1.0` — correctness hardening** (6 open issues). Recommended next
-  issue: **#161** (fuzz suite — cheapest way to protect everything else), then #162, #163.
+- **In flight:** **#161 — property/fuzz suite — PR branch `test/161-property-fuzz-suite`**
+  (done pending merge). `test/fuzz.test.mjs`: 8 graph shapes × extreme weight regimes ×
+  multi-source bounded `bmssp()` fuzzing vs. per-source oracles, seeds reported on
+  failure, `FUZZ_ROUNDS` multiplier. Found + documented the fourth tie deviation
+  (boundary-tied return, see proposals above).
+- **Milestone `1.1.0` — correctness hardening** (in progress). After #161: **#162**
+  (edge-case tests — partially covered by the fuzz suite, see proposals), then #163.
 - **2026-07-16 reflection session (post-release):** measured the BMSSP-vs-Dijkstra
   head-to-head, algorithm time only → `benchmarks/HEAD-TO-HEAD.md`. Headlines: Dijkstra
   wins wall-clock everywhere but the sparse ratio narrows with n (1.57× at 2M);
@@ -94,11 +104,11 @@ posted the measured head-to-head baseline + scope suggestion as a comment on **#
 
 Recommended order (cheapest protection first, then the deep work):
 
-| Order | # | Issue | Labels | Notes after #43 |
+| Order | # | Issue | Labels | Notes |
 |---|---|---|---|---|
-| 1 | 161 | Property/fuzz tests: BMSSP vs Dijkstra on random graphs | enhancement · help wanted | Extend the seeded stress already in `test/bmssp.test.mjs` (re-scope noted on the issue) |
-| 2 | 162 | Edge-case tests: disconnected graphs and unreachable nodes | enhancement · help wanted | Partially covered by #43 tests (noted on the issue) |
-| 3 | 163 | Deterministic tie-breaking for equal-length paths (Assumption 2.1) | enhancement · help wanted | Three concrete manifestations found in #43 (documented on the issue) |
+| 1 | 161 | Property/fuzz tests: BMSSP vs Dijkstra on random graphs | enhancement · help wanted | ✅ done pending merge (this PR, 1.0.1) |
+| 2 | 162 | Edge-case tests: disconnected graphs and unreachable nodes | enhancement · help wanted | Largely covered by #43 + #161 fuzz (disconnected forests); see proposals |
+| 3 | 163 | Deterministic tie-breaking for equal-length paths (Assumption 2.1) | enhancement · help wanted | Four concrete manifestations now: three from #43, boundary-tied return from #161 |
 | 4 | 165 | Input validation for the BMSSP constructor | good first issue · help wanted | — |
 | 5 | 164 | Optional constant-degree transform (in/out-degree ≤ 2) | enhancement · help wanted | — |
 | 6 | 166 | JSDoc / API docs for the new modules | documentation · good first issue | `bmssp()` / `deriveParameters()` ship with JSDoc already |
@@ -138,10 +148,12 @@ returning `{ bound, vertices }` sensibly) rather than new algorithm work.
 
 Closing an issue bumps the package version and, after the PR merges, ships a release:
 
-1. **In the PR that closes the issue** — `npm version minor --no-git-tag-version` (keeps
-   `package.json` + `package-lock.json` in sync; historical cadence is a **minor** `0.N.0`
-   bump per issue). **The #43 PR used `npm version major`** — the `1.0.0` milestone close is
-   the major bump, per convention.
+1. **In the PR that closes the issue** — `npm version patch --no-git-tag-version` (keeps
+   `package.json` + `package-lock.json` in sync). **Post-1.0 cadence (user-confirmed
+   2026-07-16, first applied in the #161 PR):** a **patch** bump per closed issue; the PR
+   closing a milestone's **last** issue bumps **minor** (or **major** for `2.0.0`) so
+   released versions land exactly on the milestone names (`1.1.0`, `1.2.0`, `2.0.0`).
+   (Pre-1.0 history: one minor per issue; the #43 PR's `major` closed milestone `1.0.0`.)
 2. **After the user confirms the merge** — tag `main` with the bare version (no `v` prefix)
    and `gh release create` it; publishing the release fires `publish.yml` → **npm + Docker
    Hub**.

--- a/.claude/knowledge/07-glossary.md
+++ b/.claude/knowledge/07-glossary.md
@@ -1,7 +1,7 @@
 # 07 — Glossary
 
-<!-- Updated on: 2026-07-16 (terms last extended in the docs/head-to-head-vs-dijkstra PR:
-     measured head-to-head terms) -->
+<!-- Updated on: 2026-07-16 (terms last extended in the #161 PR: fuzz-suite terms +
+     the boundary-tied-return tie caveat) -->
 
 > **Lifecycle: dynamic — updated in Phase C of every PR.** When a PR introduces new symbols
 > or terms (module names, data-structure fields, paper notation newly used in code), add
@@ -141,6 +141,21 @@ Quick lookup for the symbols and terms used across the paper, the notes, and the
 - **Boundary-tied re-queue** (#43) — an `Si` member left at `d̂ == Bi < B` after the child
   returns re-enters `D` via a regular `insert` (the paper's `[Bi', Bi)` band would silently
   drop it). Tie caveat, #163.
+- **Boundary-tied return** (#161) — under ties, a bounded **partial** `bmssp()` execution
+  can return a vertex with `d(v) == B'` (via the stall escape hatch); Lemma 3.1's strict
+  `d(v) < B'` holds only under Assumption 2.1. Internal contract under ties: returned
+  vertices satisfy `d(v) ≤ B'`, completeness below `B'` stays strict. Tie caveat, #163;
+  fuzz-found at seed 163066.
+- **Fuzz suite** (#161) — `test/fuzz.test.mjs`: high-volume seeded property tests. Full-map
+  oracle equality across 8 graph shapes and 4 extreme weight regimes, plus direct
+  multi-source bounded `bmssp(topLevel, B, S)` checks against per-source Dijkstra oracles
+  (`trueDist(v) = min_s(d0[s] + dist_s(v))`). Failure messages carry the round's seed.
+- **`FUZZ_ROUNDS`** (#161) — environment variable multiplying every fuzz round count
+  (default 1). `FUZZ_ROUNDS=25 npm test -- test/fuzz.test.mjs` runs several thousand
+  graphs in ~5 s.
+- **Dyadic-float regime** (#161) — fuzz weight regime using multiples of `1/256` (dyadic
+  rationals) of bounded magnitude: every path sum is exact in float64, so float-weight
+  testing keeps bit-exact oracle equality instead of needing tolerances.
 - **Benchmark harness** — `benchmarks/` (run via `npm run bench`): seeded graph
   **generators** + a `SCENARIOS` registry (sparse-random / dense-random / grid / chain /
   star), `timeMany` timing, and two benchmarks (adjacency-vs-scan, per-shape Dijkstra). Will

--- a/README.md
+++ b/README.md
@@ -117,7 +117,14 @@ methodology — lives in [benchmarks/HEAD-TO-HEAD.md](benchmarks/HEAD-TO-HEAD.md
 ([#170](https://github.com/Sirivasv/bmssp-js/issues/170) tracks harness integration).
 
 The test suite's core contract: for every node, BMSSP's distances must equal the Dijkstra
-oracle's — including on `test/roadNet-CA.txt`, a real road network from SNAP.
+oracle's — including on `test/roadNet-CA.txt`, a real road network from SNAP. A seeded
+property/fuzz suite (`test/fuzz.test.mjs`) hammers that contract across eight graph shapes
+(sparse/dense random, grids, chains, stars, DAGs, disconnected forests, multigraphs),
+extreme weight regimes (all-zero, mixed zero/huge, exact floats), and direct multi-source
+bounded calls checked against per-source oracles. It runs in `npm test` by default; crank
+the volume with the `FUZZ_ROUNDS` multiplier (e.g. `FUZZ_ROUNDS=25 npm test -- test/fuzz.test.mjs`
+checks several thousand graphs in a few seconds). Failures always report the seed that
+produced them.
 
 ## Roadmap
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bmssp",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bmssp",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MPL-2.0",
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bmssp",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Javascript package implementation of the bmssp algorithm.",
   "main": "index.mjs",
   "keywords": [

--- a/test/fuzz.test.mjs
+++ b/test/fuzz.test.mjs
@@ -1,0 +1,399 @@
+import { describe, test, expect } from "@jest/globals";
+import { BMSSP } from "../src/bmssp.mjs";
+import { dijkstra } from "../src/dijkstra.mjs";
+import {
+  makeRng,
+  sparseRandom,
+  denseRandom,
+  grid,
+  chain,
+  star,
+} from "../benchmarks/generators.mjs";
+
+// High-volume property/fuzz suite (#161): seeded random graphs across many
+// shapes and weight regimes, always validated against the Dijkstra oracle.
+//
+// Every check is labeled with the round's seed (plus shape/size/source), so a
+// red run is reproducible by pinning that seed in a focused test.
+//
+// FUZZ_ROUNDS multiplies every round count (default 1) for high-volume runs:
+//   FUZZ_ROUNDS=25 npm test -- test/fuzz.test.mjs
+
+const ROUNDS = Math.max(1, Math.floor(Number(process.env.FUZZ_ROUNDS) || 1));
+const FUZZ_TIMEOUT = 120_000;
+
+function pickInt(rng, lo, hi) {
+  return lo + Math.floor(rng() * (hi - lo + 1));
+}
+
+function pickSeed(rng) {
+  return Math.floor(rng() * 0x7fffffff);
+}
+
+// Random DAG: every edge is oriented from the lower id to the higher one,
+// so no cycles exist and long dependency chains are common.
+function randomDag(rng, n, m) {
+  const edges = [];
+  for (let i = 0; i < m; i += 1) {
+    const a = Math.floor(rng() * n);
+    const b = Math.floor(rng() * n);
+    if (a === b) continue;
+    edges.push([Math.min(a, b), Math.max(a, b), 1 + Math.floor(rng() * 1e6)]);
+  }
+  if (edges.length === 0) edges.push([0, 1, 1]);
+  return edges;
+}
+
+// Fully random multigraph: self-loops and duplicate edges allowed.
+function uniformRandom(rng, n, m) {
+  const edges = [];
+  for (let i = 0; i < m; i += 1) {
+    edges.push([
+      Math.floor(rng() * n),
+      Math.floor(rng() * n),
+      1 + Math.floor(rng() * 1e6),
+    ]);
+  }
+  return edges;
+}
+
+// Several small components with no edges between them: most of the graph is
+// unreachable from any single source and must stay at Infinity.
+function disconnectedForest(rng, components) {
+  const edges = [];
+  let base = 0;
+  for (let c = 0; c < components; c += 1) {
+    const size = pickInt(rng, 2, 12);
+    for (let u = 0; u < size; u += 1) {
+      const outDegree = pickInt(rng, 1, 2);
+      for (let d = 0; d < outDegree; d += 1) {
+        edges.push([
+          base + u,
+          base + Math.floor(rng() * size),
+          1 + Math.floor(rng() * 1e6),
+        ]);
+      }
+    }
+    base += size;
+  }
+  return edges;
+}
+
+// Keep the topology of `edges` but replace every weight via `regime(rng)`.
+function reweight(edges, rng, regime) {
+  return edges.map(([from, to]) => [from, to, regime(rng)]);
+}
+
+// Deterministically pick an existing node id as the source.
+function pickSource(rng, nodeIDs) {
+  const nodes = [...nodeIDs].sort((a, b) => a - b);
+  return nodes[Math.floor(rng() * nodes.length)];
+}
+
+// Run BMSSP end-to-end and require the full distance map to equal the
+// Dijkstra oracle's. Returns the number of nodes compared. `Object.is`
+// distinguishes nothing extra here (weights are chosen so every sum is an
+// exact float64); it simply makes the intent — bit-exact equality — explicit.
+function checkFullMapAgainstOracle(edges, source, label) {
+  const bmssp = new BMSSP(edges);
+  bmssp.calculateShortestPaths(source);
+  const oracle = dijkstra(bmssp.graph, bmssp.nodeIDs, source);
+  if (bmssp.shortestPaths.size !== oracle.size) {
+    throw new Error(
+      `${label}: map size mismatch: BMSSP ${bmssp.shortestPaths.size}, ` +
+        `Dijkstra ${oracle.size}`,
+    );
+  }
+  for (const [v, d] of oracle) {
+    const got = bmssp.shortestPaths.get(v);
+    if (!Object.is(got, d)) {
+      throw new Error(
+        `${label}: distance mismatch at node ${v}: BMSSP ${got}, Dijkstra ${d}`,
+      );
+    }
+  }
+  return oracle.size;
+}
+
+describe("fuzz: full-map oracle equality across graph shapes", () => {
+  // Star sizes stay modest on purpose: high fanout is a known performance
+  // (not correctness) pathology — see #182.
+  const SHAPES = [
+    [
+      "sparse-random",
+      (rng) => sparseRandom(pickInt(rng, 20, 200), 3, pickSeed(rng)),
+    ],
+    [
+      "dense-random",
+      (rng) => denseRandom(pickInt(rng, 20, 100), 12, pickSeed(rng)),
+    ],
+    ["grid", (rng) => grid(pickInt(rng, 3, 14), pickSeed(rng))],
+    ["chain", (rng) => chain(pickInt(rng, 10, 400), pickSeed(rng))],
+    ["star", (rng) => star(pickInt(rng, 10, 300), pickSeed(rng))],
+    [
+      "dag",
+      (rng) => randomDag(rng, pickInt(rng, 20, 200), pickInt(rng, 40, 600)),
+    ],
+    [
+      "disconnected-forest",
+      (rng) => disconnectedForest(rng, pickInt(rng, 2, 6)),
+    ],
+    [
+      "uniform-random",
+      (rng) => uniformRandom(rng, pickInt(rng, 10, 150), pickInt(rng, 20, 500)),
+    ],
+  ];
+
+  for (const [shape, build] of SHAPES) {
+    test(
+      `${shape}: random sizes and sources keep matching the oracle`,
+      () => {
+        let compared = 0;
+        for (let round = 0; round < 25 * ROUNDS; round += 1) {
+          const seed = 161_000 + round;
+          const rng = makeRng(seed);
+          const edges = build(rng);
+          // Two independent sources per graph exercise re-initialization
+          const bmssp = new BMSSP(edges);
+          for (let s = 0; s < 2; s += 1) {
+            const source = pickSource(rng, bmssp.nodeIDs);
+            const label = `${shape} seed=${seed} n=${bmssp.nodeIDs.size} source=${source}`;
+            compared += checkFullMapAgainstOracle(edges, source, label);
+          }
+        }
+        expect(compared).toBeGreaterThan(0);
+      },
+      FUZZ_TIMEOUT,
+    );
+  }
+
+  test(
+    "larger instances: sparse, grid and DAG in the thousands of nodes",
+    () => {
+      let compared = 0;
+      compared += checkFullMapAgainstOracle(
+        sparseRandom(3000, 3, 1611),
+        0,
+        "large sparse seed=1611",
+      );
+      compared += checkFullMapAgainstOracle(
+        grid(45, 1612),
+        0,
+        "large grid seed=1612",
+      );
+      const rng = makeRng(1613);
+      compared += checkFullMapAgainstOracle(
+        randomDag(rng, 2500, 7500),
+        0,
+        "large dag seed=1613",
+      );
+      expect(compared).toBeGreaterThan(0);
+    },
+    FUZZ_TIMEOUT,
+  );
+});
+
+describe("fuzz: extreme weight regimes", () => {
+  // All regimes produce weights whose path sums are exact in float64
+  // (integers below 2^53, or dyadic rationals — multiples of 1/256 — with
+  // small magnitude), so oracle equality can stay bit-exact even for floats.
+  const REGIMES = [
+    ["all-zero", () => 0],
+    ["zero-or-huge", (rng) => (rng() < 0.5 ? 0 : 1e12)],
+    ["tiny-int", (rng) => Math.floor(rng() * 3)],
+    ["dyadic-float", (rng) => Math.floor(rng() * (1 << 20)) / 256],
+  ];
+
+  // Sizes stay small: zero-weight clusters route BMSSP through its stall
+  // escape hatch, which is deliberately not sublinear.
+  const SMALL_SHAPES = [
+    [
+      "sparse-random",
+      (rng) => sparseRandom(pickInt(rng, 10, 50), 3, pickSeed(rng)),
+    ],
+    ["grid", (rng) => grid(pickInt(rng, 3, 7), pickSeed(rng))],
+    [
+      "uniform-random",
+      (rng) => uniformRandom(rng, pickInt(rng, 8, 40), pickInt(rng, 16, 160)),
+    ],
+  ];
+
+  for (const [regime, weightOf] of REGIMES) {
+    test(
+      `${regime}: every shape keeps matching the oracle`,
+      () => {
+        let compared = 0;
+        for (const [shape, build] of SMALL_SHAPES) {
+          for (let round = 0; round < 15 * ROUNDS; round += 1) {
+            const seed = 162_000 + round;
+            const rng = makeRng(seed);
+            const edges = reweight(build(rng), rng, weightOf);
+            const bmssp = new BMSSP(edges);
+            const source = pickSource(rng, bmssp.nodeIDs);
+            const label = `${regime}/${shape} seed=${seed} n=${bmssp.nodeIDs.size} source=${source}`;
+            compared += checkFullMapAgainstOracle(edges, source, label);
+          }
+        }
+        expect(compared).toBeGreaterThan(0);
+      },
+      FUZZ_TIMEOUT,
+    );
+  }
+});
+
+describe("fuzz: multi-source bounded bmssp() against per-source oracles", () => {
+  // Ground truth for a multi-source call with initial distances d0[s]:
+  // trueDist(v) = min over sources s of (d0[s] + dist_s(v)), i.e. shortest
+  // paths from a virtual super-source. Sources are made complete by fixing
+  // d̂[s] up to trueDist(s) (one source may undercut another), which is
+  // exactly the precondition Lemma 3.1 assumes.
+  function buildMultiSourceCase(seed) {
+    const rng = makeRng(seed);
+    const n = pickInt(rng, 20, 150);
+    const shapePick = rng();
+    let edges;
+    if (shapePick < 0.34) edges = sparseRandom(n, 3, pickSeed(rng));
+    else if (shapePick < 0.67) edges = randomDag(rng, n, n * 3);
+    else edges = uniformRandom(rng, n, n * 3);
+    // A quarter of the rounds use tie-heavy tiny weights (0-2)
+    if (rng() < 0.25) {
+      edges = reweight(edges, rng, () => Math.floor(rng() * 3));
+    }
+
+    const bmssp = new BMSSP(edges);
+    const nodes = [...bmssp.nodeIDs].sort((a, b) => a - b);
+    const sourceCount = pickInt(rng, 1, Math.min(4, nodes.length));
+    const initial = new Map();
+    while (initial.size < sourceCount) {
+      const scale = rng() < 0.5 ? 1000 : 1e7;
+      initial.set(
+        nodes[Math.floor(rng() * nodes.length)],
+        Math.floor(rng() * scale),
+      );
+    }
+
+    const oracles = new Map();
+    for (const s of initial.keys()) {
+      oracles.set(s, dijkstra(bmssp.graph, bmssp.nodeIDs, s));
+    }
+    const trueDist = new Map();
+    for (const v of nodes) {
+      let best = Infinity;
+      for (const [s, d0] of initial) {
+        best = Math.min(best, d0 + oracles.get(s).get(v));
+      }
+      trueDist.set(v, best);
+    }
+
+    bmssp.initializeShortestPaths();
+    for (const s of initial.keys()) {
+      bmssp.shortestPaths.set(s, trueDist.get(s));
+    }
+    return { rng, bmssp, sources: new Set(initial.keys()), trueDist };
+  }
+
+  // Check the Lemma 3.1 contract for a finished bmssp() call.
+  function checkContract(bmssp, trueDist, B, bound, vertices, label) {
+    if (!(bound <= B)) {
+      throw new Error(`${label}: bound ${bound} exceeds B ${B}`);
+    }
+    for (const v of vertices) {
+      if (!Object.is(bmssp.shortestPaths.get(v), trueDist.get(v))) {
+        throw new Error(
+          `${label}: returned vertex ${v} incomplete: d̂ ` +
+            `${bmssp.shortestPaths.get(v)}, true ${trueDist.get(v)}`,
+        );
+      }
+      // The paper's Lemma 3.1 states d(v) < B' for every returned vertex,
+      // but that strictness assumes distinct path lengths (Assumption 2.1).
+      // With ties, the stall escape hatch can settle — and must return —
+      // a vertex tied exactly at the boundary (fuzz-found at seed 163066;
+      // see the tie deviations tracked in #163), so the honest contract
+      // is d(v) <= B'.
+      if (!(trueDist.get(v) <= bound)) {
+        throw new Error(
+          `${label}: returned vertex ${v} at distance ${trueDist.get(v)} ` +
+            `above bound ${bound}`,
+        );
+      }
+    }
+    for (const [v, d] of trueDist) {
+      if (d < bound && !vertices.has(v)) {
+        throw new Error(
+          `${label}: vertex ${v} at distance ${d} below bound ${bound} ` +
+            `missing from U`,
+        );
+      }
+    }
+    for (const [v, dHat] of bmssp.shortestPaths) {
+      if (dHat < trueDist.get(v)) {
+        throw new Error(
+          `${label}: d̂ underestimates at ${v}: ${dHat} < ${trueDist.get(v)}`,
+        );
+      }
+    }
+    return vertices.size;
+  }
+
+  test(
+    "bounded calls satisfy the Lemma 3.1 contract",
+    () => {
+      let returned = 0;
+      for (let round = 0; round < 60 * ROUNDS; round += 1) {
+        const seed = 163_000 + round;
+        const { rng, bmssp, sources, trueDist } = buildMultiSourceCase(seed);
+        const finite = [...trueDist.values()]
+          .filter((d) => d < Infinity)
+          .sort((a, b) => a - b);
+        // B lands mid-distribution; half the rounds put it exactly on an
+        // existing distance so boundary ties are exercised
+        const q = finite[Math.floor(finite.length * (0.3 + rng() * 0.6))];
+        const B = rng() < 0.5 ? q : q + 0.5;
+        const label = `multi-source seed=${seed} |S|=${sources.size} B=${B}`;
+        const { bound, vertices } = bmssp.bmssp(bmssp.topLevel, B, sources);
+        returned += checkContract(bmssp, trueDist, B, bound, vertices, label);
+      }
+      expect(returned).toBeGreaterThan(0);
+    },
+    FUZZ_TIMEOUT,
+  );
+
+  test(
+    "unbounded calls are successful executions settling the reachable set",
+    () => {
+      let returned = 0;
+      for (let round = 0; round < 30 * ROUNDS; round += 1) {
+        const seed = 164_000 + round;
+        const { bmssp, sources, trueDist } = buildMultiSourceCase(seed);
+        const label = `multi-source seed=${seed} |S|=${sources.size} B=Infinity`;
+        const { bound, vertices } = bmssp.bmssp(
+          bmssp.topLevel,
+          Infinity,
+          sources,
+        );
+        if (bound !== Infinity) {
+          throw new Error(`${label}: expected bound Infinity, got ${bound}`);
+        }
+        returned += checkContract(
+          bmssp,
+          trueDist,
+          Infinity,
+          bound,
+          vertices,
+          label,
+        );
+        const reachable = new Set(
+          [...trueDist].filter(([, d]) => d < Infinity).map(([v]) => v),
+        );
+        if (vertices.size !== reachable.size) {
+          throw new Error(
+            `${label}: settled ${vertices.size} vertices, ` +
+              `reachable set has ${reachable.size}`,
+          );
+        }
+      }
+      expect(returned).toBeGreaterThan(0);
+    },
+    FUZZ_TIMEOUT,
+  );
+});


### PR DESCRIPTION
Closes #161

## Summary

Adds `test/fuzz.test.mjs` — the dedicated high-volume seeded property/fuzz suite the re-scoped #161 called for. 15 new tests (suite total: 101, 100% statement coverage), all validated against the Dijkstra oracle:

- **8 graph shapes**, full-distance-map equality with 2 independent sources per graph: the five `benchmarks/generators.mjs` shapes (sparse, dense, grid, chain, star) reused as the issue requested, plus new local generators for random DAGs, disconnected forests, and uniform multigraphs (self-loops/duplicate edges); one thousands-of-nodes round (sparse 3000, grid 45², DAG 2500).
- **4 extreme weight regimes**: all-zero, mixed zero-or-huge (1e12), tiny-int (0–2, tie-heavy), and dyadic floats (multiples of 1/256, so every path sum is exact in float64 and oracle equality stays bit-exact).
- **Direct multi-source `bmssp(topLevel, B, S)` fuzzing**: random source sets (1–4) with random initial distances; ground truth from per-source Dijkstra oracles (`trueDist(v) = min_s(d0[s] + dist_s(v))`); Lemma 3.1 contract checked for bounded calls (including B placed exactly on an existing distance to force boundary ties) and unbounded calls (successful execution settling exactly the reachable set).
- **Reproducibility**: every failure message carries the round's seed/shape/size/source. `FUZZ_ROUNDS=<x>` multiplies all round counts (default ≈0.5 s in `npm test`; `FUZZ_ROUNDS=25` ≈ 5 s, several thousand graphs).

**Fuzz finding (seed 163066), documented in KB 05/07:** under Assumption 2.1 violations, a bounded *partial* execution can return a vertex whose true distance **equals** the returned `B'` — the stall escape hatch must return it (it's complete; the parent has to relax out of it, and dropping it would re-queue the batch forever). Lemma 3.1's strict `d(v) < B'` holds only with distinct path lengths; the honest internal contract under ties is `d(v) ≤ B'`, with completeness below `B'` still strict. No implementation change needed — this is the fourth documented #163 tie manifestation.

**Version:** 1.0.0 → 1.0.1 — first application of the user-confirmed post-1.0 cadence (patch per closed issue; minor lands with the PR closing a milestone's last issue). Recorded in CLAUDE.md and KB 06.

**KB sync (Phase C):** 05 (fuzz suite, tie caveat 4, 101 tests, marker flip after PR #183), 06 (state + proposals + cadence), 07 (new terms), README (fuzz suite in Development).

## Test / lint status

- `npm test`: 101/101 passing, 100% statement coverage (also stress-verified at `FUZZ_ROUNDS=25`)
- `npm run lint`: clean

## Roadmap proposals

1. **Comment on #163**: document the fourth tie manifestation (boundary-tied return, fuzz seed 163066; Lemma 3.1's strict `<` is Assumption-2.1-only; a principled tie-break would restore it).
2. **Comment on #162**: note partial coverage from this PR (disconnected forests + unreachable-stays-Infinity now fuzzed every run); remaining value is small deterministic hand-built edge cases — or close as covered if that residue isn't worth an issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)