### PR TITLE
chore: remove roadNet-CA.txt — seeded generated graphs take over

### DIFF
--- a/.claude/knowledge/05-codebase-map.md
+++ b/.claude/knowledge/05-codebase-map.md
@@ -1,11 +1,12 @@
 # 05 — Codebase Map (current state)
 
-<!-- BOOKMARK-COMMIT: 29de94bba02bf5ce6d342ace5a179660ead0a547 -->
-<!-- PENDING-PR-BRANCH: test/161-property-fuzz-suite -->
-<!-- Last validated: 2026-07-16, inside the #161 PR (high-volume property/fuzz suite,
-     version 1.0.0 → 1.0.1). This map describes the tree of the
-     test/161-property-fuzz-suite branch: new test/fuzz.test.mjs (15 tests), no src/
-     changes. Also carries the session-start marker flip after PR #183 merged. -->
+<!-- BOOKMARK-COMMIT: b59f8860c3e900acdd26374e16cc4c16852e83f4 -->
+<!-- PENDING-PR-BRANCH: chore/remove-roadnet-ca -->
+<!-- Last validated: 2026-07-16, inside the roadNet-CA removal PR (no issue, no version
+     bump). This map describes the tree of the chore/remove-roadnet-ca branch:
+     test/roadNet-CA.txt deleted, main.test.mjs rewritten on a seeded 10k sparse graph,
+     fuzz.test.mjs gains seeded scale runs (+FUZZ_XL). No src/ changes. Also carries the
+     session-start marker flip after PR #184 (#161 fuzz suite) merged. -->
 
 Snapshot of what exists in `bmssp-js` today, so you know what to build on vs. what's missing.
 
@@ -62,15 +63,14 @@ src/
   baseCase.mjs            # #40: BaseCase(B, S) — Algorithm 2 bounded mini-Dijkstra
   findPivots.mjs          # #44: FindPivots(B, S) — Algorithm 1 frontier shrink
 test/
-  main.test.mjs           # Jest tests: constructor, nodeIDs, adjacency, shortestPaths, BMSSP-vs-Dijkstra (roadNet-CA)
+  main.test.mjs           # Jest tests: constructor, nodeIDs, adjacency, shortestPaths, BMSSP-vs-Dijkstra (seeded 10k sparse)
   bmssp.test.mjs          # #43: 15 recursion tests — params, hand graphs, ties, Lemma 3.1 contract, seeded stress
-  fuzz.test.mjs           # NEW (#161): 15 high-volume fuzz tests — shapes × weight regimes × multi-source; FUZZ_ROUNDS env multiplier
+  fuzz.test.mjs           # #161: 18 high-volume fuzz tests — shapes × weight regimes × multi-source × seeded scale; FUZZ_ROUNDS / FUZZ_XL env vars
   blockList.test.mjs      # #42: 18 BlockList tests incl. a seeded random stress test
   heap.test.mjs           # #41: 16 MinHeap tests incl. a seeded stress test vs. a naive queue
   baseCase.test.mjs       # #40: 13 BaseCase tests incl. seeded oracle-comparison stress
   findPivots.test.mjs     # #44: 12 FindPivots tests incl. two seeded oracle stress tests
-  roadNet-CA.txt          # real road-network edge list (SNAP roadNet-CA), weights randomized at load
-  README.md
+  README.md               # test-suite principles (everything seeded, no data files) + file map
 benchmarks/               # dependency-free benchmark harness, `npm run bench`
   generators.mjs          #   seeded graph builders + SCENARIOS registry (sparse/dense/grid/chain/star)
   bench-util.mjs          #   timing (timeMany) + markdown-table helpers
@@ -146,13 +146,13 @@ zero-weight edges) occur; all are covered by tests in `test/bmssp.test.mjs`:
 **Performance (measured 2026-07-16, Apple Silicon, node v26.5.0 — full data + methodology
 in `benchmarks/HEAD-TO-HEAD.md`):** algorithm-only wall-clock (construction excluded,
 Dijkstra fed the same prebuilt adjacency): Dijkstra wins every shape/size; sparse-graph
-ratio narrows with n (2.54× at 50k → **1.57× at 2M**), roadNet-CA ≈2.1×. **Comparison
+ratio narrows with n (2.54× at 50k → **1.57× at 2M**). **Comparison
 counts (the paper's metric) cross over:** BMSSP does fewer distance comparisons than
 Dijkstra past ~n = 1M sparse (0.96× at 1M, **0.91× at 2M**). Two measured pathologies,
 tracked in **#182**: star graphs blow up superlinearly (67.8× at n = 500k) and the ratio
-cliffs to 5× at n = 4M where `topLevel` steps 3→4. The two roadNet tests in
-`main.test.mjs` carry explicit 120 s Jest timeouts (the default 5 s is not enough for a
-real BMSSP run under CI).
+cliffs to 5× at n = 4M where `topLevel` steps 3→4. Note `topLevel` is **3 from n = 10k
+all the way to 2M** — scale tests buy volume/memory pressure, not recursion depth. The
+default suite runs in ~3 s; the opt-in `FUZZ_XL=1` 2M-node round takes ~30 s.
 
 ## `src/blockList.mjs` — Lemma 3.3 structure `D` (#42)
 
@@ -247,9 +247,11 @@ implementation is tested against — and, since #43, no longer part of the BMSSP
 ## Tests — the contract
 
 - `test/main.test.mjs` (12): constructor/nodeIDs/adjacency/shortestPaths contracts, plus the
-  **key one** — "BMSSP vs Dijkstra" on roadNet-CA: for a fixed source, `myBMSSP.shortestPaths`
-  must equal `dijkstra(...)` for every node. **Now exercises the real algorithm** (120 s
-  timeouts on the two tests that run it on the road network).
+  **key one** — "BMSSP vs Dijkstra" on a **seeded 10k-node sparse graph** (`sparseRandom(10_000,
+  3, 1601)`, already `topLevel` 3): for a fixed source, `myBMSSP.shortestPaths` must equal
+  `dijkstra(...)` for every node. (Until 2026-07-16 this ran on `roadNet-CA.txt`, an 87 MB
+  SNAP road network with unseeded random weights — removed: irreproducible failures, ~71 s
+  of every run, coverage superseded by the seeded fuzz + scale suite.)
 - `test/bmssp.test.mjs` (15, NEW in #43): parameter derivation (clamps, paper formulas,
   `k·2^(topLevel·t) ≥ n` guard), end-to-end hand-built graphs (README example, multi-hop vs
   direct, unreachable ⇒ Infinity, self-loop, source switch), degenerate ties (zero-weight
@@ -260,22 +262,21 @@ implementation is tested against — and, since #43, no longer part of the BMSSP
 - `test/blockList.test.mjs` (18), `test/heap.test.mjs` (16), `test/baseCase.test.mjs` (13),
   `test/findPivots.test.mjs` (12): per-module contracts incl. seeded stress — see the
   module sections above.
-- `test/fuzz.test.mjs` (15, NEW in #161): the high-volume property/fuzz suite. Full-map
-  oracle equality across 8 shapes (the 5 benchmark generators reused, plus local random-DAG,
-  disconnected-forest and uniform-multigraph generators; 2 sources per graph; a
-  thousands-of-nodes round), 4 extreme weight regimes (all-zero, zero-or-huge, tiny-int
-  0–2, dyadic floats — multiples of 1/256 so every path sum is exact in float64 and oracle
-  equality stays bit-exact), and direct multi-source `bmssp(topLevel, B, S)` fuzzing:
-  random source sets (1–4) with initial distances, ground truth = per-source Dijkstra
+- `test/fuzz.test.mjs` (18, #161 + scale runs added 2026-07-16): the high-volume
+  property/fuzz suite. Full-map oracle equality across 8 shapes (the 5 benchmark generators
+  reused, plus local random-DAG, disconnected-forest and uniform-multigraph generators; 2
+  sources per graph; a thousands-of-nodes round), 4 extreme weight regimes (all-zero,
+  zero-or-huge, tiny-int 0–2, dyadic floats — multiples of 1/256 so every path sum is exact
+  in float64 and oracle equality stays bit-exact), direct multi-source `bmssp(topLevel, B, S)`
+  fuzzing: random source sets (1–4) with initial distances, ground truth = per-source Dijkstra
   oracles (`trueDist(v) = min_s(d0[s] + dist_s(v))`), checking the Lemma 3.1 contract for
-  bounded (incl. boundary-tie `B` choices) and unbounded calls. Every failure message
-  carries the round's seed for reproduction. **`FUZZ_ROUNDS=<x>`** multiplies all round
-  counts (default 1 ≈ 0.5 s; 25 ≈ 5 s, several thousand graphs).
-- Current suite: **101 tests, all passing**, 100% statement coverage.
-
-Graph data: `roadNet-CA.txt` is a large real directed road network; edge weights are assigned
-a random integer in `[1, 1e8]` at load time (so weights differ per run, but BMSSP and Dijkstra
-see the same array within a run).
+  bounded (incl. boundary-tie `B` choices) and unbounded calls — plus **seeded scale runs**:
+  sparse n = 150k (asserted `topLevel` 3) and grid 300×300 in the default suite, and an
+  **opt-in `FUZZ_XL=1` sparse n = 2M round** (~30 s, `test.skip` otherwise). Every failure
+  message carries the round's seed for reproduction. **`FUZZ_ROUNDS=<x>`** multiplies all
+  round counts (default 1 ≈ 0.5 s; 25 ≈ 5 s, several thousand graphs).
+- Current suite: **104 tests — 103 passing + 1 XL skipped by default**, 100% statement
+  coverage, ~3 s wall-clock. No graph data files: every test graph is generated from a seed.
 
 ## Benchmarks (`benchmarks/`, `npm run bench`)
 

--- a/.claude/knowledge/06-milestones-roadmap.md
+++ b/.claude/knowledge/06-milestones-roadmap.md
@@ -1,8 +1,9 @@
 # 06 — Milestones Roadmap
 
-<!-- SYNCED-FROM-GITHUB: 2026-07-16 (Phase A of the #161 session: GitHub matched this file
-     exactly; Phase C update inside the test/161-property-fuzz-suite PR) -->
-<!-- Current package version: 1.0.1 (bumped in the #161 PR; 1.0.0 is the latest release) -->
+<!-- SYNCED-FROM-GITHUB: 2026-07-16 (Phase A of the roadNet-CA removal session: GitHub
+     matched this file; Phase C update inside the chore/remove-roadnet-ca PR) -->
+<!-- Current package version: 1.0.1 (released 2026-07-16; the roadNet-CA removal PR closes
+     no issue, so no bump) -->
 
 Maps GitHub **milestones** and **issues** (Sirivasv/bmssp-js) to the paper's building blocks,
 with a dependency-aware build order. This is the "intent" side of the knowledge base (what to
@@ -38,37 +39,49 @@ it runs the same Phase C reconciliation directly on `main`.
 
 ## 📋 Roadmap proposals (pending user approval)
 
-From the #161 PR (test/161-property-fuzz-suite), 2026-07-16:
+From the roadNet-CA removal PR (chore/remove-roadnet-ca), 2026-07-16:
 
-1. **Comment on #163** documenting the fourth tie manifestation, fuzz-found at seed
-   163066: through the stall escape hatch, a bounded **partial** execution can return a
-   vertex whose true distance **equals** the returned `B'` — Lemma 3.1's strict
-   `d(v) < B'` only holds under Assumption 2.1. The honest internal contract under ties
-   is `d(v) ≤ B'` (completeness below `B'` stays strict). A principled tie-break (#163's
-   goal) would restore the strict form.
-2. **Comment on #162** noting partial coverage from #161: the fuzz suite now generates
-   disconnected forests (2–6 components) and checks unreachable-stays-Infinity across
-   random sources and shapes every run. #162's remaining value is small deterministic
-   hand-built edge cases (isolated source, single-node components, empty adjacency) —
-   or closing it as covered if that residue isn't worth an issue.
+1. **Comment on closed #24** (datasets research, roadNet-CA) noting the dataset was
+   removed on 2026-07-16 and why: unseeded random weights made failures irreproducible,
+   the two tests cost ~71 s of every `npm test` run, and the seeded fuzz + scale suite
+   (#161 + this PR) supersedes its coverage — the file also accounted for ~95% of clone
+   size, purged from history after the merge.
 
-_(Earlier batches — the five #43-PR proposals and the two reflection-session edits
-(#182 created, #170 baseline comment) — were all approved and executed on GitHub in
-Phase E, 2026-07-16.)_
+_(Both #161-PR proposals were approved and executed in Phase E on 2026-07-16: the fourth
+tie manifestation posted on **#163**, and the partial-coverage note posted on **#162**,
+which stays open re-scoped to deterministic hand-built edge cases.)_
+
+## ⚠️ Pending post-merge operation (2026-07-16) — git history purge
+
+After the `chore/remove-roadnet-ca` PR merges, the user has **already directed** (this
+session) a history rewrite to purge the 87 MB `test/roadNet-CA.txt` blob (~95% of the
+17.7 MiB pack; clones drop to <1 MiB):
+
+1. Requires `git-filter-repo` (install if missing) and branch protection on `main`
+   temporarily lifted (force-push).
+2. `git filter-repo --path test/roadNet-CA.txt --invert-paths` on a fresh clone —
+   rewrites **all SHAs** (the blob dates to the first commit) and migrates tags.
+3. Force-push `main` + all tags; verify the GitHub Releases (0.19.0…1.0.1) still attach
+   to their re-pointed tags; **do not** let this retrigger `publish.yml` (it only fires
+   on `release: published` — tag pushes are safe).
+4. `05`'s `BOOKMARK-COMMIT` will then be unresolvable — next session re-stamps it to the
+   rewritten HEAD (the bookmark procedure's step 3 covers this).
+5. Confirm with the user immediately before every force-push. Remove this section once done.
 
 ---
 
 ## Current state (as synced)
 
-- **Package version:** `1.0.1` — bumped in the in-flight #161 PR (**patch** per the
-  post-1.0 cadence below). Latest release: `1.0.0` (2026-07-16, npm + Docker Hub).
+- **Package version:** `1.0.1` — released 2026-07-16 (npm + Docker Hub), tag matches.
 - **Milestone `1.0.0`:** **closed on GitHub** — all 11 issues done. The algorithm is
   functional end-to-end.
-- **In flight:** **#161 — property/fuzz suite — PR branch `test/161-property-fuzz-suite`**
-  (done pending merge). `test/fuzz.test.mjs`: 8 graph shapes × extreme weight regimes ×
-  multi-source bounded `bmssp()` fuzzing vs. per-source oracles, seeds reported on
-  failure, `FUZZ_ROUNDS` multiplier. Found + documented the fourth tie deviation
-  (boundary-tied return, see proposals above).
+- **#161 property/fuzz suite:** merged (PR #184) and released as `1.0.1`.
+- **In flight:** **roadNet-CA removal — PR branch `chore/remove-roadnet-ca`** (no issue,
+  no version bump; user-directed 2026-07-16). Deletes `test/roadNet-CA.txt` (87 MB,
+  unseeded weights, ~71 s of every test run), rewrites `main.test.mjs` on a seeded 10k
+  sparse graph, adds seeded scale runs to `fuzz.test.mjs` (150k sparse + 300×300 grid
+  default, `FUZZ_XL=1` → 2M nodes). Suite: ~75 s → ~3 s. **A history purge follows the
+  merge — see the pending-operation section above.**
 - **Milestone `1.1.0` — correctness hardening** (in progress). After #161: **#162**
   (edge-case tests — partially covered by the fuzz suite, see proposals), then #163.
 - **2026-07-16 reflection session (post-release):** measured the BMSSP-vs-Dijkstra
@@ -106,7 +119,7 @@ Recommended order (cheapest protection first, then the deep work):
 
 | Order | # | Issue | Labels | Notes |
 |---|---|---|---|---|
-| 1 | 161 | Property/fuzz tests: BMSSP vs Dijkstra on random graphs | enhancement · help wanted | ✅ done pending merge (this PR, 1.0.1) |
+| 1 | 161 | Property/fuzz tests: BMSSP vs Dijkstra on random graphs | enhancement · help wanted | ✅ merged (PR #184, 1.0.1) |
 | 2 | 162 | Edge-case tests: disconnected graphs and unreachable nodes | enhancement · help wanted | Largely covered by #43 + #161 fuzz (disconnected forests); see proposals |
 | 3 | 163 | Deterministic tie-breaking for equal-length paths (Assumption 2.1) | enhancement · help wanted | Four concrete manifestations now: three from #43, boundary-tied return from #161 |
 | 4 | 165 | Input validation for the BMSSP constructor | good first issue · help wanted | — |
@@ -162,8 +175,9 @@ Full procedure + exact commands live in **`../CLAUDE.md` → "Version bump & rel
 release step is an outward-facing publish and is **gated on explicit user confirmation**.
 
 ## Testing tips
-- Small hand-built graphs with known distances for unit tests; `roadNet-CA.txt` for the big
-  equivalence test (120 s Jest timeouts on the two tests that run BMSSP on it).
+- Small hand-built graphs with known distances for unit tests; seeded generated graphs
+  (`benchmarks/generators.mjs`) for equivalence/scale tests — **never unseeded randomness,
+  never data files**. `FUZZ_XL=1` opts into the 2M-node round (~30 s).
 - Any `bmssp(l, B, S)` call's completed vertices+distances must equal
   `{ v : d_dijkstra(v) < B', shortest path visits S }` — `test/bmssp.test.mjs` has the
   pattern ("recursion contract" describe block).

--- a/.claude/knowledge/07-glossary.md
+++ b/.claude/knowledge/07-glossary.md
@@ -1,7 +1,7 @@
 # 07 — Glossary
 
-<!-- Updated on: 2026-07-16 (terms last extended in the #161 PR: fuzz-suite terms +
-     the boundary-tied-return tie caveat) -->
+<!-- Updated on: 2026-07-16 (terms last extended in the roadNet-CA removal PR: FUZZ_XL,
+     seeded scale runs; roadNet-CA itself removed) -->
 
 > **Lifecycle: dynamic — updated in Phase C of every PR.** When a PR introduces new symbols
 > or terms (module names, data-structure fields, paper notation newly used in code), add
@@ -153,6 +153,11 @@ Quick lookup for the symbols and terms used across the paper, the notes, and the
 - **`FUZZ_ROUNDS`** (#161) — environment variable multiplying every fuzz round count
   (default 1). `FUZZ_ROUNDS=25 npm test -- test/fuzz.test.mjs` runs several thousand
   graphs in ~5 s.
+- **`FUZZ_XL`** — environment variable opting into the seeded 2M-node sparse scale round
+  in `test/fuzz.test.mjs` (~30 s; `test.skip` otherwise). With the default-suite scale
+  runs (sparse 150k, grid 300×300) it replaced `roadNet-CA.txt` — the 87 MB SNAP road
+  network removed 2026-07-16 (unseeded weights, ~71 s per run). Note: `topLevel` is 3
+  from n = 10k to 2M, so scale rounds buy volume and memory pressure, not depth.
 - **Dyadic-float regime** (#161) — fuzz weight regime using multiples of `1/256` (dyadic
   rationals) of bounded magnitude: every path sum is exact in float64, so float-weight
   testing keeps bit-exact oracle equality instead of needing tolerances.

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ first to beat Dijkstra's O(m + n·log n) bound on sparse directed graphs.
 
 **The algorithm is functional end-to-end as of `1.0.0`** 🎉 — `calculateShortestPaths()`
 computes distances via the paper's method (FindPivots → block list → recursive BMSSP with
-the bounded base case), validated node-by-node against a Dijkstra oracle, including on a
-real 2-million-node road network. The project was built piece by piece against the paper,
+the bounded base case), validated node-by-node against a Dijkstra oracle on thousands of
+seeded graphs — up to 2 million nodes. The project was built piece by piece against the paper,
 with every building block shipped, tested, and released individually:
 
 | Building block (paper) | Where | Status |
@@ -107,7 +107,7 @@ Other image versions are on [Docker Hub](https://hub.docker.com/r/sirivasv/bmssp
 
 ```bash
 npm install
-npm test          # Jest suite, incl. BMSSP-vs-Dijkstra equivalence on a real road network
+npm test          # Jest suite — every graph seeded, every failure reproducible (~3 s)
 npm run lint      # Prettier + ESLint
 npm run bench     # seeded micro-benchmarks (see benchmarks/README.md)
 ```
@@ -117,14 +117,14 @@ methodology — lives in [benchmarks/HEAD-TO-HEAD.md](benchmarks/HEAD-TO-HEAD.md
 ([#170](https://github.com/Sirivasv/bmssp-js/issues/170) tracks harness integration).
 
 The test suite's core contract: for every node, BMSSP's distances must equal the Dijkstra
-oracle's — including on `test/roadNet-CA.txt`, a real road network from SNAP. A seeded
-property/fuzz suite (`test/fuzz.test.mjs`) hammers that contract across eight graph shapes
-(sparse/dense random, grids, chains, stars, DAGs, disconnected forests, multigraphs),
-extreme weight regimes (all-zero, mixed zero/huge, exact floats), and direct multi-source
-bounded calls checked against per-source oracles. It runs in `npm test` by default; crank
-the volume with the `FUZZ_ROUNDS` multiplier (e.g. `FUZZ_ROUNDS=25 npm test -- test/fuzz.test.mjs`
-checks several thousand graphs in a few seconds). Failures always report the seed that
-produced them.
+oracle's. A seeded property/fuzz suite (`test/fuzz.test.mjs`) hammers that contract across
+eight graph shapes (sparse/dense random, grids, chains, stars, DAGs, disconnected forests,
+multigraphs), extreme weight regimes (all-zero, mixed zero/huge, exact floats), direct
+multi-source bounded calls checked against per-source oracles, and seeded scale runs up to
+150k nodes. It runs in `npm test` by default; crank the volume with the `FUZZ_ROUNDS`
+multiplier (e.g. `FUZZ_ROUNDS=25 npm test -- test/fuzz.test.mjs` checks several thousand
+graphs in a few seconds), and set `FUZZ_XL=1` for an additional 2-million-node round
+(~30 s). Failures always report the seed that produced them.
 
 ## Roadmap
 

--- a/test/README.md
+++ b/test/README.md
@@ -1,67 +1,42 @@
 # Test Suite
 
-This directory contains the comprehensive test suite for the BMSSP (Bidirectional Multi-Source Shortest Path) JavaScript implementation.
+Jest tests for the BMSSP (**B**ounded **M**ulti-**S**ource **S**hortest **P**ath)
+implementation. The core contract everywhere: **for every node, BMSSP's distance must
+equal the Dijkstra oracle's** (`src/dijkstra.mjs`).
 
-## Overview
+## Principles
 
-The test suite includes:
-- Unit tests for core algorithm functions
-- Code coverage reports
+- **Everything is seeded.** No test uses unseeded randomness; every generated graph comes
+  from a fixed seed or a derived one that is printed in the failure message, so any red
+  run is reproducible by pinning that seed.
+- **No data files.** Graphs are generated on the fly by the seeded builders in
+  [`../benchmarks/generators.mjs`](../benchmarks/generators.mjs) (plus a few local
+  generators in `fuzz.test.mjs`). The suite runs in a few seconds.
 
-## Test Structure
+## Files
 
-### Unit Tests
-- **Location**: `main.test.mjs`
-- **Framework**: Jest
-- **Coverage**: Core algorithm functions, utility methods, error handling
+| File | Covers |
+| --- | --- |
+| `main.test.mjs` | `BMSSP` class contracts (constructor, `nodeIDs`, adjacency, `shortestPaths`, error handling) + full-map BMSSP-vs-Dijkstra equality on a seeded 10k-node sparse graph |
+| `bmssp.test.mjs` | Algorithm 3 recursion: parameter derivation, hand-built graphs, degenerate ties, the Lemma 3.1 bounded-call contract, seeded stress |
+| `fuzz.test.mjs` | High-volume property/fuzz suite (#161): 8 graph shapes × extreme weight regimes × multi-source bounded calls vs. per-source oracles, plus seeded scale runs (150k-node sparse, 300×300 grid, opt-in 2M) |
+| `findPivots.test.mjs` | Algorithm 1 (`FindPivots`) contracts incl. seeded oracle stress |
+| `baseCase.test.mjs` | Algorithm 2 (`BaseCase`) bounded mini-Dijkstra contracts |
+| `blockList.test.mjs` | Lemma 3.3 block-based partial-sort structure `D` |
+| `heap.test.mjs` | Indexed binary min-heap used by `BaseCase` |
 
-## Datasets
+## Running
 
-### California Road Network
-- **File**: `roadNet-CA.txt`
-- **Source**: [Stanford Network Analysis Project (SNAP)](https://snap.stanford.edu/data/roadNet-CA.html)
-- **Type**: Directed graph (each unordered pair of nodes is saved once)
-- **Statistics**:
-  - Nodes: 1,965,206
-  - Edges: 5,533,214
-- **Format**: Tab-separated values
-  - Column 1: FromNodeId
-  - Column 2: ToNodeId
-- **Description**: Large-scale road network from California state, ideal for testing shortest path algorithms on realistic transportation graphs.
+```bash
+npm test                                        # full suite + coverage (~3 s)
+FUZZ_ROUNDS=25 npm test -- test/fuzz.test.mjs   # multiply every fuzz round count
+FUZZ_XL=1 npm test -- test/fuzz.test.mjs        # add the 2M-node scale round (~30 s)
+```
 
-## Test Categories
+## Contributing to tests
 
-### 1. Core Algorithm Tests
-- BMSSP algorithm correctness
-- Bidirectional search functionality
-- Multi-source initialization
-- Path reconstruction
-
-### 2. Edge Cases
-- Empty graphs
-- Single node graphs
-- Disconnected components
-- Negative weights (if supported)
-
-### 3. Performance Tests
-- Large dataset processing
-- Memory efficiency
-- Scalability with different graph sizes
-
-## Benchmarking
-
-Performance benchmarks compare against standard Dijkstra's algorithm
-
-Metrics to be tracked:
-- Execution time
-- Memory consumption
-- Accuracy of results
-
-## Contributing to Tests
-
-When adding new tests:
-1. Follow existing naming conventions
-2. Include both positive and negative test cases
-3. Add performance tests for new algorithms
-4. Update documentation for new datasets
-5. Ensure tests pass linting requirements
+1. Seed everything; put the seed in the failure message.
+2. Include both positive and negative cases.
+3. New graph shapes belong in `benchmarks/generators.mjs` if benchmarks can reuse them,
+   or as local generators in `fuzz.test.mjs` if not.
+4. Ensure `npm run lint` passes.

--- a/test/fuzz.test.mjs
+++ b/test/fuzz.test.mjs
@@ -18,6 +18,8 @@ import {
 //
 // FUZZ_ROUNDS multiplies every round count (default 1) for high-volume runs:
 //   FUZZ_ROUNDS=25 npm test -- test/fuzz.test.mjs
+// FUZZ_XL=1 additionally runs the 2M-node seeded scale round (~30 s):
+//   FUZZ_XL=1 npm test -- test/fuzz.test.mjs
 
 const ROUNDS = Math.max(1, Math.floor(Number(process.env.FUZZ_ROUNDS) || 1));
 const FUZZ_TIMEOUT = 120_000;
@@ -239,6 +241,43 @@ describe("fuzz: extreme weight regimes", () => {
       FUZZ_TIMEOUT,
     );
   }
+});
+
+describe("fuzz: seeded scale runs", () => {
+  // These replace the old roadNet-CA.txt fixture (a real 2M-node road
+  // network with unseeded random weights): same sparse m = O(n) regime, but
+  // reproducible and generated on the fly. Recursion depth is NOT what scale
+  // buys here — topLevel is 3 from n = 10k all the way to 2M (the 3 → 4 step
+  // sits near n = 4M, see #182) — the value is volume: block-list churn,
+  // memory pressure, and millions of oracle-checked distances.
+  test(
+    "sparse n = 150k matches the oracle at topLevel 3",
+    () => {
+      const edges = sparseRandom(150_000, 3, 1651);
+      expect(new BMSSP(edges).topLevel).toBe(3);
+      checkFullMapAgainstOracle(edges, 0, "scale sparse seed=1651");
+    },
+    FUZZ_TIMEOUT,
+  );
+
+  test(
+    "grid 300×300 (n = 90k) matches the oracle",
+    () => {
+      checkFullMapAgainstOracle(grid(300, 1652), 0, "scale grid seed=1652");
+    },
+    FUZZ_TIMEOUT,
+  );
+
+  // Opt-in XL round: the old road-network scale, seeded. ~30 s, so it stays
+  // out of the default `npm test` (and CI) budget.
+  (process.env.FUZZ_XL ? test : test.skip)(
+    "XL: sparse n = 2M matches the oracle",
+    () => {
+      const edges = sparseRandom(2_000_000, 3, 1653);
+      checkFullMapAgainstOracle(edges, 0, "xl sparse seed=1653");
+    },
+    600_000,
+  );
 });
 
 describe("fuzz: multi-source bounded bmssp() against per-source oracles", () => {

--- a/test/main.test.mjs
+++ b/test/main.test.mjs
@@ -1,38 +1,28 @@
 import { describe, test, expect } from "@jest/globals";
 import { BMSSP, dijkstra } from "../index.mjs";
-import fs from "fs";
+import { sparseRandom } from "../benchmarks/generators.mjs";
 
-// Load the roadNet-CA.txt graph and parse it into an array of edges
-let roadNetCA = (() => {
-  let graph = [];
-  const filePath = new URL("./roadNet-CA.txt", import.meta.url).pathname;
-  const data = fs.readFileSync(filePath, "utf-8");
-  data.split("\n").forEach((line) => {
-    if (line.startsWith("#") || line.trim() === "") return;
-    const [from, to] = line.trim().split(/\s+/).map(Number);
-    if (!isNaN(from) && !isNaN(to)) {
-      let min = 1,
-        max = 1e8;
-      let randomWeight = Math.floor(Math.random() * (max - min + 1)) + min;
-      graph.push([from, to, randomWeight]);
-    }
-  });
-  return graph;
-})();
+// Seeded medium-size sparse graph (m = O(n) — the regime the paper targets).
+// It replaces the old 87 MB roadNet-CA.txt fixture: the same full-map
+// BMSSP-vs-Dijkstra contract, but reproducible (fixed seed instead of
+// unseeded random weights) and orders of magnitude faster. Even at this size
+// the recursion already runs at topLevel = 3, the same depth a 2M-node graph
+// reaches; larger seeded scale runs live in test/fuzz.test.mjs.
+const mediumSparse = sparseRandom(10_000, 3, 1601);
 
 // Have an initialized BMSSP instance for tests
-const myBMSSP = new BMSSP(roadNetCA);
+const myBMSSP = new BMSSP(mediumSparse);
 
 describe("BMSSP constructor", () => {
   test("initializes the graph correctly", () => {
-    expect(myBMSSP.graph).toEqual(roadNetCA);
+    expect(myBMSSP.graph).toEqual(mediumSparse);
   });
 });
 
 describe("BMSSP nodeIDs", () => {
   test("stores unique node IDs correctly", () => {
     const uniqueNodeIDs = new Set();
-    roadNetCA.forEach((edge) => {
+    mediumSparse.forEach((edge) => {
       uniqueNodeIDs.add(edge[0]);
       uniqueNodeIDs.add(edge[1]);
     });
@@ -74,7 +64,7 @@ describe("BMSSP adjacency map", () => {
     for (const edges of myBMSSP.adjacency.values()) {
       edgeCount += edges.length;
     }
-    expect(edgeCount).toBe(roadNetCA.length);
+    expect(edgeCount).toBe(mediumSparse.length);
   });
 
   test("getEdges returns a node's edges and [] for unknown nodes", () => {
@@ -105,7 +95,7 @@ describe("BMSSP initialize calculateShortestPaths", () => {
     const startNode = [...myBMSSP.nodeIDs][0];
     myBMSSP.calculateShortestPaths(startNode);
     expect(myBMSSP.shortestPaths.get(startNode)).toBe(0);
-  }, 120000); // A real BMSSP run over the full road network takes a few seconds
+  });
   test("throws an error if the start node is not in the graph", () => {
     const invalidStartNode = -1; // Assuming -1 is not a valid node ID in the graph
     expect(() => {
@@ -118,7 +108,7 @@ describe("dijkstra source validation", () => {
   test("throws an error if the source node is not in nodeIDs", () => {
     const invalidSource = -1; // Assuming -1 is not a valid node ID in the graph
     expect(() => {
-      dijkstra(roadNetCA, myBMSSP.nodeIDs, invalidSource);
+      dijkstra(mediumSparse, myBMSSP.nodeIDs, invalidSource);
     }).toThrow("Source node not found in nodeIDs");
   });
 });
@@ -129,11 +119,11 @@ describe("BMSSP vs Dijkstra shortest paths", () => {
     const source = nodeArray[0];
 
     myBMSSP.calculateShortestPaths(source);
-    const dijkstraPaths = dijkstra(roadNetCA, myBMSSP.nodeIDs, source);
+    const dijkstraPaths = dijkstra(mediumSparse, myBMSSP.nodeIDs, source);
 
     expect(myBMSSP.shortestPaths.size).toBe(dijkstraPaths.size);
     for (const [nodeId, distance] of myBMSSP.shortestPaths) {
       expect(dijkstraPaths.get(nodeId)).toBe(distance);
     }
-  }, 120000); // A real BMSSP run + a Dijkstra oracle run over the full road network
+  });
 });


### PR DESCRIPTION
Closes no issue (user-directed chore, 2026-07-16) — so **no version bump** per the post-1.0 cadence.

## Summary

`test/roadNet-CA.txt` (87 MB, ~95% of clone size) cost **~71 s of every `npm test` run** and assigned **unseeded** random weights at load, so any failure on it was irreproducible — the opposite of the seeded fuzz suite's design. Its coverage is superseded:

- **`main.test.mjs`**: same API contracts + the full-map BMSSP-vs-Dijkstra equality test, now on `sparseRandom(10_000, 3, 1601)`. At n = 10k the recursion already runs at `topLevel = 3` — the same depth the 2M-node road network reached (the 3→4 step sits near n = 4M, see #182), so no recursion-depth coverage is lost.
- **`fuzz.test.mjs`**: new **seeded scale runs** — sparse n = 150k (asserted `topLevel` 3) and grid 300×300 in the default suite, plus an opt-in **`FUZZ_XL=1`** sparse **n = 2M** round (~26 s measured) at the old road-network scale (volume + memory pressure).
- Suite wall-clock: **~75 s → ~3 s**.
- Docs/KB synced in this PR (Phase C): README, `test/README.md` (rewritten — it was stale boilerplate and mis-expanded the acronym), knowledge `05`/`06`/`07`. Also dropped `05`'s "roadNet-CA ≈2.1×" claim, which had no backing data in `HEAD-TO-HEAD.md`.

## Post-merge follow-up (user-directed)

The blob stays in git history until purged. After this merges, a **`git filter-repo` history rewrite** removes it (clones drop from ~18 MiB to <1 MiB) — rewrites all SHAs and re-points tags; branch protection must be lifted temporarily, and each force-push gets explicit confirmation first. The exact procedure is recorded in `knowledge/06`.

## Test/lint status

- `npm test`: 7 suites, **103 passed + 1 XL skipped**, 100% statement coverage, 2.8 s
- `FUZZ_XL=1` 2M-node round: passes in ~26 s
- `npm run lint`: clean

## Roadmap proposals

1. **Comment on closed #24** (datasets research, roadNet-CA) noting the dataset was removed on 2026-07-16 and why (irreproducibility, runtime, clone weight; coverage superseded by #161 + this PR), for anyone following the trail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)