### PR TITLE
docs: semver release convention — bump only on bug fix or milestone close

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -23,8 +23,9 @@ if/else so nothing depends on inference.
    - Symbol/term lookup → [knowledge/07-glossary.md](knowledge/07-glossary.md)
    If you spot a dynamic fact anywhere else (including this file), treat it as a bug: move
    it to the right dynamic file and replace it with a pointer.
-2. **One PR per issue, and that PR carries everything**: code + tests + version bump +
-   refreshed `05`/`06`/`07` + `README.md` updates. Never open a second "sync the docs" PR —
+2. **One PR per issue, and that PR carries everything**: code + tests + version bump (only
+   when one is warranted — see "Version bump & release" below) + refreshed `05`/`06`/`07` +
+   `README.md` updates. Never open a second "sync the docs" PR —
    the pre-PR sync (Phase C below) exists precisely to prevent that.
 3. **Two hard gates — never bypass:**
    - **GitHub writes beyond the PR itself** (creating/editing/closing issues or milestones):
@@ -93,10 +94,11 @@ existing APIs to build on. Ship focused unit tests with every piece. Before Phas
 
 **Run this on the feature branch, before opening any PR. Do not wait to be asked.**
 
-1. **Version bump** (only if the PR closes an issue — see "Version bump & release" below
-   for which of patch/minor/major applies):
+1. **Version bump** (only if the PR warrants a release — see "Version bump & release"
+   below: bug fix → `patch`; milestone-closing PR → `minor`/`major`. Most PRs, including
+   most issue-closing PRs, bump **nothing**):
    ```bash
-   npm version patch --no-git-tag-version
+   npm version <patch|minor|major> --no-git-tag-version
    ```
 2. **Rewrite `05`** to describe the tree **as it will exist once this PR merges** (the
    branch's own tree). Set the `PENDING-PR-BRANCH:` marker to the feature branch name and
@@ -145,7 +147,7 @@ any Roadmap proposals, and execute only user-approved GitHub edits.
 
 ---
 
-## 🚀 Version bump & release (when a working session closes an issue)
+## 🚀 Version bump & release (only when a PR warrants one — see the convention below)
 
 The repo ships via **tag → GitHub Release → CI/CD**. Publishing a GitHub Release
 (`release: published`) fires `.github/workflows/publish.yml`, which **publishes to npm**
@@ -161,13 +163,23 @@ changes deploy Pages via `static.yml` — no action needed for those.)
 hand-edit:
 
 ```bash
-npm version patch --no-git-tag-version   # e.g. 1.0.0 → 1.0.1
+npm version <patch|minor|major> --no-git-tag-version   # e.g. patch: 1.0.1 → 1.0.2
 ```
 
-Convention (post-1.0, user-confirmed 2026-07-16): one **patch** bump per closed issue; the
-PR that closes a milestone's **last** issue bumps **minor** instead (`major` for the
-`2.0.0` milestone), so released versions land exactly on the milestone names. Deviate only
-when the user directs otherwise.
+Convention (semver — <https://semver.org/> — user-confirmed 2026-07-17, superseding the
+2026-07-16 "patch per closed issue" cadence). A PR bumps the version **only** in exactly
+two cases:
+
+- **It fixes a bug** in shipped behavior → **patch** (semver: backward-compatible bug fix).
+- **It closes a milestone's last open issue** → **minor** (**major** for the `2.0.0`
+  milestone), so released versions land exactly on the milestone names (`1.1.0`, `1.2.0`,
+  `2.0.0`).
+
+**Every other PR bumps nothing and ships no release** — including PRs that close an issue
+(tests, docs, tooling, internal refactors) and mid-milestone feature PRs, whose work
+reaches npm with the milestone-closing minor/major release. Every bump goes through
+Phase 2 below (a bumped-but-untagged version is a bug that Phase A step 5 surfaces).
+Deviate only when the user directs otherwise.
 
 **Phase 2 — tag + release, only after the user confirms the merge:**
 

--- a/.claude/knowledge/06-milestones-roadmap.md
+++ b/.claude/knowledge/06-milestones-roadmap.md
@@ -137,19 +137,25 @@ returning `{ bound, vertices }` sensibly) rather than new algorithm work.
 
 ---
 
-## Release mechanics (version bump per closed issue)
+## Release mechanics (semver: bump only on bug fix or milestone close)
 
-Closing an issue bumps the package version and, after the PR merges, ships a release:
+Not every merged PR ships a release — not even every issue-closing PR. **Semver cadence
+(user-confirmed 2026-07-17, superseding the 2026-07-16 patch-per-issue cadence):**
 
-1. **In the PR that closes the issue** — `npm version patch --no-git-tag-version` (keeps
-   `package.json` + `package-lock.json` in sync). **Post-1.0 cadence (user-confirmed
-   2026-07-16, first applied in the #161 PR):** a **patch** bump per closed issue; the PR
-   closing a milestone's **last** issue bumps **minor** (or **major** for `2.0.0`) so
-   released versions land exactly on the milestone names (`1.1.0`, `1.2.0`, `2.0.0`).
-   (Pre-1.0 history: one minor per issue; the #43 PR's `major` closed milestone `1.0.0`.)
-2. **After the user confirms the merge** — tag `main` with the bare version (no `v` prefix)
-   and `gh release create` it; publishing the release fires `publish.yml` → **npm + Docker
-   Hub**.
+1. **Bug-fix PR** (corrects wrong shipped behavior) → **patch** bump inside the PR
+   (`npm version patch --no-git-tag-version` keeps `package.json` + `package-lock.json`
+   in sync), release after the merge.
+2. **PR closing a milestone's last open issue** → **minor** bump (**major** for `2.0.0`),
+   so released versions land exactly on the milestone names (`1.1.0`, `1.2.0`, `2.0.0`).
+3. **Everything else** — issue-closing or not (tests, docs, tooling, refactors,
+   mid-milestone features) → **no bump, no release**; the work reaches npm with the
+   milestone-closing release.
+4. **After the user confirms the merge** (cases 1–2 only) — tag `main` with the bare
+   version (no `v` prefix) and `gh release create` it; publishing the release fires
+   `publish.yml` → **npm + Docker Hub**.
+
+(History: pre-1.0 bumped one minor per issue; the #43 PR's `major` closed milestone
+`1.0.0`; `1.0.1` shipped under the short-lived patch-per-issue cadence.)
 
 Full procedure + exact commands live in **`../CLAUDE.md` → "Version bump & release"**. The
 release step is an outward-facing publish and is **gated on explicit user confirmation**.


### PR DESCRIPTION
## Summary

Updates the knowledge base's release convention to follow [semver](https://semver.org/), superseding the 2026-07-16 "patch bump per closed issue" cadence (user-directed, 2026-07-17):

- **Bug-fix PR** → **patch** bump + release.
- **PR closing a milestone's last open issue** → **minor** bump (**major** for `2.0.0`), so released versions still land exactly on the milestone names.
- **Every other PR** — including issue-closing test/docs/tooling PRs and mid-milestone features — **no bump, no release**; the work reaches npm with the milestone-closing release.

Touched: `.claude/CLAUDE.md` (ground rule 2, Phase C step 1, the "Version bump & release" section) and `.claude/knowledge/06-milestones-roadmap.md` ("Release mechanics" section). This PR itself follows the new convention: docs-only, no bump.

## Test / lint

Docs-only change under `.claude/` (ESLint ignores `.claude/**`); no code touched.

## Roadmap proposals

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)