### PR TITLE
test(#162): deterministic edge-case fixtures — disconnected graphs and unreachable nodes

### DIFF
--- a/.claude/knowledge/05-codebase-map.md
+++ b/.claude/knowledge/05-codebase-map.md
@@ -1,13 +1,14 @@
 # 05 — Codebase Map (current state)
 
-<!-- BOOKMARK-COMMIT: a8675496483c564edfd055ba8d1d94a3761c9592 -->
-<!-- PENDING-PR-BRANCH: (none) -->
-<!-- Last validated: 2026-07-17, right after the history purge + re-sign: PR #185
-     (roadNet-CA removal) merged, then git-filter-repo purged the 87 MB blob from all
-     history and every commit was re-signed (SSH key, committer normalized to the owner)
-     and force-pushed — all SHAs changed. NOTE: HEAD is expected to be exactly ONE
-     docs-only commit past this bookmark (the commit that wrote these markers, made on
-     the rewritten main); if so, treat this map as current. -->
+<!-- BOOKMARK-COMMIT: 52686ff15802109bb096c8ec85d89bb0b4e84e79 -->
+<!-- PENDING-PR-BRANCH: test/162-edge-case-disconnected -->
+<!-- Last validated: 2026-07-17 (Phase C of the #162 PR). Describes the tree as it will
+     exist once that PR merges: adds test/edgeCases.test.mjs (9 deterministic
+     disconnection fixtures), no src/ changes, no version bump (semver convention —
+     see 06 "Release mechanics"). NOTE: the docs-only PR #186 (semver release
+     convention, branch docs/semver-release-convention) may merge around the same
+     time; it touches only .claude/CLAUDE.md and .claude/knowledge/06 and does not
+     affect this map. -->
 
 Snapshot of what exists in `bmssp-js` today, so you know what to build on vs. what's missing.
 
@@ -67,6 +68,7 @@ test/
   main.test.mjs           # Jest tests: constructor, nodeIDs, adjacency, shortestPaths, BMSSP-vs-Dijkstra (seeded 10k sparse)
   bmssp.test.mjs          # #43: 15 recursion tests — params, hand graphs, ties, Lemma 3.1 contract, seeded stress
   fuzz.test.mjs           # #161: 18 high-volume fuzz tests — shapes × weight regimes × multi-source × seeded scale; FUZZ_ROUNDS / FUZZ_XL env vars
+  edgeCases.test.mjs      # #162: 9 deterministic disconnection fixtures — isolated/sink sources, many components, source switching
   blockList.test.mjs      # #42: 18 BlockList tests incl. a seeded random stress test
   heap.test.mjs           # #41: 16 MinHeap tests incl. a seeded stress test vs. a naive queue
   baseCase.test.mjs       # #40: 13 BaseCase tests incl. seeded oracle-comparison stress
@@ -264,6 +266,14 @@ implementation is tested against — and, since #43, no longer part of the BMSSP
 - `test/blockList.test.mjs` (18), `test/heap.test.mjs` (16), `test/baseCase.test.mjs` (13),
   `test/findPivots.test.mjs` (12): per-module contracts incl. seeded stress — see the
   module sections above.
+- `test/edgeCases.test.mjs` (9, #162): deterministic hand-built disconnection fixtures,
+  each checked against a hand-computed full distance map **and** the Dijkstra oracle
+  (Infinity entries included): self-loop-only source, sink source (adjacency keeps an
+  empty list), empty graph rejects any start, five single-node components, ten 3-node
+  chain components, a bridge edge pointing into the source's component, a 2-node island
+  beside a 100-node chain (source on each side), and A→B→A source switching on one
+  instance to prove state resets. Complements the randomized disconnected-forest rounds
+  in `fuzz.test.mjs`.
 - `test/fuzz.test.mjs` (18, #161 + scale runs added 2026-07-17): the high-volume
   property/fuzz suite. Full-map oracle equality across 8 shapes (the 5 benchmark generators
   reused, plus local random-DAG, disconnected-forest and uniform-multigraph generators; 2
@@ -277,8 +287,9 @@ implementation is tested against — and, since #43, no longer part of the BMSSP
   **opt-in `FUZZ_XL=1` sparse n = 2M round** (~30 s, `test.skip` otherwise). Every failure
   message carries the round's seed for reproduction. **`FUZZ_ROUNDS=<x>`** multiplies all
   round counts (default 1 ≈ 0.5 s; 25 ≈ 5 s, several thousand graphs).
-- Current suite: **104 tests — 103 passing + 1 XL skipped by default**, 100% statement
-  coverage, ~3 s wall-clock. No graph data files: every test graph is generated from a seed.
+- Current suite: **113 tests — 112 passing + 1 XL skipped by default**, 100% statement
+  coverage, ~3 s wall-clock. No graph data files: every generated test graph comes from a
+  seed; the #162 fixtures are hand-built and fully deterministic.
 
 ## Benchmarks (`benchmarks/`, `npm run bench`)
 
@@ -300,7 +311,8 @@ comparison-count mode); the raw baseline is also on #170 as a comment.
 | Base case (bounded Dijkstra) | `src/baseCase.mjs` | #40 | ✅ done (PR #178) |
 | FindPivots | `src/findPivots.mjs` | #44 | ✅ done (PR #180) |
 | Main `BMSSP(l, B, S)` recursion + `k,t` derivation | `src/bmssp.mjs` | #43 | ✅ done (PR #181) — **1.0.0 milestone complete** |
-| Property/fuzz suite vs. the oracle | `test/fuzz.test.mjs` | #161 | ✅ done (this PR, 1.0.1) |
+| Property/fuzz suite vs. the oracle | `test/fuzz.test.mjs` | #161 | ✅ done (PR #184, 1.0.1) |
+| Deterministic disconnection edge cases | `test/edgeCases.test.mjs` | #162 | ✅ done (this PR, no bump) |
 
-Milestone `1.1.0` (correctness hardening) is in progress: #161 lands with this PR; next up
-are #162, #163 — see [06-milestones-roadmap.md](06-milestones-roadmap.md).
+Milestone `1.1.0` (correctness hardening) is in progress: #162 lands with this PR; next up
+are #163, #165 — see [06-milestones-roadmap.md](06-milestones-roadmap.md).

--- a/.claude/knowledge/06-milestones-roadmap.md
+++ b/.claude/knowledge/06-milestones-roadmap.md
@@ -1,9 +1,9 @@
 # 06 — Milestones Roadmap
 
-<!-- SYNCED-FROM-GITHUB: 2026-07-17 (roadNet-CA removal session: PR #185 merged, history
-     purge + re-sign executed the same day, Phase E proposal on #24 executed) -->
-<!-- Current package version: 1.0.1 (released 2026-07-16; the roadNet-CA removal PR closed
-     no issue, so no bump) -->
+<!-- SYNCED-FROM-GITHUB: 2026-07-17 (#162 session: milestones 1.1.0/1.2.0/2.0.0 open with
+     5/5/3 open issues; #162 done-pending-merge in this PR) -->
+<!-- Current package version: 1.0.1 (released 2026-07-16; the #162 PR ships no bump under
+     the semver convention — see "Release mechanics" and PR #186) -->
 
 Maps GitHub **milestones** and **issues** (Sirivasv/bmssp-js) to the paper's building blocks,
 with a dependency-aware build order. This is the "intent" side of the knowledge base (what to
@@ -39,8 +39,17 @@ it runs the same Phase C reconciliation directly on `main`.
 
 ## 📋 Roadmap proposals (pending user approval)
 
-_None right now. Phase C writes proposed GitHub edits here (and in the PR body); Phase E
-executes the approved ones — one confirmation each — and clears them from this list._
+From the #162 PR (Phase C, 2026-07-17):
+
+1. **Comment on #165 (input validation):** the #162 edge-case work locked in the current
+   empty-graph behavior — `new BMSSP([])` constructs silently and only
+   `calculateShortestPaths()` throws (`"Start node not found in the graph"`,
+   `test/edgeCases.test.mjs`). Propose adding a note to #165 so the validation design
+   explicitly decides whether an empty edge list should throw at construction or stay
+   allowed (and, if allowed, that the test's locked-in behavior is the contract).
+
+_Phase C writes proposed GitHub edits here (and in the PR body); Phase E executes the
+approved ones — one confirmation each — and clears them from this list._
 _(The #185-PR proposal — removal note on closed **#24** — was approved and executed
 2026-07-17. Earlier: both #161-PR proposals executed 2026-07-16 on **#163**/**#162**.)_
 
@@ -62,8 +71,11 @@ _(The #185-PR proposal — removal note on closed **#24** — was approved and e
   and dates preserved), `main` + all 21 tags force-pushed with ruleset 7764713
   temporarily disabled. **All commit SHAs before 2026-07-17 changed**; old SHAs in
   closed PRs/issues no longer resolve. Repo-local git config now signs future commits.
-- **Milestone `1.1.0` — correctness hardening** (in progress). After #161: **#162**
-  (edge-case tests — partially covered by the fuzz suite, see proposals), then #163.
+- **Milestone `1.1.0` — correctness hardening** (in progress). **#162 done-pending-merge**
+  (this PR: `test/edgeCases.test.mjs`, 9 deterministic disconnection fixtures, no bump).
+  Next: **#163** (tie-breaking), then #165.
+- **Semver release convention (user-directed 2026-07-17, PR #186):** bumps only on bug
+  fix (patch) or milestone-closing PR (minor/major) — see "Release mechanics" below.
 - **2026-07-16 reflection session (post-release):** measured the BMSSP-vs-Dijkstra
   head-to-head, algorithm time only → `benchmarks/HEAD-TO-HEAD.md`. Headlines: Dijkstra
   wins wall-clock everywhere but the sparse ratio narrows with n (1.57× at 2M);
@@ -100,7 +112,7 @@ Recommended order (cheapest protection first, then the deep work):
 | Order | # | Issue | Labels | Notes |
 |---|---|---|---|---|
 | 1 | 161 | Property/fuzz tests: BMSSP vs Dijkstra on random graphs | enhancement · help wanted | ✅ merged (PR #184, 1.0.1) |
-| 2 | 162 | Edge-case tests: disconnected graphs and unreachable nodes | enhancement · help wanted | Largely covered by #43 + #161 fuzz (disconnected forests); see proposals |
+| 2 | 162 | Edge-case tests: disconnected graphs and unreachable nodes | enhancement · help wanted | ✅ done-pending-merge (this PR, no bump): deterministic fixtures in `test/edgeCases.test.mjs`; randomized side already in #161 fuzz |
 | 3 | 163 | Deterministic tie-breaking for equal-length paths (Assumption 2.1) | enhancement · help wanted | Four concrete manifestations now: three from #43, boundary-tied return from #161 |
 | 4 | 165 | Input validation for the BMSSP constructor | good first issue · help wanted | — |
 | 5 | 164 | Optional constant-degree transform (in/out-degree ≤ 2) | enhancement · help wanted | — |

--- a/.claude/knowledge/07-glossary.md
+++ b/.claude/knowledge/07-glossary.md
@@ -150,6 +150,11 @@ Quick lookup for the symbols and terms used across the paper, the notes, and the
   oracle equality across 8 graph shapes and 4 extreme weight regimes, plus direct
   multi-source bounded `bmssp(topLevel, B, S)` checks against per-source Dijkstra oracles
   (`trueDist(v) = min_s(d0[s] + dist_s(v))`). Failure messages carry the round's seed.
+- **Edge-case suite** (#162) — `test/edgeCases.test.mjs`: deterministic hand-built
+  disconnection fixtures with hand-verifiable expected maps — isolated/sink/self-loop-only
+  sources, single-node and many-chain components, wrong-direction bridge edges, tiny
+  component beside a giant chain, and source switching across components on one instance.
+  Complements the randomized disconnected-forest coverage in the fuzz suite (#161).
 - **`FUZZ_ROUNDS`** (#161) — environment variable multiplying every fuzz round count
   (default 1). `FUZZ_ROUNDS=25 npm test -- test/fuzz.test.mjs` runs several thousand
   graphs in ~5 s.

--- a/test/README.md
+++ b/test/README.md
@@ -20,6 +20,7 @@ equal the Dijkstra oracle's** (`src/dijkstra.mjs`).
 | `main.test.mjs` | `BMSSP` class contracts (constructor, `nodeIDs`, adjacency, `shortestPaths`, error handling) + full-map BMSSP-vs-Dijkstra equality on a seeded 10k-node sparse graph |
 | `bmssp.test.mjs` | Algorithm 3 recursion: parameter derivation, hand-built graphs, degenerate ties, the Lemma 3.1 bounded-call contract, seeded stress |
 | `fuzz.test.mjs` | High-volume property/fuzz suite (#161): 8 graph shapes × extreme weight regimes × multi-source bounded calls vs. per-source oracles, plus seeded scale runs (150k-node sparse, 300×300 grid, opt-in 2M) |
+| `edgeCases.test.mjs` | Deterministic disconnection fixtures (#162): isolated/sink/self-loop-only sources, single-node and multi-chain components, wrong-direction bridges, tiny-vs-giant components, source switching across components — each vs. a hand-computed map and the oracle |
 | `findPivots.test.mjs` | Algorithm 1 (`FindPivots`) contracts incl. seeded oracle stress |
 | `baseCase.test.mjs` | Algorithm 2 (`BaseCase`) bounded mini-Dijkstra contracts |
 | `blockList.test.mjs` | Lemma 3.3 block-based partial-sort structure `D` |

--- a/test/edgeCases.test.mjs
+++ b/test/edgeCases.test.mjs
@@ -1,0 +1,186 @@
+import { describe, test, expect } from "@jest/globals";
+import { BMSSP } from "../src/bmssp.mjs";
+import { dijkstra } from "../src/dijkstra.mjs";
+
+// Deterministic edge-case fixtures for disconnected graphs and unreachable
+// nodes (#162). Every graph is hand-built and every expected distance map is
+// hand-verifiable; the randomized side of this coverage (disconnected
+// forests across shapes and sources) lives in fuzz.test.mjs (#161).
+
+// Run BMSSP from source, then require the full distance map to equal both
+// the hand-computed expectation and the Dijkstra oracle — including the
+// Infinity entries for unreachable vertices.
+function expectDistances(edges, source, expected) {
+  const bmssp = new BMSSP(edges);
+  bmssp.calculateShortestPaths(source);
+
+  const oracle = dijkstra(bmssp.graph, bmssp.nodeIDs, source);
+  expect(bmssp.shortestPaths.size).toBe(oracle.size);
+  for (const [v, d] of oracle) {
+    expect(bmssp.shortestPaths.get(v)).toBe(d);
+  }
+
+  expect(bmssp.shortestPaths.size).toBe(expected.size);
+  for (const [v, d] of expected) {
+    expect(bmssp.shortestPaths.get(v)).toBe(d);
+  }
+  return bmssp;
+}
+
+describe("Edge cases (#162): isolated and sink sources", () => {
+  test("a source whose only edge is a self-loop reaches nothing else", () => {
+    const bmssp = expectDistances(
+      [
+        [0, 0, 7],
+        [1, 2, 3],
+      ],
+      0,
+      new Map([
+        [0, 0],
+        [1, Infinity],
+        [2, Infinity],
+      ]),
+    );
+    // The self-loop is the node's only outgoing edge
+    expect(bmssp.getEdges(0)).toEqual([[0, 7]]);
+  });
+
+  test("a sink source (no outgoing edges) reaches only itself", () => {
+    // Node 1 only ever appears as an edge target
+    const bmssp = expectDistances(
+      [
+        [0, 1, 5],
+        [2, 1, 4],
+      ],
+      1,
+      new Map([
+        [0, Infinity],
+        [1, 0],
+        [2, Infinity],
+      ]),
+    );
+    // The adjacency map still knows the sink — with an empty edge list
+    expect(bmssp.getEdges(1)).toEqual([]);
+    expect(bmssp.adjacency.has(1)).toBe(true);
+  });
+
+  test("an empty graph rejects every start node", () => {
+    const bmssp = new BMSSP([]);
+    expect(bmssp.nodeIDs.size).toBe(0);
+    expect(() => {
+      bmssp.calculateShortestPaths(0);
+    }).toThrow("Start node not found in the graph");
+  });
+});
+
+describe("Edge cases (#162): many components, one source", () => {
+  test("single-node components (self-loops) stay isolated from each other", () => {
+    const edges = [];
+    for (let node = 0; node < 5; node += 1) edges.push([node, node, 1]);
+    const expected = new Map([
+      [0, Infinity],
+      [1, Infinity],
+      [2, 0],
+      [3, Infinity],
+      [4, Infinity],
+    ]);
+    expectDistances(edges, 2, expected);
+  });
+
+  test("ten 3-node chain components: only the source's chain gets finite distances", () => {
+    // Component c holds nodes 3c -> 3c+1 -> 3c+2 with weights c+1, c+2
+    const edges = [];
+    for (let c = 0; c < 10; c += 1) {
+      edges.push([3 * c, 3 * c + 1, c + 1]);
+      edges.push([3 * c + 1, 3 * c + 2, c + 2]);
+    }
+    const expected = new Map();
+    for (let node = 0; node < 30; node += 1) expected.set(node, Infinity);
+    // Source 9 heads component c = 3: distances 0, 4, 4 + 5
+    expected.set(9, 0);
+    expected.set(10, 4);
+    expected.set(11, 9);
+    expectDistances(edges, 9, expected);
+  });
+
+  test("an edge pointing INTO the source's component leaves its origin unreachable", () => {
+    // 5 -> 0 bridges the components in the wrong direction for source 0
+    expectDistances(
+      [
+        [0, 1, 2],
+        [5, 0, 1],
+        [5, 6, 1],
+      ],
+      0,
+      new Map([
+        [0, 0],
+        [1, 2],
+        [5, Infinity],
+        [6, Infinity],
+      ]),
+    );
+  });
+});
+
+describe("Edge cases (#162): tiny component beside a giant one", () => {
+  // One 2-node component {0, 1} and a 100-node chain 100 -> 101 -> ... -> 199
+  function twoIslands() {
+    const edges = [[0, 1, 3]];
+    for (let i = 0; i < 99; i += 1) edges.push([100 + i, 101 + i, 1]);
+    return edges;
+  }
+
+  test("source in the tiny component: the giant chain stays at Infinity", () => {
+    const expected = new Map([
+      [0, 0],
+      [1, 3],
+    ]);
+    for (let i = 0; i < 100; i += 1) expected.set(100 + i, Infinity);
+    expectDistances(twoIslands(), 0, expected);
+  });
+
+  test("source in the giant chain: prefix-sum distances, tiny component at Infinity", () => {
+    const expected = new Map([
+      [0, Infinity],
+      [1, Infinity],
+    ]);
+    for (let i = 0; i < 100; i += 1) expected.set(100 + i, i);
+    const bmssp = expectDistances(twoIslands(), 100, expected);
+    // The chain's last node is a sink the adjacency map handles cleanly
+    expect(bmssp.getEdges(199)).toEqual([]);
+  });
+});
+
+describe("Edge cases (#162): re-running across components of one instance", () => {
+  test("switching the source between components resets all state cleanly", () => {
+    // Component A: 0 -> 1 -> 2; component B: 10 -> 11
+    const bmssp = new BMSSP([
+      [0, 1, 1],
+      [1, 2, 1],
+      [10, 11, 7],
+    ]);
+    const fromA = new Map([
+      [0, 0],
+      [1, 1],
+      [2, 2],
+      [10, Infinity],
+      [11, Infinity],
+    ]);
+    const fromB = new Map([
+      [0, Infinity],
+      [1, Infinity],
+      [2, Infinity],
+      [10, 0],
+      [11, 7],
+    ]);
+    // A -> B -> A again: no distance may leak from the previous run
+    for (const expected of [fromA, fromB, fromA]) {
+      const source = expected.get(0) === 0 ? 0 : 10;
+      bmssp.calculateShortestPaths(source);
+      expect(bmssp.shortestPaths.size).toBe(expected.size);
+      for (const [v, d] of expected) {
+        expect(bmssp.shortestPaths.get(v)).toBe(d);
+      }
+    }
+  });
+});


### PR DESCRIPTION
Closes #162

## Summary

Adds `test/edgeCases.test.mjs` — 9 deterministic, hand-built disconnection fixtures, each verified against a **hand-computed full distance map** and the **Dijkstra oracle** (Infinity entries included), completing the deterministic side of #162 (the randomized side ships in the #161 fuzz suite):

- Source whose only edge is a self-loop; sink source (appears only as an edge target — adjacency keeps an empty list for it); empty graph rejects any start node.
- Five single-node (self-loop) components; ten 3-node chain components with only the source's chain finite; a bridge edge pointing *into* the source's component (origin stays unreachable).
- A 2-node island beside a 100-node chain, source on each side (prefix-sum distances vs. all-Infinity).
- A→B→A source switching across components on one instance — no distance leaks between runs.

**No version bump** — test-only issue, not a bug fix, and milestone 1.1.0 still has open issues (semver convention from #186).

## Test / lint

- `npm test`: 8 suites, **113 tests — 112 passed + 1 XL skipped by default** (9 new), 100% statement coverage, ~3 s.
- `npm run lint`: clean.

KB refreshed in-branch: `05` (layout, test contract, gaps table, `PENDING-PR-BRANCH` marker), `06` (current state, 1.1.0 table, proposals), `07` (edge-case suite entry), `test/README.md` file table. The `06` edits deliberately avoid the "Release mechanics" section so this PR does not conflict with #186.

## Roadmap proposals

1. **Comment on #165 (input validation):** this PR locked in the current empty-graph behavior — `new BMSSP([])` constructs silently and only `calculateShortestPaths()` throws. Propose noting on #165 that the validation design should explicitly decide whether an empty edge list throws at construction or stays allowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)