### PR TITLE
feat(#163): deterministic tie-breaking — Assumption 2.1 realized via composite keys

### DIFF
--- a/.claude/knowledge/05-codebase-map.md
+++ b/.claude/knowledge/05-codebase-map.md
@@ -1,14 +1,14 @@
 # 05 — Codebase Map (current state)
 
-<!-- BOOKMARK-COMMIT: 52686ff15802109bb096c8ec85d89bb0b4e84e79 -->
-<!-- PENDING-PR-BRANCH: test/162-edge-case-disconnected -->
-<!-- Last validated: 2026-07-17 (Phase C of the #162 PR). Describes the tree as it will
-     exist once that PR merges: adds test/edgeCases.test.mjs (9 deterministic
-     disconnection fixtures), no src/ changes, no version bump (semver convention —
-     see 06 "Release mechanics"). NOTE: the docs-only PR #186 (semver release
-     convention, branch docs/semver-release-convention) may merge around the same
-     time; it touches only .claude/CLAUDE.md and .claude/knowledge/06 and does not
-     affect this map. -->
+<!-- BOOKMARK-COMMIT: ef5153b54f2cd06883ded48785bae13eb27787ba -->
+<!-- PENDING-PR-BRANCH: feat/163-deterministic-tie-break -->
+<!-- Last validated: 2026-07-17 (Phase C of the #163 PR). Describes the tree as it will
+     exist once that PR merges: new src/tieBreak.mjs (composite [length, hops, id]
+     keys realizing Assumption 2.1), canonical relaxation through baseCase /
+     findPivots / bmssp, comparator support in MinHeap / BlockList, the pre-#163
+     degenerate-tie guards removed, test/tieBreak.test.mjs added. No version bump
+     (enhancement; milestone 1.1.0 still open — semver convention, 06 "Release
+     mechanics"). -->
 
 Snapshot of what exists in `bmssp-js` today, so you know what to build on vs. what's missing.
 
@@ -60,15 +60,17 @@ index.mjs                 # re-exports { BMSSP } and { dijkstra }
 src/
   bmssp.mjs               # BMSSP class — full Algorithm 3 recursion (#43); wires the pieces below
   dijkstra.mjs            # reference Dijkstra (array binary-heap) — DONE, used as oracle
-  blockList.mjs           # #42: Lemma 3.3 block-based partial-sort structure D
-  heap.mjs                # #41: indexed binary min-heap (MinHeap) for BaseCase (Alg 2)
-  baseCase.mjs            # #40: BaseCase(B, S) — Algorithm 2 bounded mini-Dijkstra
-  findPivots.mjs          # #44: FindPivots(B, S) — Algorithm 1 frontier shrink
+  tieBreak.mjs            # #163: composite [length, hops, id] keys — Assumption 2.1 realized (compareKeys/toBound/relaxEdge)
+  blockList.mjs           # #42: Lemma 3.3 block-based partial-sort structure D (comparator-aware since #163)
+  heap.mjs                # #41: indexed binary min-heap (MinHeap) for BaseCase (comparator-aware since #163)
+  baseCase.mjs            # #40: BaseCase(B, S) — Algorithm 2 bounded mini-Dijkstra on composite keys
+  findPivots.mjs          # #44: FindPivots(B, S) — Algorithm 1 frontier shrink, canonical-pred forest
 test/
   main.test.mjs           # Jest tests: constructor, nodeIDs, adjacency, shortestPaths, BMSSP-vs-Dijkstra (seeded 10k sparse)
   bmssp.test.mjs          # #43: 15 recursion tests — params, hand graphs, ties, Lemma 3.1 contract, seeded stress
   fuzz.test.mjs           # #161: 18 high-volume fuzz tests — shapes × weight regimes × multi-source × seeded scale; FUZZ_ROUNDS / FUZZ_XL env vars
   edgeCases.test.mjs      # #162: 9 deterministic disconnection fixtures — isolated/sink sources, many components, source switching
+  tieBreak.test.mjs       # #163: 16 tests — key order, canonical relaxEdge, edge-order determinism, strict Lemma 3.1, lex-oracle hops/preds
   blockList.test.mjs      # #42: 18 BlockList tests incl. a seeded random stress test
   heap.test.mjs           # #41: 16 MinHeap tests incl. a seeded stress test vs. a naive queue
   baseCase.test.mjs       # #40: 13 BaseCase tests incl. seeded oracle-comparison stress
@@ -105,46 +107,51 @@ class BMSSP {
   //   this.nodeIDs        : Set of all node IDs (from both endpoints)
   //   this.shortestPaths  : Map<nodeId, distance>, initialized to Infinity  ← this is d̂[·]
   //   this.adjacency      : Map<nodeId, Array<[to, weight]>>  ← #45, built in constructor
+  //   this.hops, this.preds : Map — #163 canonical labels (edge count + predecessor of the
+  //                           canonical shortest path), updated in lockstep with d̂
+  //   this.ties           : { hops, preds } bundle handed to relaxEdge
   //   this.k, this.t, this.topLevel : paper parameters, derived in the constructor
-  initializeShortestPaths()        // (re)set every nodeId's distance to Infinity
+  initializeShortestPaths()        // (re)set every nodeId's distance to Infinity; clears hops/preds
   buildAdjacency()                 // #45: (re)build adjacency from this.graph
   getEdges(nodeId)                 // #45: O(1) outgoing-edge lookup; [] for unknown nodes
   deriveParameters()               // #43: k = max(1,⌊(log₂n)^⅓⌋), t = max(1,⌊(log₂n)^⅔⌋),
                                    //      topLevel = max(1,⌈log₂n / t⌉) — from this.nodeIDs.size
-  bmssp(l, B, S)                   // #43: Algorithm 3 → { bound, vertices } (the paper's B', U)
-  calculateShortestPaths(startNode)// #43: validates, sets d̂[start] = 0, runs
+  bmssp(l, B, S)                   // #43: Algorithm 3 → { bound, boundKey, vertices } (B', its
+                                   //      composite key, U); B scalar or composite — scalar in,
+                                   //      scalar bound out (boundKey always composite)
+  calculateShortestPaths(startNode)// #43: validates, sets d̂[start] = 0 (hop 0), runs
                                    //      bmssp(topLevel, Infinity, {startNode}) — NO Dijkstra
 }
 ```
 
 **`bmssp(l, B, S)` (#43):** level 0 delegates to `baseCase`. At level ≥ 1: `findPivots`
-shrinks the frontier; pivots seed a `BlockList(M = 2^((l-1)·t), B)`; the loop pulls
-`Bi, Si ← D.pull()`, recurses `bmssp(l-1, Bi, Si)`, relaxes edges out of the returned `Ui`
-(band `[Bi, B)` → `D.insert`, band `[Bi', Bi)` → staged `K` → `D.batchPrepend` together with
-the uncompleted `Si` members), and stops when `D` empties (success, `bound === B`) or
-`|U| ≥ k·2^(l·t)` trips (partial, `bound < B`). Finally folds in the `W` vertices below the
+shrinks the frontier; pivots seed a `BlockList(M = 2^((l-1)·t), B, compareKeys)`; the loop
+pulls `Bi, Si ← D.pull()`, recurses `bmssp(l-1, Bi, Si)`, relaxes edges out of the returned
+`Ui` (band `[Bi, B)` → `D.insert`, band `[Bi', Bi)` → staged `K` → `D.batchPrepend` together
+with the uncompleted `Si` members), and stops when `D` empties (success, `boundKey` = B's
+key) or `|U| ≥ k·2^(l·t)` trips (partial). Finally folds in the `W` vertices below the
 returned bound. Since `k·2^(topLevel·t) ≥ n`, the top call is always a successful execution.
 
-**Degenerate-tie guards (Assumption 2.1 violations — context in #163).** Three deliberate
-deviations from the paper's literal text, each needed only when equal path lengths (e.g.
-zero-weight edges) occur; all are covered by tests in `test/bmssp.test.mjs`:
-1. **Completed-vertex guard:** a vertex already in this call's `U` is never re-queued by an
-   equal-sum relaxation (mirrors `baseCase`'s settled guard; prevents ping-pong loops).
-2. **Out-of-scope pivot gate:** a pull can return a key tied with its separator, so a pivot
-   can arrive with `d̂ ≥ B`; it is skipped when seeding `D` (`BlockList.insert` requires
-   `value < B`) — the ancestor whose band covers it is responsible for it.
-3. **Stall escape hatch:** if a child returns zero vertices (only possible when everything
-   it settled tied exactly at its boundary), the batch would be re-pulled forever; instead
-   each batch member is settled with an uncapped `baseCase` run bounded by `Bi` — correct,
-   just not sublinear. Boundary-tied `Si` members (`d̂ == Bi < B`) re-enter `D` via a regular
-   insert rather than being dropped.
-4. **Boundary-tied return (fuzz-found in #161, seed 163066):** through the escape hatch, a
-   bounded **partial** execution can return a vertex whose true distance **equals** the
-   returned `B'` (the paper's Lemma 3.1 states strict `d(v) < B'`, but that strictness
-   assumes Assumption 2.1). Returning it is required — it is complete and the parent must
-   relax out of it; dropping it would re-queue the same batch forever. Callers of
-   `bmssp(l, B, S)` must treat the returned-vertex contract as `d(v) ≤ B'` under ties
-   (the completeness direction stays strict: every `v` with `d(v) < B'` is returned).
+**Deterministic tie-breaking (#163, `src/tieBreak.mjs`).** All internal ordering uses
+composite `[length, hops, id]` keys (lexicographic), realizing the paper's Assumption 2.1
+(distinct path lengths): a zero-weight edge strictly increases `hops`, distinct vertex ids
+make every frontier comparison strict. Consequences, replacing the pre-#163 guards:
+1. **Canonical relaxation** (`relaxEdge`): d̂/hops/preds update together iff the candidate
+   path key `[d̂[u]+w, hops[u]+1, u]` beats the stored one — the chosen predecessor is the
+   smallest among `(length, hops)`-optimal parents, independent of edge/iteration order.
+2. **Exact-equality re-enqueue** (the paper's `≤` made canonical): when a completed `u`
+   re-derives `v`'s label exactly, `v` is re-enqueued at the current level (it was labeled
+   by a deeper call without being completed) — only the recorded label-setter triggers
+   this; the `U.has(v)` / `settled.has(v)` filters keep it finite. This is the lazy repair
+   chain that lets labels set by excluded boundary vertices get completed later.
+3. **Strict Lemma 3.1:** pull separators are strict, pivots never arrive tied with `B`
+   (the seeding filter now only scopes direct multi-source callers' sources), boundary-tied
+   batch members are impossible, a child's `U` is never empty — the old stall escape hatch
+   is gone. `boundKey` is strict: every returned vertex's key < `boundKey`; in the scalar
+   projection a returned vertex may still tie `bound`'s length (`d(v) ≤ bound`), never
+   exceed it.
+4. **Full determinism:** distances, hops, preds, and even partial-call `U`/`boundKey` are
+   invariant under edge-list permutation (`test/tieBreak.test.mjs` asserts this).
 
 **Performance (measured 2026-07-16, Apple Silicon, node v26.5.0 — full data + methodology
 in `benchmarks/HEAD-TO-HEAD.md`):** algorithm-only wall-clock (construction excluded,
@@ -155,18 +162,21 @@ Dijkstra past ~n = 1M sparse (0.96× at 1M, **0.91× at 2M**). Two measured path
 tracked in **#182**: star graphs blow up superlinearly (67.8× at n = 500k) and the ratio
 cliffs to 5× at n = 4M where `topLevel` steps 3→4. Note `topLevel` is **3 from n = 10k
 all the way to 2M** — scale tests buy volume/memory pressure, not recursion depth. The
-default suite runs in ~3 s; the opt-in `FUZZ_XL=1` 2M-node round takes ~30 s.
+default suite runs in ~3 s; the opt-in `FUZZ_XL=1` 2M-node round takes ~33 s (#163's
+composite keys added ~10% over the ~30 s scalar baseline — candidate for #168).
 
 ## `src/blockList.mjs` — Lemma 3.3 structure `D` (#42)
 
 ```js
 class BlockList {
-  constructor(M, B)        // block/pull size M >= 1 (floored), strict value upper bound B (Infinity OK)
+  constructor(M, B, compare?) // block/pull size M >= 1 (floored), strict value upper bound B
+                              // (Infinity OK); optional value comparator (default numeric) —
+                              // #163 passes compareKeys with composite-key values and bounds
   get size / isEmpty()
   insert(key, value)       // throws if !(value < B); duplicate key keeps the smallest value
   batchPrepend(pairs)      // iterable of [key, value]; caller guarantees "smaller than everything stored"
-  pull()                   // → { keys: Set, bound } — the ≤M smallest keys; max(pulled) ≤ bound ≤ min(remaining);
-}                          //   bound === B when the pull drains the structure
+  pull()                   // → { keys: Set, bound } — the ≤M smallest keys; bound = min(remaining)
+}                          //   exactly (strict under a total order); bound === B when drained
 export { BlockList };      // NOT re-exported from index.mjs — internal to the algorithm
 ```
 
@@ -177,20 +187,22 @@ Implementation notes (matches §03-B including its documented shortcuts):
 - Overfull `d1` block splits around the median via sort (O(M log M), not linear-time selection).
 - Big `batchPrepend` batches are sorted and chunked into blocks of ≤ ⌈M/2⌉, prepended to `d0`.
 - Last `d1` block (bound `B`) is kept even when empty so every `insert` finds a home.
-- **Tie caveat (seen in #43):** with equal values across a pull boundary, `pull()`'s bound can
-  equal a pulled key's value (the paper's `max(S') < x` is strict only under Assumption 2.1).
-  Callers must tolerate batch members with `d̂ == Bi` — `bmssp()` does (guards above).
+- The pulled set is always the exact M smallest values regardless of block layout, so pulls
+  are insertion-order independent. Under #163's composite keys (all values distinct) the
+  separator is strictly above every pulled value — the pre-#163 tie caveat (bound tying a
+  pulled key, `d̂ == Bi` batch members) is gone.
 
 ## `src/heap.mjs` — indexed binary min-heap (#41)
 
 ```js
 class MinHeap {
-  constructor()            // no parameters
+  constructor(compare?)    // optional value comparator (default numeric; non-number values
+                           // then throw) — #163's baseCase passes compareKeys
   get size / isEmpty()
   has(key)                 // O(1) membership — Algorithm 2's "if v not in H"
   getValue(key)            // current value or undefined
   peekMin()                // → { key, value } without removing; throws when empty
-  insert(key, value)       // throws on duplicate key or non-number value
+  insert(key, value)       // throws on duplicate key (and non-number value in numeric mode)
   decreaseKey(key, value)  // throws on missing key; ignored unless value < current (smallest wins)
   extractMin()             // → { key, value }; throws when empty
 }
@@ -204,41 +216,74 @@ variant `src/dijkstra.mjs` uses internally. An extracted key may be re-inserted 
 ## `src/baseCase.mjs` — `BaseCase(B, S)`, Algorithm 2 (#40)
 
 ```js
-baseCase(B, S, dHat, adjacency, k)  // → { bound, vertices }
-// B         : strict distance upper bound (Infinity OK)
+baseCase(B, S, dHat, adjacency, k, ties?)  // → { bound, boundKey, vertices }
+// B         : strict upper bound — scalar (Infinity OK) or composite key; scalar in,
+//             scalar bound out (boundKey always the composite boundary)
 // S         : singleton Set holding the complete source x (throws otherwise)
 // dHat      : Map<nodeId, number> — the global d̂[·]; RELAXED IN PLACE
 // adjacency : Map<nodeId, [to, weight][]> — the class's this.adjacency
 // k         : settle cap >= 1 (floored); throws otherwise
+// ties      : { hops, preds } canonical labels (#163); fresh throwaway maps by default
 export { baseCase };     // NOT re-exported from index.mjs — internal to the algorithm
 ```
 
-Bounded mini-Dijkstra from `x` on the `MinHeap`, stopping after settling `k+1` vertices.
-Full success (heap exhausted at ≤ k settled) → `{ bound: B, vertices: U0 }`; partial (cap
-hit) → `bound` = max settled `d̂`, `vertices` = the strictly-closer ones. Relaxation uses
-the paper's `≤` + `< B` test, with the settled-vertex guard against equal-sum re-insertion.
-`bmssp()` calls it at level 0, and also re-uses it (with `k = n`, uncapped) as the
-degenerate-tie stall escape hatch.
+Bounded mini-Dijkstra from `x` on a `MinHeap(compareKeys)` ordered by composite keys,
+stopping after settling `k+1` vertices. Full success (heap exhausted at ≤ k settled) →
+`{ bound: B, vertices: U0 }`; partial (cap hit) → `boundKey` = max settled key, `vertices` =
+exactly the k strictly-closer ones (composite-strict: a returned vertex may tie the
+boundary's scalar length). Relaxation is canonical `relaxEdge` gated by `< B`; the settled
+filter only skips exact-equality re-enqueue signals, keeping zero-weight plateaus quiescent.
+`bmssp()` calls it at level 0 (the pre-#163 escape-hatch re-use is gone).
 
 ## `src/findPivots.mjs` — `FindPivots(B, S)`, Algorithm 1 (#44)
 
 ```js
-findPivots(B, S, dHat, adjacency, k)  // → { pivots, W }
-// B         : strict bound gating membership in W (Infinity OK); d̂ updates are NOT gated
+findPivots(B, S, dHat, adjacency, k, ties?)  // → { pivots, W }
+// B         : strict bound gating membership in W — scalar (Infinity OK) or composite key;
+//             d̂ updates are NOT gated
 // S         : non-empty Set of complete frontier sources (throws if empty / any d̂ not finite)
 // dHat      : Map<nodeId, number> — the global d̂[·]; RELAXED IN PLACE
 // adjacency : Map<nodeId, [to, weight][]> — the class's this.adjacency
 // k         : rounds + tree-size threshold >= 1 (floored); throws otherwise
+// ties      : { hops, preds } canonical labels (#163); fresh throwaway maps by default
 export { findPivots };   // NOT re-exported from index.mjs — internal to the algorithm
 ```
 
-`k` rounds of Bellman-Ford relaxation out of `S` (paper's `≤` test; `< B` gates only the
-membership in `W`). **Early exit:** as soon as `|W| > k·|S|`, returns `pivots = S` (copy)
-with the partial `W`. Otherwise builds the tight-edge forest `F` inside `W` — each vertex
-takes **at most one parent** (ties/DAG caveat, see #163) — and returns as pivots the
-`S`-roots of trees with `≥ k` vertices. Guarantees `|pivots| ≤ |W|/k`. Note: a source with
-`d̂ ≥ B` can be returned as a pivot (early exit copies all of `S`); `bmssp()` filters those
-out when seeding `D`.
+`k` strictly-layered rounds of canonical relaxation out of `S` (`relaxEdge`, ungated;
+`< B` in the composite order gates only membership in `W`, and exact canonical equality
+re-admits an already-labeled vertex through its recorded setter). **Early exit:** as soon
+as `|W| > k·|S|`, returns `pivots = S` (copy) with the partial `W`. Otherwise the paper's
+tight-edge forest is simply the canonical predecessor pointers: every vertex of `W \ S`
+hangs off `preds[v]` (always itself in `W`), a DAG or tight cycle is impossible (one pred
+per vertex; zero-weight edges strictly increase hops), parent chains always end in `S`,
+and `S` members are roots by definition. Pivots = `S`-roots of trees with `≥ k` vertices;
+`|pivots| ≤ |W|/k`. The two #44-era tie ambiguities are resolved by construction. Note: a
+source with key ≥ `B` can still be returned as a pivot (early exit copies all of `S`,
+and direct multi-source callers may pass such sources); `bmssp()` filters them at seeding.
+
+## `src/tieBreak.mjs` — composite keys, Assumption 2.1 realized (#163)
+
+```js
+compareKeys(a, b)                  // lexicographic compare of [length, hops, id] triples
+toBound(B)                         // scalar B → [B, -Infinity, -Infinity] (infimum of length-B
+                                   // keys, so key < toBound(B) ⇔ the strict scalar contract);
+                                   // composite bounds pass through
+makeTies(hops?, preds?)            // bundle the canonical label maps (fresh by default)
+orderKey(v, dHat, ties)            // frontier key [d̂[v], hops[v] ?? 0, v]
+relaxEdge(u, v, w, dHat, ties, bound?) // canonical relaxation → { key, improved } | null:
+                                   // improved=true updated d̂/hops/preds together;
+                                   // improved=false = candidate exactly matches v's stored
+                                   // label (u is the recorded setter) — the re-enqueue signal
+export { compareKeys, toBound, makeTies, orderKey, relaxEdge, NO_PRED };
+                                   // NOT re-exported from index.mjs — internal to the algorithm
+```
+
+The paper's Assumption 2.1 ("all path lengths distinct") in code: paths ranked by
+`[length, hops, id]` — `hops` (the paper's "#vertices") makes zero-weight extensions
+strictly increasing, `id` (pred id inside relaxation, own id for frontier order) stands in
+for the paper's full vertex-sequence comparison at O(1). Sources (no stored pred) hold a
+`-Infinity` pred sentinel and never lose an equal-`(length, hops)` tie; unlabeled vertices
+read as hop-0 / distance-∞, so externally seeded multi-source calls need no extra setup.
 
 ## `src/dijkstra.mjs` — the oracle (already done)
 
@@ -265,7 +310,18 @@ implementation is tested against — and, since #43, no longer part of the BMSSP
   and seeded full-map-vs-oracle stress across sizes (up to n = 2000).
 - `test/blockList.test.mjs` (18), `test/heap.test.mjs` (16), `test/baseCase.test.mjs` (13),
   `test/findPivots.test.mjs` (12): per-module contracts incl. seeded stress — see the
-  module sections above.
+  module sections above. (Since #163 the baseCase partial-run tests assert the composite
+  contract: strictly below `boundKey`, `≤` the scalar bound.)
+- `test/tieBreak.test.mjs` (16, #163): unit tests for `compareKeys`/`toBound`/`relaxEdge`
+  (lexicographic order, scalar-bound infimum, canonical pred choice, zero-weight-cycle
+  quiescence, the equality re-enqueue signal), then the system-level properties:
+  **edge-order determinism** (full runs AND bounded partial calls return identical
+  d̂/hops/preds/`boundKey`/`U` across seeded permutations of tie-heavy 0–2-weight graphs),
+  **strict Lemma 3.1** (returned vertices strictly below `boundKey`; strict completeness),
+  the old zero-weight-cluster stall scenario under a tied bound, and canonical-label
+  equality against an independent O(n²) lexicographic-(length, hops) Dijkstra oracle
+  (hops = minimal edge count among shortest paths; preds = smallest optimal parent, chain
+  reaching the source acyclically).
 - `test/edgeCases.test.mjs` (9, #162): deterministic hand-built disconnection fixtures,
   each checked against a hand-computed full distance map **and** the Dijkstra oracle
   (Infinity entries included): self-loop-only source, sink source (adjacency keeps an
@@ -284,10 +340,10 @@ implementation is tested against — and, since #43, no longer part of the BMSSP
   oracles (`trueDist(v) = min_s(d0[s] + dist_s(v))`), checking the Lemma 3.1 contract for
   bounded (incl. boundary-tie `B` choices) and unbounded calls — plus **seeded scale runs**:
   sparse n = 150k (asserted `topLevel` 3) and grid 300×300 in the default suite, and an
-  **opt-in `FUZZ_XL=1` sparse n = 2M round** (~30 s, `test.skip` otherwise). Every failure
+  **opt-in `FUZZ_XL=1` sparse n = 2M round** (~33 s, `test.skip` otherwise). Every failure
   message carries the round's seed for reproduction. **`FUZZ_ROUNDS=<x>`** multiplies all
-  round counts (default 1 ≈ 0.5 s; 25 ≈ 5 s, several thousand graphs).
-- Current suite: **113 tests — 112 passing + 1 XL skipped by default**, 100% statement
+  round counts (default 1 ≈ 0.5 s; 25 ≈ 10 s, several thousand graphs).
+- Current suite: **129 tests — 128 passing + 1 XL skipped by default**, 100% statement
   coverage, ~3 s wall-clock. No graph data files: every generated test graph comes from a
   seed; the #162 fixtures are hand-built and fully deterministic.
 
@@ -312,7 +368,8 @@ comparison-count mode); the raw baseline is also on #170 as a comment.
 | FindPivots | `src/findPivots.mjs` | #44 | ✅ done (PR #180) |
 | Main `BMSSP(l, B, S)` recursion + `k,t` derivation | `src/bmssp.mjs` | #43 | ✅ done (PR #181) — **1.0.0 milestone complete** |
 | Property/fuzz suite vs. the oracle | `test/fuzz.test.mjs` | #161 | ✅ done (PR #184, 1.0.1) |
-| Deterministic disconnection edge cases | `test/edgeCases.test.mjs` | #162 | ✅ done (this PR, no bump) |
+| Deterministic disconnection edge cases | `test/edgeCases.test.mjs` | #162 | ✅ done (PR #187, no bump) |
+| Deterministic tie-breaking (Assumption 2.1) | `src/tieBreak.mjs` + all modules | #163 | ✅ done (this PR, no bump) |
 
-Milestone `1.1.0` (correctness hardening) is in progress: #162 lands with this PR; next up
-are #163, #165 — see [06-milestones-roadmap.md](06-milestones-roadmap.md).
+Milestone `1.1.0` (correctness hardening) is in progress: #163 lands with this PR; next up
+are #165, #164, #166 — see [06-milestones-roadmap.md](06-milestones-roadmap.md).

--- a/.claude/knowledge/06-milestones-roadmap.md
+++ b/.claude/knowledge/06-milestones-roadmap.md
@@ -1,9 +1,10 @@
 # 06 — Milestones Roadmap
 
-<!-- SYNCED-FROM-GITHUB: 2026-07-17 (#162 session: milestones 1.1.0/1.2.0/2.0.0 open with
-     5/5/3 open issues; #162 done-pending-merge in this PR) -->
-<!-- Current package version: 1.0.1 (released 2026-07-16; the #162 PR ships no bump under
-     the semver convention — see "Release mechanics" and PR #186) -->
+<!-- SYNCED-FROM-GITHUB: 2026-07-17 (#163 session: PRs #186 semver convention and #187
+     edge cases merged, #162 closed; milestones 1.1.0/1.2.0/2.0.0 open with 4/5/3 open
+     issues; #163 done-pending-merge in this PR) -->
+<!-- Current package version: 1.0.1 (released 2026-07-16; the #163 PR ships no bump under
+     the semver convention — enhancement, milestone still open) -->
 
 Maps GitHub **milestones** and **issues** (Sirivasv/bmssp-js) to the paper's building blocks,
 with a dependency-aware build order. This is the "intent" side of the knowledge base (what to
@@ -39,19 +40,22 @@ it runs the same Phase C reconciliation directly on `main`.
 
 ## 📋 Roadmap proposals (pending user approval)
 
-From the #162 PR (Phase C, 2026-07-17):
+From the #163 PR (Phase C, 2026-07-17):
 
-1. **Comment on #165 (input validation):** the #162 edge-case work locked in the current
-   empty-graph behavior — `new BMSSP([])` constructs silently and only
-   `calculateShortestPaths()` throws (`"Start node not found in the graph"`,
-   `test/edgeCases.test.mjs`). Propose adding a note to #165 so the validation design
-   explicitly decides whether an empty edge list should throw at construction or stay
-   allowed (and, if allowed, that the test's locked-in behavior is the contract).
+1. **Re-scope #169 (path reconstruction, milestone 1.2.0):** #163 already ships the
+   canonical predecessor map — `BMSSP.preds` holds a deterministic shortest-path tree
+   (smallest optimal parent, verified against a lexicographic oracle). Propose editing
+   #169's description: the remaining work is only exposing a public
+   `reconstructPath(target)` (walk `preds` backwards), not building `Pred[]` itself.
+2. **Comment on #168 (micro-optimizations, milestone 1.2.0):** #163's composite keys cost
+   ~10% on the 2M-node XL round (~30 s → ~33 s) — the hot spots are the per-relaxation
+   array allocations in `relaxEdge` and `compareKeys` calls in the heap/block-list. Worth
+   listing as a concrete optimization target (e.g. packed number encoding or key reuse).
 
 _Phase C writes proposed GitHub edits here (and in the PR body); Phase E executes the
 approved ones — one confirmation each — and clears them from this list._
-_(The #185-PR proposal — removal note on closed **#24** — was approved and executed
-2026-07-17. Earlier: both #161-PR proposals executed 2026-07-16 on **#163**/**#162**.)_
+_(The #187-PR proposal — empty-graph validation note on **#165** — was approved and
+executed 2026-07-17.)_
 
 ---
 
@@ -71,9 +75,12 @@ _(The #185-PR proposal — removal note on closed **#24** — was approved and e
   and dates preserved), `main` + all 21 tags force-pushed with ruleset 7764713
   temporarily disabled. **All commit SHAs before 2026-07-17 changed**; old SHAs in
   closed PRs/issues no longer resolve. Repo-local git config now signs future commits.
-- **Milestone `1.1.0` — correctness hardening** (in progress). **#162 done-pending-merge**
-  (this PR: `test/edgeCases.test.mjs`, 9 deterministic disconnection fixtures, no bump).
-  Next: **#163** (tie-breaking), then #165.
+- **Milestone `1.1.0` — correctness hardening** (in progress). #162 merged (PR #187).
+  **#163 done-pending-merge** (this PR): `src/tieBreak.mjs` composite `[length, hops, id]`
+  keys realize Assumption 2.1 end-to-end — canonical relaxation (d̂/hops/preds in
+  lockstep), strict pull separators, all pre-#163 tie guards removed (incl. the stall
+  escape hatch), strict Lemma 3.1 restored, full edge-order determinism proven by test.
+  No bump. Next: **#165** (input validation), then #164, #166.
 - **Semver release convention (user-directed 2026-07-17, PR #186):** bumps only on bug
   fix (patch) or milestone-closing PR (minor/major) — see "Release mechanics" below.
 - **2026-07-16 reflection session (post-release):** measured the BMSSP-vs-Dijkstra
@@ -112,8 +119,8 @@ Recommended order (cheapest protection first, then the deep work):
 | Order | # | Issue | Labels | Notes |
 |---|---|---|---|---|
 | 1 | 161 | Property/fuzz tests: BMSSP vs Dijkstra on random graphs | enhancement · help wanted | ✅ merged (PR #184, 1.0.1) |
-| 2 | 162 | Edge-case tests: disconnected graphs and unreachable nodes | enhancement · help wanted | ✅ done-pending-merge (this PR, no bump): deterministic fixtures in `test/edgeCases.test.mjs`; randomized side already in #161 fuzz |
-| 3 | 163 | Deterministic tie-breaking for equal-length paths (Assumption 2.1) | enhancement · help wanted | Four concrete manifestations now: three from #43, boundary-tied return from #161 |
+| 2 | 162 | Edge-case tests: disconnected graphs and unreachable nodes | enhancement · help wanted | ✅ merged (PR #187, no bump) |
+| 3 | 163 | Deterministic tie-breaking for equal-length paths (Assumption 2.1) | enhancement · help wanted | ✅ done-pending-merge (this PR, no bump): composite keys in `src/tieBreak.mjs`, all six tie manifestations resolved by construction |
 | 4 | 165 | Input validation for the BMSSP constructor | good first issue · help wanted | — |
 | 5 | 164 | Optional constant-degree transform (in/out-degree ≤ 2) | enhancement · help wanted | — |
 | 6 | 166 | JSDoc / API docs for the new modules | documentation · good first issue | `bmssp()` / `deriveParameters()` ship with JSDoc already |
@@ -179,5 +186,7 @@ release step is an outward-facing publish and is **gated on explicit user confir
 - Any `bmssp(l, B, S)` call's completed vertices+distances must equal
   `{ v : d_dijkstra(v) < B', shortest path visits S }` — `test/bmssp.test.mjs` has the
   pattern ("recursion contract" describe block).
-- Ties (equal path lengths) are the #1 source of subtle bugs — see the degenerate-tie
-  guards in `05-codebase-map.md` and the notes headed for #163.
+- Ties (equal path lengths) were the #1 source of subtle bugs until #163 resolved them
+  with composite `[length, hops, id]` keys — see "Deterministic tie-breaking" in
+  `05-codebase-map.md`. Tie-heavy graphs (0–2 weights) remain the best stress inputs;
+  `test/tieBreak.test.mjs` has the edge-order-permutation and lex-oracle patterns.

--- a/.claude/knowledge/07-glossary.md
+++ b/.claude/knowledge/07-glossary.md
@@ -19,7 +19,7 @@ Quick lookup for the symbols and terms used across the paper, the notes, and the
 | `d(v)` | **true** shortest distance from `s` to `v`. |
 | `d̂[v]` | current distance **estimate** (`≥ d(v)`, starts ∞, only decreases). In code: `shortestPaths` map. |
 | `w(u,v)`, `w_uv` | weight of edge `(u,v)`; non-negative. |
-| `Pred[v]` | predecessor of `v` on the current best path (forms a tree). |
+| `Pred[v]` | predecessor of `v` on the current best path (forms a tree). In code: the canonical `preds` map (#163), deterministic smallest optimal parent. |
 | `B` | upper distance **bound** for a (sub)problem; only vertices with `d < B` are in scope. |
 | `B'` | the **returned** boundary of a call, `B' ≤ B`. Says how much real progress was made. |
 | `S` | the **frontier** / source set of a (sub)problem. `|S| ≤ 2^(l·t)`. |
@@ -27,7 +27,7 @@ Quick lookup for the symbols and terms used across the paper, the notes, and the
 | `U'` | (analysis) all `v` with `d(v) < B` whose shortest path visits `S`. Success ⇒ `U = U'`. |
 | `P` | **pivots**: the ⊆ `S` roots of big shortest-path trees; `|P| ≤ |W|/k`. From FindPivots. |
 | `W` | vertices completed/collected by FindPivots' `k` Bellman-Ford rounds; `|W| = O(k·|S|)`. |
-| `F` | forest of "tight" edges (`d̂[v] == d̂[u]+w(u,v)`) inside `W`; used to find pivot roots. |
+| `F` | forest of "tight" edges (`d̂[v] == d̂[u]+w(u,v)`) inside `W`; used to find pivot roots. In code since #163: the canonical `preds` pointers restricted to `W`. |
 | `D` | the Lemma 3.3 **block-based list** (Insert / BatchPrepend / Pull). §03-B. |
 | `k` | `⌊log^(1/3) n⌋`. Bellman-Ford step count in FindPivots; base-case batch cap (`k+1`). |
 | `t` | `⌊log^(2/3) n⌋`. Governs branching/level sizing. |
@@ -98,28 +98,33 @@ Quick lookup for the symbols and terms used across the paper, the notes, and the
   skip stale pops). Both are correct; §03-A discusses the trade-off.
 - **`baseCase(B, S, dHat, adjacency, k)`** (#40) — `src/baseCase.mjs`, Algorithm 2:
   bounded mini-Dijkstra from the singleton complete source in `S`, settling at most `k+1`
-  vertices, relaxing the shared `dHat` (`d̂[·]`) **in place**. Returns `{ bound, vertices }`
-  (= the paper's `B', U`). Internal (not re-exported from `index.mjs`).
-- **Settled-vertex guard** (#40) — `baseCase` never re-inserts a vertex it already settled
-  in the same call: the paper's `≤` relaxation admits equal-sum re-relaxations (e.g.
-  zero-weight cycles) that would loop forever, and with non-negative weights a settled
-  vertex cannot strictly improve, so skipping it is loss-free.
-- **`findPivots(B, S, dHat, adjacency, k)`** (#44) — `src/findPivots.mjs`, Algorithm 1:
-  `k` rounds of Bellman-Ford out of the complete frontier `S`, relaxing the shared `dHat`
-  (`d̂[·]`) **in place**; `< B` gates membership in `W` only (the d̂ write is unconditional).
-  Returns `{ pivots, W }` (= the paper's `P, W`), with `|pivots| ≤ |W|/k`. Internal (not
-  re-exported from `index.mjs`).
+  vertices, relaxing the shared `dHat` (`d̂[·]`) **in place** (canonically, with an optional
+  `ties` bundle since #163). Returns `{ bound, boundKey, vertices }` (= the paper's `B'`,
+  its composite key, `U`). Internal (not re-exported from `index.mjs`).
+- **Settled filter** (#40, re-scoped by #163) — `baseCase` never re-inserts a vertex it
+  already settled in the same call. Pre-#163 this guarded against equal-sum ping-pong
+  loops; since #163 strict canonical relaxation makes improvements on settled vertices
+  impossible, and the filter only skips exact-equality re-enqueue signals (see
+  "Re-enqueue signal"), keeping zero-weight plateaus quiescent.
+- **`findPivots(B, S, dHat, adjacency, k, ties?)`** (#44) — `src/findPivots.mjs`,
+  Algorithm 1: `k` strictly-layered rounds of canonical Bellman-Ford out of the complete
+  frontier `S`, relaxing the shared `dHat` (`d̂[·]`) **in place**; `< B` (composite) gates
+  membership in `W` only (the d̂ write is unconditional). Returns `{ pivots, W }` (= the
+  paper's `P, W`), with `|pivots| ≤ |W|/k`; the forest is the canonical `preds` pointers.
+  Internal (not re-exported from `index.mjs`).
 - **Early exit** (#44) — `findPivots`' first branch: as soon as `|W| > k·|S|` after a round,
   return `pivots = S` — the frontier is already small relative to `W`.
-- **One-parent rule** (#44) — building the tight-edge forest `F`, each vertex accepts at
-  most one parent (the first tight edge in W-iteration order). Keeps tree sizes well-defined
-  when equal-length paths make `F` a DAG (tie caveat, #163). Corollary: vertices on a tight
-  (zero-weight) cycle all have parents, so none roots a tree and none can be a pivot.
+- **One-parent rule** (#44, superseded by #163) — pre-#163, each vertex accepted the first
+  tight edge in W-iteration order as its parent to keep tree sizes well-defined when ties
+  made `F` a DAG. Since #163 the forest **is** the canonical `preds` pointers: exactly one
+  deterministic parent per vertex of `W \ S`, no DAG possible, and tight cycles cannot
+  exist (zero-weight edges strictly increase hops). `S` members are roots by definition.
 - **`bmssp(l, B, S)`** (#43) — method on the `BMSSP` class, Algorithm 3: the main bounded
   multi-source recursion. Level 0 delegates to `baseCase`; level ≥ 1 wires `findPivots` →
   `BlockList` → recursive `bmssp(l-1, Bi, Si)` calls with band-routed relaxation. Returns
-  `{ bound, vertices }` (= the paper's `B', U`). `calculateShortestPaths(start)` runs
-  `bmssp(topLevel, Infinity, {start})` after setting `d̂[start] = 0`.
+  `{ bound, boundKey, vertices }` (= the paper's `B'`, its composite key, `U`); scalar `B`
+  in → scalar `bound` out. `calculateShortestPaths(start)` runs
+  `bmssp(topLevel, Infinity, {start})` after setting `d̂[start] = 0`, `hops[start] = 0`.
 - **`deriveParameters()`** (#43) — class method (called by the constructor) that derives and
   stores `this.k`, `this.t`, `this.topLevel` from `n = nodeIDs.size`, each clamped to ≥ 1:
   `k = ⌊(log₂n)^(1/3)⌋`, `t = ⌊(log₂n)^(2/3)⌋`, `topLevel = ⌈log₂n / t⌉`. The clamp keeps
@@ -127,25 +132,37 @@ Quick lookup for the symbols and terms used across the paper, the notes, and the
   successful execution.
 - **Workload guard / cap** (#43) — Algorithm 3's `|U| < k·2^(l·t)` loop condition: trips on
   partial executions (`bound < B`); can never trip below `n` at the top level.
-- **Completed-vertex guard** (#43) — `bmssp()` never re-queues a vertex already in the
-  current call's `U` on an equal-sum relaxation (the level-≥1 mirror of `baseCase`'s
-  settled-vertex guard; prevents zero-weight ping-pong loops).
-- **Out-of-scope pivot gate** (#43) — a pivot arriving with `d̂ ≥ B` (possible when a pull
-  returns a key tied with its separator) is skipped when seeding `D`; the ancestor whose
-  band covers its distance handles it. Tie caveat, #163.
-- **Stall escape hatch** (#43) — when a child `bmssp`/`baseCase` call returns zero vertices
-  (everything it settled tied exactly at its boundary — zero-weight paths, #163), each batch
-  member is settled with an uncapped `baseCase` run (`k = n`) bounded by `Bi` so the loop
-  always makes progress. Correct, just not sublinear; only reachable on Assumption 2.1
-  violations.
-- **Boundary-tied re-queue** (#43) — an `Si` member left at `d̂ == Bi < B` after the child
-  returns re-enters `D` via a regular `insert` (the paper's `[Bi', Bi)` band would silently
-  drop it). Tie caveat, #163.
-- **Boundary-tied return** (#161) — under ties, a bounded **partial** `bmssp()` execution
-  can return a vertex with `d(v) == B'` (via the stall escape hatch); Lemma 3.1's strict
-  `d(v) < B'` holds only under Assumption 2.1. Internal contract under ties: returned
-  vertices satisfy `d(v) ≤ B'`, completeness below `B'` stays strict. Tie caveat, #163;
-  fuzz-found at seed 163066.
+- **Pre-#163 tie guards (historical)** — four deviations from the paper's literal text
+  that handled Assumption 2.1 violations before #163 removed them by construction:
+  the *completed-vertex guard* (no equal-sum re-queue of `U` members), the *out-of-scope
+  pivot gate* (pivots tied with `B` skipped at seeding), the *stall escape hatch*
+  (uncapped `baseCase` runs when a child returned zero vertices), and the *boundary-tied
+  re-queue / return* (`d̂ == Bi` batch members re-inserted; partial executions returning
+  `d(v) == B'`, fuzz-found at seed 163066). All are impossible under composite keys; the
+  scalar-projection caveat `d(v) ≤ bound` for returned vertices remains the documented
+  external contract (`boundKey` carries the strict form).
+- **Composite key** (#163) — `[length, hops, id]` compared lexicographically
+  (`src/tieBreak.mjs`): `length` = path length, `hops` = edge count (the paper's
+  "#vertices" tie-break — zero-weight extensions strictly increase it), `id` = pred id in
+  relaxation / own id in frontier order (O(1) stand-in for the paper's vertex-sequence
+  comparison). Realizes Assumption 2.1: all frontier comparisons strict.
+- **Canonical label / relaxation** (#163) — `relaxEdge(u, v, w, dHat, ties, bound?)`
+  updates `d̂`/`hops`/`preds` together iff the candidate path key beats the stored one;
+  the fixed point is the lexicographic minimum over all paths, so labels, predecessor
+  pointers and completed sets are invariant under edge/iteration order (tested in
+  `test/tieBreak.test.mjs` against an O(n²) lexicographic Dijkstra oracle).
+- **Re-enqueue signal** (#163) — `relaxEdge`'s `improved: false` result: the candidate
+  exactly matches `v`'s stored label, meaning `u` is the recorded label-setter and `v` was
+  labeled by a deeper call without being completed. The caller re-enqueues `v` unless it
+  is already settled/completed — the paper's `≤` relaxation made canonical, firing from
+  exactly one predecessor.
+- **`ties`** (#163) — the `{ hops, preds }` bundle (`makeTies`) that accompanies `dHat`
+  through `baseCase`/`findPivots`/`relaxEdge`; the `BMSSP` class owns one as `this.ties`
+  (`this.hops`, `this.preds`), cleared by `initializeShortestPaths()`. Missing entries
+  read as hop-0 / no-pred, so externally seeded sources need no setup.
+- **`boundKey`** (#163) — the composite boundary in `baseCase`/`bmssp` results: every
+  returned vertex's order key is strictly below it. The scalar `bound` is its projection
+  (a returned vertex may tie `bound`'s length, never exceed it).
 - **Fuzz suite** (#161) — `test/fuzz.test.mjs`: high-volume seeded property tests. Full-map
   oracle equality across 8 graph shapes and 4 extreme weight regimes, plus direct
   multi-source bounded `bmssp(topLevel, B, S)` checks against per-source Dijkstra oracles

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ with every building block shipped, tested, and released individually:
 | `BaseCase(B, S)` — Algorithm 2, bounded mini-Dijkstra ([#40](https://github.com/Sirivasv/bmssp-js/issues/40)) | `src/baseCase.mjs` | ✅ done |
 | `FindPivots(B, S)` — Algorithm 1, frontier shrinking ([#44](https://github.com/Sirivasv/bmssp-js/issues/44)) | `src/findPivots.mjs` | ✅ done |
 | `BMSSP(l, B, S)` — Algorithm 3, the main recursion ([#43](https://github.com/Sirivasv/bmssp-js/issues/43)) | `src/bmssp.mjs` | ✅ done — **1.0.0** |
+| Deterministic tie-breaking — Assumption 2.1 realized ([#163](https://github.com/Sirivasv/bmssp-js/issues/163)) | `src/tieBreak.mjs` | ✅ done |
 
 > **Honest note:** the paper's win is asymptotic, and this repo optimizes for correctness
 > and readability, not raw speed. Measured head-to-head (algorithm time only, graph
@@ -40,8 +41,10 @@ with every building block shipped, tested, and released individually:
 > from about n = 1M on sparse graphs** (0.91× at n = 2M), and the advantage grows with
 > size: the "sorting barrier" is measurably broken; what remains is JS constant factors.
 > Where inputs violate the paper's distinct-path-lengths assumption (e.g. zero-weight
-> edges), documented tie guards keep the results correct
-> ([#163](https://github.com/Sirivasv/bmssp-js/issues/163) tracks a principled tie-break).
+> edges), a principled deterministic tie-break
+> ([#163](https://github.com/Sirivasv/bmssp-js/issues/163)) realizes that assumption in
+> code: paths are ranked by composite `(length, hops, id)` keys, so distances, predecessor
+> pointers and completed sets are identical no matter how the edge list is ordered.
 
 ## How it works (in two ideas)
 

--- a/src/baseCase.mjs
+++ b/src/baseCase.mjs
@@ -1,4 +1,11 @@
 import { MinHeap } from "./heap.mjs";
+import {
+  compareKeys,
+  toBound,
+  makeTies,
+  orderKey,
+  relaxEdge,
+} from "./tieBreak.mjs";
 
 /**
  * BaseCase(B, S) — Algorithm 2 of "Breaking the Sorting Barrier for Directed
@@ -12,26 +19,40 @@ import { MinHeap } from "./heap.mjs";
  *
  * Distance estimates are read from and written into dHat in place — exactly
  * like the paper's global d̂[·] labels, so improvements made here are visible
- * to the levels above.
+ * to the levels above. Since #163 the heap is ordered by the composite
+ * [length, hops, id] keys of src/tieBreak.mjs, which realize the paper's
+ * Assumption 2.1 (distinct path lengths): a settled vertex carries its
+ * canonical (lexicographically minimal) label, which no later relaxation can
+ * improve. The settled filter below only skips canonical re-enqueue signals
+ * (exact label equality from the recorded predecessor), which is what keeps
+ * zero-weight plateaus quiescent instead of looping.
  *
  * Two outcomes:
  * - Full success (fewer than k + 1 vertices exist under B): every vertex
- *   with d(v) < B is settled and returned, with bound === B.
- * - Partial (the k + 1 cap was hit): bound = the largest settled distance
- *   B' <= B, and only the strictly-closer vertices (d̂ < B') are returned.
+ *   with key < B is settled and returned, with bound === B.
+ * - Partial (the k + 1 cap was hit): boundKey = the largest settled key
+ *   B' < B, and exactly the k strictly-closer vertices are returned. Under
+ *   the composite order the strictly-closer filter is exact — scalar-length
+ *   ties with the boundary vertex are broken by (hops, id), and a returned
+ *   vertex may therefore share the boundary's scalar length (the documented
+ *   d(v) <= bound caveat of the scalar view).
  *   Every returned vertex is complete either way.
  *
- * @param {number} B - Strict upper bound on the distances to settle (Infinity is allowed)
+ * @param {number|[number, number, *]} B - Strict upper bound on the keys to
+ *   settle: a number (Infinity is allowed) or a composite bound
  * @param {Set<*>|Iterable<*>} S - Singleton set holding the complete source x
  * @param {Map<*, number>} dHat - Global distance estimates d̂[·], updated in place
  * @param {Map<*, Array<[*, number]>>} adjacency - nodeId -> outgoing [to, weight] edges
  * @param {number} k - Settle cap parameter, >= 1 (floored); the paper's ⌊log^(1/3) n⌋
- * @returns {{ bound: number, vertices: Set<*> }} The boundary B' <= B and the
- *   set U of vertices settled below it
+ * @param {{ hops: Map<*, number>, preds: Map<*, *> }} [ties] - Canonical
+ *   tie-break labels updated alongside dHat; fresh throwaway maps by default
+ * @returns {{ bound: number|[number, number, *], boundKey: [number, number, *], vertices: Set<*> }}
+ *   The boundary B' <= B (same kind as the B passed in), its composite key,
+ *   and the set U of vertices settled below it
  * @throws {Error} If k is not a number >= 1, S is not a singleton, or the
  *   source has no finite distance estimate
  */
-function baseCase(B, S, dHat, adjacency, k) {
+function baseCase(B, S, dHat, adjacency, k, ties = makeTies()) {
   if (typeof k !== "number" || Number.isNaN(k) || k < 1) {
     throw new Error("k must be a number >= 1");
   }
@@ -45,50 +66,53 @@ function baseCase(B, S, dHat, adjacency, k) {
   if (typeof sourceDistance !== "number" || !Number.isFinite(sourceDistance)) {
     throw new Error("the source must have a finite distance estimate");
   }
+  const boundKey = toBound(B);
 
   // U0 in the paper: the vertices settled by this call, seeded with x
   const settled = new Set([x]);
-  const heap = new MinHeap();
-  heap.insert(x, sourceDistance);
+  const heap = new MinHeap(compareKeys);
+  heap.insert(x, orderKey(x, dHat, ties));
 
   while (!heap.isEmpty() && settled.size < cap + 1) {
-    const { key: u, value: du } = heap.extractMin();
+    const { key: u } = heap.extractMin();
     settled.add(u);
     for (const [v, weight] of adjacency.get(u) ?? []) {
-      const candidate = du + weight;
-      // Paper relaxation: d̂[u] + w(u,v) <= d̂[v], and below the bound B
-      if (candidate <= (dHat.get(v) ?? Infinity) && candidate < B) {
-        dHat.set(v, candidate);
-        // With non-negative weights a vertex settled in this call cannot
-        // strictly improve, so an equal-sum relaxation (which the <= allows,
-        // e.g. via a zero-weight cycle) must not re-enter the heap.
-        if (settled.has(v)) continue;
-        if (heap.has(v)) {
-          heap.decreaseKey(v, candidate);
-        } else {
-          heap.insert(v, candidate);
-        }
+      // Canonical relaxation, gated by the bound (the paper's `< B`). An
+      // exact-equality result means u is v's recorded label-setter (v was
+      // labeled by an earlier phase without being completed) and v must be
+      // (re-)enqueued — unless this very call already settled it, which is
+      // what keeps zero-weight plateaus finite.
+      const relaxed = relaxEdge(u, v, weight, dHat, ties, boundKey);
+      if (relaxed === null || settled.has(v)) continue;
+      if (heap.has(v)) {
+        heap.decreaseKey(v, relaxed.key);
+      } else {
+        heap.insert(v, relaxed.key);
       }
     }
   }
 
   if (settled.size <= cap) {
     // Exhausted before the cap: everything under B is settled (B' = B)
-    return { bound: B, vertices: settled };
+    return { bound: B, boundKey, vertices: settled };
   }
 
-  // Hit the k + 1 cap: report B' = the largest settled distance and return
-  // only the vertices strictly below it
-  let boundary = -Infinity;
+  // Hit the k + 1 cap: report B' = the largest settled key and return the
+  // vertices strictly below it — exactly k of them, keys being distinct
+  let boundary = null;
   for (const v of settled) {
-    const distance = dHat.get(v);
-    if (distance > boundary) boundary = distance;
+    const key = orderKey(v, dHat, ties);
+    if (boundary === null || compareKeys(key, boundary) > 0) boundary = key;
   }
   const vertices = new Set();
   for (const v of settled) {
-    if (dHat.get(v) < boundary) vertices.add(v);
+    if (compareKeys(orderKey(v, dHat, ties), boundary) < 0) vertices.add(v);
   }
-  return { bound: boundary, vertices };
+  return {
+    bound: typeof B === "number" ? boundary[0] : boundary,
+    boundKey: boundary,
+    vertices,
+  };
 }
 
 export { baseCase };

--- a/src/blockList.mjs
+++ b/src/blockList.mjs
@@ -22,15 +22,19 @@ class BlockList {
   /**
    * Initialize the structure (Lemma 3.3 Initialize).
    * @param {number} M - Block size / pull batch size, >= 1. At recursion level l this is 2^((l-1)·t).
-   * @param {number} B - Strict upper bound on every value ever stored (Infinity is allowed)
+   * @param {*} B - Strict upper bound on every value ever stored (Infinity is allowed)
+   * @param {(a: *, b: *) => number} [compare] - Value comparator (negative
+   *   when a < b). Defaults to numeric order; #163 passes composite
+   *   [length, hops, id] keys with their lexicographic comparator.
    * @throws {Error} If M is not a number >= 1
    */
-  constructor(M, B) {
+  constructor(M, B, compare) {
     if (typeof M !== "number" || Number.isNaN(M) || M < 1) {
       throw new Error("M must be a number >= 1");
     }
     this.M = Math.floor(M);
     this.B = B;
+    this.compare = compare ?? ((a, b) => (a < b ? -1 : a > b ? 1 : 0));
     // d1 starts as a single empty block with upper bound B
     this.d1 = [this.makeBlock(B)];
     this.d0 = [];
@@ -61,12 +65,12 @@ class BlockList {
    * @throws {Error} If value >= B
    */
   insert(key, value) {
-    if (!(value < this.B)) {
+    if (!(this.compare(value, this.B) < 0)) {
       throw new Error("value must be < B");
     }
     const holder = this.locator.get(key);
     if (holder !== undefined) {
-      if (holder.entries.get(key) <= value) return;
+      if (this.compare(holder.entries.get(key), value) <= 0) return;
       this.removeKey(key, holder);
     }
     // Binary-search d1 for the first block whose bound covers the value
@@ -74,7 +78,7 @@ class BlockList {
     let hi = this.d1.length - 1;
     while (lo < hi) {
       const mid = (lo + hi) >> 1;
-      if (this.d1[mid].bound >= value) {
+      if (this.compare(this.d1[mid].bound, value) >= 0) {
         hi = mid;
       } else {
         lo = mid + 1;
@@ -96,7 +100,7 @@ class BlockList {
   // simpler — acceptable for this correctness-first implementation.)
   splitBlock(index) {
     const block = this.d1[index];
-    const sorted = [...block.entries].sort((a, b) => a[1] - b[1]);
+    const sorted = [...block.entries].sort((a, b) => this.compare(a[1], b[1]));
     const half = sorted.length >> 1;
     const lower = this.makeBlock(sorted[half - 1][1]);
     for (let i = 0; i < half; i += 1) {
@@ -121,11 +125,11 @@ class BlockList {
     // Dedupe the batch, keeping the smallest value per key
     const best = new Map();
     for (const [key, value] of pairs) {
-      if (!(value < this.B)) {
+      if (!(this.compare(value, this.B) < 0)) {
         throw new Error("value must be < B");
       }
       const seen = best.get(key);
-      if (seen === undefined || value < seen) {
+      if (seen === undefined || this.compare(value, seen) < 0) {
         best.set(key, value);
       }
     }
@@ -134,7 +138,7 @@ class BlockList {
     for (const [key, value] of best) {
       const holder = this.locator.get(key);
       if (holder !== undefined) {
-        if (holder.entries.get(key) <= value) continue;
+        if (this.compare(holder.entries.get(key), value) <= 0) continue;
         this.removeKey(key, holder);
       }
       fresh.push([key, value]);
@@ -145,7 +149,7 @@ class BlockList {
     if (fresh.length <= this.M) {
       chunks = [fresh];
     } else {
-      fresh.sort((a, b) => a[1] - b[1]);
+      fresh.sort((a, b) => this.compare(a[1], b[1]));
       const chunkSize = Math.ceil(this.M / 2);
       chunks = [];
       for (let i = 0; i < fresh.length; i += chunkSize) {
@@ -155,11 +159,13 @@ class BlockList {
     // Prepend in reverse chunk order so the smallest chunk lands at the front
     for (let c = chunks.length - 1; c >= 0; c -= 1) {
       const chunk = chunks[c];
-      const block = this.makeBlock(-Infinity);
+      // Seed the block bound with the first value, then max-update — avoids
+      // needing a -Infinity sentinel that a custom comparator can't order
+      const block = this.makeBlock(chunk[0][1]);
       for (const [key, value] of chunk) {
         block.entries.set(key, value);
         this.locator.set(key, block);
-        if (value > block.bound) block.bound = value;
+        if (this.compare(value, block.bound) > 0) block.bound = value;
         this.count += 1;
       }
       this.d0.unshift(block);
@@ -198,21 +204,24 @@ class BlockList {
       }
     }
     // Take the M smallest candidates out of the structure
-    candidates.sort((a, b) => a[1] - b[1]);
+    candidates.sort((a, b) => this.compare(a[1], b[1]));
     const keys = new Set();
     for (let i = 0; i < this.M; i += 1) {
       const [key, , block] = candidates[i];
       keys.add(key);
       this.removeKey(key, block);
     }
-    // Separator = smallest value still stored. Thanks to the inter-block
-    // ordering it lives in the first non-empty block of d0 or d1.
-    let bound = Infinity;
+    // Separator = smallest value still stored (non-null here: this branch
+    // only runs when more than M values were present). Thanks to the
+    // inter-block ordering it lives in the first non-empty block of d0/d1.
+    // Under a strict total order (#163's composite keys) this separator is
+    // strictly above every pulled value — no boundary ties.
+    let bound = null;
     for (const seq of [this.d0, this.d1]) {
       const block = seq.find((b) => b.entries.size > 0);
       if (block) {
         for (const value of block.entries.values()) {
-          if (value < bound) bound = value;
+          if (bound === null || this.compare(value, bound) < 0) bound = value;
         }
       }
     }

--- a/src/bmssp.mjs
+++ b/src/bmssp.mjs
@@ -1,6 +1,13 @@
 import { baseCase } from "./baseCase.mjs";
 import { findPivots } from "./findPivots.mjs";
 import { BlockList } from "./blockList.mjs";
+import {
+  compareKeys,
+  toBound,
+  makeTies,
+  orderKey,
+  relaxEdge,
+} from "./tieBreak.mjs";
 
 class BMSSP {
   constructor(inputGraph) {
@@ -14,6 +21,13 @@ class BMSSP {
     // Lets the algorithm fetch a node's edges in O(1) instead of scanning
     // the whole edge list on every lookup.
     this.adjacency = new Map();
+    // Canonical tie-break labels (#163): hops = edge count of the canonical
+    // shortest path, preds = its predecessor pointer. Updated in lockstep
+    // with shortestPaths by relaxEdge; together they realize the paper's
+    // Assumption 2.1 (distinct path lengths) via [length, hops, id] keys.
+    this.hops = new Map();
+    this.preds = new Map();
+    this.ties = makeTies(this.hops, this.preds);
 
     for (let edge of inputGraph) {
       // Create a deep copy of each edge array
@@ -57,11 +71,14 @@ class BMSSP {
     return this.adjacency.get(nodeId) ?? [];
   }
 
-  // Method to initialize the shortest paths map
+  // Method to initialize the shortest paths map (and the #163 tie-break
+  // labels that travel with it)
   initializeShortestPaths() {
     for (let nodeId of this.nodeIDs) {
       this.shortestPaths.set(nodeId, Infinity);
     }
+    this.hops.clear();
+    this.preds.clear();
   }
 
   /**
@@ -93,45 +110,79 @@ class BMSSP {
    *   path through some complete vertex of S.
    *
    * Distance estimates live in this.shortestPaths (the paper's d̂[·]) and
-   * are relaxed in place at every level.
+   * are relaxed in place at every level, together with the canonical hops
+   * and preds labels (#163). All internal ordering uses the composite
+   * [length, hops, id] keys of src/tieBreak.mjs, which realize the paper's
+   * Assumption 2.1: pull separators are strict, no key ever ties a bound,
+   * and the pre-#163 degenerate-tie guards (out-of-scope pivots,
+   * boundary-tied batch members, the empty-child stall escape hatch) are
+   * unnecessary by construction.
    *
-   * Two outcomes (Lemma 3.1):
-   * - Successful execution: the block list emptied — bound === B and
-   *   vertices holds every v with d(v) < B reachable through S.
-   * - Partial execution: the k·2^(l·t) workload guard tripped — bound < B
-   *   and vertices holds exactly the v with d(v) < bound.
+   * Two outcomes (Lemma 3.1, strict under the composite order):
+   * - Successful execution: the block list emptied — boundKey === B's key
+   *   and vertices holds every v with key(v) < B reachable through S.
+   * - Partial execution: the k·2^(l·t) workload guard tripped —
+   *   boundKey < B's key and vertices holds exactly the v with
+   *   key(v) < boundKey. In the scalar projection a returned vertex may tie
+   *   the returned bound's length (never exceed it).
    *   Every returned vertex is complete either way.
    *
    * @param {number} l - Recursion level; 0 delegates to baseCase
-   * @param {number} B - Strict upper bound on the distances in scope (Infinity is allowed)
+   * @param {number|[number, number, *]} B - Strict upper bound on the keys
+   *   in scope: a number (Infinity is allowed) or a composite bound
    * @param {Set<*>} S - Non-empty set of complete frontier sources
-   * @returns {{ bound: number, vertices: Set<*> }} The boundary B' <= B and
-   *   the set U of vertices completed below it
+   * @returns {{ bound: number|[number, number, *], boundKey: [number, number, *], vertices: Set<*> }}
+   *   The boundary B' <= B (same kind as the B passed in: scalar callers
+   *   get a scalar), its composite key, and the set U of vertices
+   *   completed below it
    */
   bmssp(l, B, S) {
     const dHat = this.shortestPaths;
+    const ties = this.ties;
+    const boundKey = toBound(B);
+    const scalarB = typeof B === "number";
+    // Project the composite result back to the caller's kind: a successful
+    // execution echoes B itself, a partial one reports the separator (whose
+    // length is strictly below a scalar B by construction)
+    const finish = (finalKey, vertices) => ({
+      bound: scalarB
+        ? compareKeys(finalKey, boundKey) === 0
+          ? B
+          : finalKey[0]
+        : finalKey,
+      boundKey: finalKey,
+      vertices,
+    });
+
     if (l === 0) {
-      return baseCase(B, S, dHat, this.adjacency, this.k);
+      const result = baseCase(boundKey, S, dHat, this.adjacency, this.k, ties);
+      return finish(result.boundKey, result.vertices);
     }
 
     // Shrink the frontier: only the pivots are worth recursing on, and W
     // is a batch of already-completed vertices folded in at the end
-    const { pivots, W } = findPivots(B, S, dHat, this.adjacency, this.k);
+    const { pivots, W } = findPivots(
+      boundKey,
+      S,
+      dHat,
+      this.adjacency,
+      this.k,
+      ties,
+    );
 
-    // Seed the Lemma 3.3 block list with the pivots. lastBound tracks the
-    // paper's Bi': B when P is empty, min d̂ over P before the first pull,
-    // then the boundary returned by the latest recursive call.
-    // A pivot with d̂ >= B is out of scope at this level (only possible
-    // when equal path lengths violate Assumption 2.1 and a pull returned
-    // a key tied with its separator): skip it — the ancestor whose band
-    // covers its distance is responsible for it.
-    const D = new BlockList(2 ** ((l - 1) * this.t), B);
-    let lastBound = B;
+    // Seed the Lemma 3.3 block list with the pivots. lastBoundKey tracks
+    // the paper's Bi': B when P is empty, min key over P before the first
+    // pull, then the boundary returned by the latest recursive call.
+    // The scope filter is for direct multi-source callers who may pass
+    // sources at or above B — internal calls can't produce one, because
+    // every pull separator is strict under the composite order.
+    const D = new BlockList(2 ** ((l - 1) * this.t), boundKey, compareKeys);
+    let lastBoundKey = boundKey;
     for (const x of pivots) {
-      const dx = dHat.get(x);
-      if (dx < B) {
-        D.insert(x, dx);
-        if (dx < lastBound) lastBound = dx;
+      const key = orderKey(x, dHat, ties);
+      if (compareKeys(key, boundKey) < 0) {
+        D.insert(x, key);
+        if (compareKeys(key, lastBoundKey) < 0) lastBoundKey = key;
       }
     }
 
@@ -140,86 +191,64 @@ class BMSSP {
 
     while (U.size < workloadCap && !D.isEmpty()) {
       // Bi, Si <- D.Pull(): the next-closest small batch and its separator
-      const { keys: Si, bound: Bi } = D.pull();
-      let { bound: BiPrime, vertices: Ui } = this.bmssp(l - 1, Bi, Si);
+      const { keys: Si, bound: BiKey } = D.pull();
+      const child = this.bmssp(l - 1, BiKey, Si);
+      const BiPrimeKey = child.boundKey;
+      const Ui = child.vertices;
 
-      if (Ui.size === 0) {
-        // Degenerate tie stall: the child settled only vertices tied
-        // exactly at its boundary (possible only through zero-weight
-        // paths, which violate the paper's Assumption 2.1 — see #163),
-        // so its strict d̂ < B' filter returned nothing and this batch
-        // would be re-pulled forever. Escape hatch: settle everything
-        // below Bi reachable through the batch with an uncapped bounded
-        // Dijkstra per member — correct, just not sublinear.
-        Ui = new Set();
-        for (const x of Si) {
-          const { vertices } = baseCase(
-            Bi,
-            new Set([x]),
-            dHat,
-            this.adjacency,
-            Math.max(1, this.nodeIDs.size),
-          );
-          for (const v of vertices) Ui.add(v);
-        }
-        BiPrime = Bi;
-      }
-
-      lastBound = BiPrime;
+      lastBoundKey = BiPrimeKey;
       for (const v of Ui) U.add(v);
 
-      // Relax out of the newly-completed Ui, routing improved neighbors
-      // by distance band: [Bi, B) re-enters the block list, [Bi', Bi) is
-      // staged for a batch prepend (closer than the current batch's floor)
+      // Relax out of the newly-completed Ui, routing improved neighbors by
+      // key band: [Bi, B) re-enters the block list, [Bi', Bi) is staged for
+      // a batch prepend (closer than the current batch's floor). An exact
+      // canonical equality re-enqueues a vertex that a deeper call labeled
+      // without completing (the paper's `≤` relaxation, deterministic here:
+      // only the recorded label-setter triggers it); vertices already
+      // completed at this level are filtered so re-enqueues stay finite.
       const K = [];
       for (const u of Ui) {
-        const du = dHat.get(u);
         for (const [v, weight] of this.adjacency.get(u) ?? []) {
-          const candidate = du + weight;
-          // Paper relaxation: d̂[u] + w(u,v) <= d̂[v] always updates d̂
-          if (candidate <= (dHat.get(v) ?? Infinity)) {
-            dHat.set(v, candidate);
-            // A vertex already completed at this level cannot strictly
-            // improve (non-negative weights), so an equal-sum relaxation
-            // — which the <= allows, e.g. via a zero-weight cycle — must
-            // not be re-queued (mirrors the baseCase settled guard)
-            if (U.has(v)) continue;
-            if (candidate >= Bi && candidate < B) {
-              D.insert(v, candidate);
-            } else if (candidate >= BiPrime && candidate < Bi) {
-              K.push([v, candidate]);
-            }
+          const relaxed = relaxEdge(u, v, weight, dHat, ties);
+          if (relaxed === null || U.has(v)) continue;
+          const key = relaxed.key;
+          if (compareKeys(key, BiKey) >= 0 && compareKeys(key, boundKey) < 0) {
+            D.insert(v, key);
+          } else if (
+            compareKeys(key, BiPrimeKey) >= 0 &&
+            compareKeys(key, BiKey) < 0
+          ) {
+            K.push([v, key]);
           }
         }
       }
-      // Batch members the child did not complete (d̂ still in [Bi', Bi))
-      // go back in front of everything else. A member tied exactly at the
-      // separator (d̂ == Bi < B, an Assumption 2.1 violation) is still in
-      // scope at this level and re-enters through a regular insert.
+      // Batch members the child did not complete (key still in [Bi', Bi))
+      // go back in front of everything else
       for (const x of Si) {
         if (U.has(x)) continue;
-        const dx = dHat.get(x);
-        if (dx >= BiPrime && dx < Bi) {
-          K.push([x, dx]);
-        } else if (dx === Bi && Bi < B) {
-          D.insert(x, dx);
+        const key = orderKey(x, dHat, ties);
+        if (compareKeys(key, BiPrimeKey) >= 0 && compareKeys(key, BiKey) < 0) {
+          K.push([x, key]);
         }
       }
       if (K.length > 0) D.batchPrepend(K);
     }
 
     // B' <- min(last Bi', B); fold in the FindPivots batch below it
-    const bound = Math.min(lastBound, B);
+    const finalKey =
+      compareKeys(lastBoundKey, boundKey) < 0 ? lastBoundKey : boundKey;
     for (const x of W) {
-      if (dHat.get(x) < bound) U.add(x);
+      if (compareKeys(orderKey(x, dHat, ties), finalKey) < 0) U.add(x);
     }
-    return { bound, vertices: U };
+    return finish(finalKey, U);
   }
 
   // Method to calculate shortest paths from startNode via the BMSSP
   // recursion (Algorithm 3). The top-level call BMSSP(topLevel, ∞, {start})
   // is always a successful execution, so it completes every reachable
-  // vertex; unreachable ones keep their Infinity estimate.
+  // vertex; unreachable ones keep their Infinity estimate. Distances, hop
+  // counts and predecessor pointers all end at their canonical values —
+  // independent of edge or iteration order (#163).
   calculateShortestPaths(startNode) {
     // To clean the state before calculation
     this.initializeShortestPaths();
@@ -229,8 +258,10 @@ class BMSSP {
       throw new Error("Start node not found in the graph");
     }
 
-    // The source is complete at distance 0; everything else is Infinity
+    // The source is complete at distance 0 with zero hops and no
+    // predecessor; everything else is Infinity
     this.shortestPaths.set(startNode, 0);
+    this.hops.set(startNode, 0);
     this.bmssp(this.topLevel, Infinity, new Set([startNode]));
   }
 }

--- a/src/findPivots.mjs
+++ b/src/findPivots.mjs
@@ -1,3 +1,5 @@
+import { compareKeys, toBound, makeTies, relaxEdge } from "./tieBreak.mjs";
+
 /**
  * FindPivots(B, S) — Algorithm 1 of "Breaking the Sorting Barrier for Directed
  * Single-Source Shortest Paths". Shrinks the frontier S: runs k rounds of
@@ -13,30 +15,42 @@
  *
  * Distance estimates are read from and written into dHat in place — exactly
  * like the paper's global d̂[·] labels, so improvements made here are visible
- * to the levels above. The `<=` relaxation updates d̂ unconditionally; the
- * `< B` test only gates membership in W.
+ * to the levels above. Relaxation is canonical (#163, src/tieBreak.mjs):
+ * d̂, hops and preds move together under the composite [length, hops, id]
+ * order, and an exact-equality result re-admits a vertex to W through its
+ * one canonical label-setter (the paper's `≤` made deterministic). The `< B`
+ * test only gates membership in W; d̂ updates are not gated.
+ *
+ * The paper's tight-edge forest falls out of the canonical labels: each
+ * vertex of W \ S hangs off its recorded canonical predecessor, which is
+ * always itself in W. Equal-length paths cannot make this a DAG (one pred
+ * per vertex) and tight zero-weight cycles cannot occur (a zero-weight edge
+ * strictly increases the hops component), so parent chains always terminate
+ * in S — the two #44-era tie ambiguities are gone by construction. Members
+ * of S are roots by definition and never count toward another source's tree.
  *
  * Two outcomes:
  * - Early exit (|W| grows past k·|S|): the frontier is already small relative
  *   to W, so every vertex of S is a pivot.
  * - Forest case (k rounds complete with |W| <= k·|S|): pivots are the S-roots
- *   of tight-edge trees with >= k vertices. Equal-length paths can make the
- *   tight-edge graph a DAG (see #163); each vertex is assigned at most one
- *   parent deterministically (first tight edge in W iteration order) so tree
- *   sizes are well-defined. Guarantees |pivots| <= |W| / k either way.
+ *   of canonical-predecessor trees with >= k vertices.
+ *   Guarantees |pivots| <= |W| / k either way.
  *
- * @param {number} B - Strict upper bound gating membership in W (Infinity is allowed)
+ * @param {number|[number, number, *]} B - Strict upper bound gating membership
+ *   in W: a number (Infinity is allowed) or a composite bound
  * @param {Set<*>|Iterable<*>} S - Non-empty set of complete frontier sources
  * @param {Map<*, number>} dHat - Global distance estimates d̂[·], updated in place
  * @param {Map<*, Array<[*, number]>>} adjacency - nodeId -> outgoing [to, weight] edges
  * @param {number} k - Relaxation rounds / tree-size threshold, >= 1 (floored);
  *   the paper's ⌊log^(1/3) n⌋
+ * @param {{ hops: Map<*, number>, preds: Map<*, *> }} [ties] - Canonical
+ *   tie-break labels updated alongside dHat; fresh throwaway maps by default
  * @returns {{ pivots: Set<*>, W: Set<*> }} The pivot subset of S and the set W
  *   of vertices touched below B (W always contains S)
  * @throws {Error} If k is not a number >= 1, S is empty, or any source has no
  *   finite distance estimate
  */
-function findPivots(B, S, dHat, adjacency, k) {
+function findPivots(B, S, dHat, adjacency, k, ties = makeTies()) {
   if (typeof k !== "number" || Number.isNaN(k) || k < 1) {
     throw new Error("k must be a number >= 1");
   }
@@ -51,8 +65,10 @@ function findPivots(B, S, dHat, adjacency, k) {
       throw new Error("every source must have a finite distance estimate");
     }
   }
+  const boundKey = toBound(B);
 
   // W accumulates everything relaxed below B; layer is the paper's W_{i-1}
+  const sourceSet = new Set(sources);
   const W = new Set(sources);
   let layer = new Set(sources);
 
@@ -60,11 +76,12 @@ function findPivots(B, S, dHat, adjacency, k) {
     const nextLayer = new Set();
     for (const u of layer) {
       for (const [v, weight] of adjacency.get(u) ?? []) {
-        const candidate = dHat.get(u) + weight;
-        // Paper relaxation: <= always updates d̂; < B gates the W membership
-        if (candidate <= (dHat.get(v) ?? Infinity)) {
-          dHat.set(v, candidate);
-          if (candidate < B) nextLayer.add(v);
+        // Canonical relaxation: d̂ updates are not gated by B (paper), and
+        // both improvements and exact canonical equality admit v to the
+        // next layer when its key is below B
+        const relaxed = relaxEdge(u, v, weight, dHat, ties);
+        if (relaxed !== null && compareKeys(relaxed.key, boundKey) < 0) {
+          nextLayer.add(v);
         }
       }
     }
@@ -76,28 +93,20 @@ function findPivots(B, S, dHat, adjacency, k) {
     }
   }
 
-  // Forest F of tight edges inside W. Each vertex takes at most one parent,
-  // chosen deterministically, so tree sizes stay well-defined even when ties
-  // make F a DAG. Vertices on tight cycles (zero-weight cycles) all end up
-  // with parents, so they belong to no root's tree.
+  // Forest of canonical predecessors inside W: every vertex of W \ S was
+  // (re-)labeled through some layer member during this call, so its
+  // recorded pred is in W and parent chains end in S
   const children = new Map();
-  const hasParent = new Set();
-  for (const u of W) {
-    const du = dHat.get(u);
-    for (const [v, weight] of adjacency.get(u) ?? []) {
-      if (v === u || !W.has(v) || hasParent.has(v)) continue;
-      if (dHat.get(v) === du + weight) {
-        hasParent.add(v);
-        if (!children.has(u)) children.set(u, []);
-        children.get(u).push(v);
-      }
-    }
+  for (const v of W) {
+    if (sourceSet.has(v)) continue;
+    const parent = ties.preds.get(v);
+    if (!children.has(parent)) children.set(parent, []);
+    children.get(parent).push(v);
   }
 
-  // Pivots: sources that root a tight-edge tree with >= k vertices
+  // Pivots: sources that root a canonical tree with >= k vertices
   const pivots = new Set();
   for (const x of sources) {
-    if (hasParent.has(x)) continue;
     let size = 0;
     const stack = [x];
     while (stack.length > 0) {

--- a/src/heap.mjs
+++ b/src/heap.mjs
@@ -14,11 +14,29 @@
  * duplicate-and-skip variant used inside src/dijkstra.mjs.
  */
 class MinHeap {
-  constructor() {
+  /**
+   * @param {(a: *, b: *) => number} [compare] - Value comparator (negative
+   *   when a < b). Defaults to numeric order, in which case values must be
+   *   numbers; with a custom comparator values are opaque (#163 passes
+   *   composite [length, hops, id] keys).
+   */
+  constructor(compare) {
     // entries[i] = [key, value], heap-ordered by value
     this.entries = [];
     // key -> index of that key in entries, for O(1) membership / lookup
     this.position = new Map();
+    this.numericValues = compare === undefined;
+    this.compare = compare ?? ((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+  }
+
+  // Internal: reject non-number values, but only in default numeric mode
+  checkValue(value) {
+    if (
+      this.numericValues &&
+      (typeof value !== "number" || Number.isNaN(value))
+    ) {
+      throw new Error("value must be a number");
+    }
   }
 
   // Number of pairs currently stored
@@ -65,9 +83,7 @@ class MinHeap {
    * @throws {Error} If the key is already stored, or value is not a number
    */
   insert(key, value) {
-    if (typeof value !== "number" || Number.isNaN(value)) {
-      throw new Error("value must be a number");
-    }
+    this.checkValue(value);
     if (this.position.has(key)) {
       throw new Error("key already in heap — use decreaseKey");
     }
@@ -85,14 +101,12 @@ class MinHeap {
    * @throws {Error} If the key is not stored, or value is not a number
    */
   decreaseKey(key, value) {
-    if (typeof value !== "number" || Number.isNaN(value)) {
-      throw new Error("value must be a number");
-    }
+    this.checkValue(value);
     const index = this.position.get(key);
     if (index === undefined) {
       throw new Error("key not in heap — use insert");
     }
-    if (this.entries[index][1] <= value) return;
+    if (this.compare(this.entries[index][1], value) <= 0) return;
     this.entries[index][1] = value;
     this.siftUp(index);
   }
@@ -132,7 +146,7 @@ class MinHeap {
     let i = index;
     while (i > 0) {
       const parent = (i - 1) >> 1;
-      if (this.entries[parent][1] <= this.entries[i][1]) break;
+      if (this.compare(this.entries[parent][1], this.entries[i][1]) <= 0) break;
       this.swap(parent, i);
       i = parent;
     }
@@ -147,13 +161,13 @@ class MinHeap {
       let smallest = i;
       if (
         left < this.entries.length &&
-        this.entries[left][1] < this.entries[smallest][1]
+        this.compare(this.entries[left][1], this.entries[smallest][1]) < 0
       ) {
         smallest = left;
       }
       if (
         right < this.entries.length &&
-        this.entries[right][1] < this.entries[smallest][1]
+        this.compare(this.entries[right][1], this.entries[smallest][1]) < 0
       ) {
         smallest = right;
       }

--- a/src/tieBreak.mjs
+++ b/src/tieBreak.mjs
@@ -1,0 +1,142 @@
+/**
+ * Deterministic tie-breaking for equal-length paths (#163) — the code-level
+ * stand-in for the paper's Assumption 2.1 ("all paths have distinct
+ * lengths", "Breaking the Sorting Barrier for Directed Single-Source
+ * Shortest Paths").
+ *
+ * Every path is ranked by a composite key `[length, hops, id]`, compared
+ * lexicographically:
+ *
+ * - `length` — the ordinary path length (sum of weights). Always dominates,
+ *   so plain distances are unaffected.
+ * - `hops`   — the number of edges on the path (the paper's "#vertices"
+ *   tie-break component). A zero-weight edge leaves `length` unchanged but
+ *   always increments `hops`, so extending a path strictly increases its
+ *   key: tight (zero-weight) cycles cannot tie with themselves and an
+ *   equal-sum re-relaxation can never loop.
+ * - `id`     — a final disambiguator standing in for the paper's full
+ *   "vertex sequence" (O(1) to compare instead of O(path)): inside
+ *   relaxation it is the candidate predecessor's id (picking the canonical
+ *   parent among equal-(length, hops) alternatives), while for frontier
+ *   ordering it is the vertex's own id (making the order on vertices a
+ *   strict total order).
+ *
+ * With distinct vertex ids no two frontier keys are ever equal, which is
+ * exactly what Assumption 2.1 grants the paper: every BlockList pull
+ * separator is strict, no vertex ties with a bound, and Lemma 3.1 holds in
+ * its strict form — the guards that #40/#43/#161 had to add for degenerate
+ * ties become dead code.
+ *
+ * Scalar bounds stay expressible: `toBound(B)` maps the number B to
+ * `[B, -Infinity, -Infinity]`, the infimum of every real key of length B,
+ * so "key < toBound(B)" is exactly the public "distance strictly below B"
+ * contract.
+ *
+ * The canonical labels live in three maps updated together by `relaxEdge`:
+ * d̂ (the class's `shortestPaths`), plus `hops` and `preds` bundled as a
+ * `ties` object. Missing entries default to hops 0 (an externally seeded
+ * source is a hop-0 root) and "no predecessor" (which never loses a tie).
+ */
+
+// Sentinel predecessor for sources: compares below every real id, so a
+// source's own label never loses an equal-(length, hops) comparison.
+const NO_PRED = -Infinity;
+
+/**
+ * Lexicographic comparison of two composite keys.
+ * @param {[number, number, *]} a - [length, hops, id]
+ * @param {[number, number, *]} b - [length, hops, id]
+ * @returns {number} Negative when a < b, positive when a > b, 0 when equal
+ */
+function compareKeys(a, b) {
+  if (a[0] !== b[0]) return a[0] < b[0] ? -1 : 1;
+  if (a[1] !== b[1]) return a[1] < b[1] ? -1 : 1;
+  if (a[2] !== b[2]) return a[2] < b[2] ? -1 : 1;
+  return 0;
+}
+
+/**
+ * Normalize a bound to a composite key. A scalar B becomes the infimum of
+ * all keys of length B, preserving the strict "distance < B" contract;
+ * a composite bound (an array) passes through unchanged.
+ * @param {number|[number, number, *]} B
+ * @returns {[number, number, *]}
+ */
+function toBound(B) {
+  return typeof B === "number" ? [B, -Infinity, -Infinity] : B;
+}
+
+/**
+ * Bundle (or create) the tie-break label maps that accompany d̂.
+ * @param {Map<*, number>} [hops] - Canonical path edge counts
+ * @param {Map<*, *>} [preds] - Canonical predecessor of each vertex
+ * @returns {{ hops: Map<*, number>, preds: Map<*, *> }}
+ */
+function makeTies(hops = new Map(), preds = new Map()) {
+  return { hops, preds };
+}
+
+/**
+ * The frontier-ordering key of a vertex under its current labels.
+ * @param {*} v - Vertex id
+ * @param {Map<*, number>} dHat - Distance estimates d̂[·]
+ * @param {{ hops: Map<*, number> }} ties - Tie-break labels
+ * @returns {[number, number, *]} [d̂[v], hops[v], v]
+ */
+function orderKey(v, dHat, ties) {
+  return [dHat.get(v) ?? Infinity, ties.hops.get(v) ?? 0, v];
+}
+
+/**
+ * Attempt the canonical relaxation of edge (u, v). The candidate path
+ * (canonical path to u, then this edge) has path key
+ * [d̂[u] + w, hops[u] + 1, u]; it wins iff it is strictly smaller than v's
+ * current path key [d̂[v], hops[v], preds[v]] — so d̂, hops and preds move
+ * together and the chosen predecessor is deterministic regardless of edge
+ * or iteration order. Improvements strictly decrease v's path key, which is
+ * bounded below, so chains of relaxations always terminate (no zero-weight
+ * cycle can loop).
+ *
+ * The exact-equality case — the candidate IS v's current canonical label —
+ * is reported separately as `improved: false`. It is the paper's `≤`
+ * re-relaxation made canonical: when a caller completes u and relaxes its
+ * edges, an equal result on (u, v) means u is v's recorded label-setter and
+ * v may need to be re-enqueued at this level (it was labeled by a deeper
+ * call that did not complete it). Only the one canonical predecessor
+ * triggers this, so re-enqueues are deterministic and never duplicated by
+ * tied alternative parents; callers filter already-completed vertices to
+ * keep the re-enqueue finite, exactly like the paper.
+ *
+ * @param {*} u - Edge tail (its labels are read)
+ * @param {*} v - Edge head (its labels may be updated)
+ * @param {number} weight - Edge weight, >= 0
+ * @param {Map<*, number>} dHat - Distance estimates d̂[·], updated in place
+ * @param {{ hops: Map<*, number>, preds: Map<*, *> }} ties - Updated in place
+ * @param {[number, number, *]} [bound] - Optional gate: skip (no d̂ update)
+ *   unless the resulting order key would be strictly below this bound
+ * @returns {{ key: [number, number, *], improved: boolean }|null} v's order
+ *   key [d̂[v], hops[v], v] with `improved: true` when the labels were
+ *   updated, `improved: false` when the candidate exactly matches v's
+ *   canonical label; null when the candidate loses (or the bound gates it)
+ */
+function relaxEdge(u, v, weight, dHat, ties, bound) {
+  const length = dHat.get(u) + weight;
+  const hopCount = (ties.hops.get(u) ?? 0) + 1;
+  if (bound !== undefined && compareKeys([length, hopCount, v], bound) >= 0) {
+    return null;
+  }
+  const currentPathKey = [
+    dHat.get(v) ?? Infinity,
+    ties.hops.get(v) ?? 0,
+    ties.preds.has(v) ? ties.preds.get(v) : NO_PRED,
+  ];
+  const cmp = compareKeys([length, hopCount, u], currentPathKey);
+  if (cmp > 0) return null;
+  if (cmp === 0) return { key: [length, hopCount, v], improved: false };
+  dHat.set(v, length);
+  ties.hops.set(v, hopCount);
+  ties.preds.set(v, u);
+  return { key: [length, hopCount, v], improved: true };
+}
+
+export { compareKeys, toBound, makeTies, orderKey, relaxEdge, NO_PRED };

--- a/test/README.md
+++ b/test/README.md
@@ -21,6 +21,7 @@ equal the Dijkstra oracle's** (`src/dijkstra.mjs`).
 | `bmssp.test.mjs` | Algorithm 3 recursion: parameter derivation, hand-built graphs, degenerate ties, the Lemma 3.1 bounded-call contract, seeded stress |
 | `fuzz.test.mjs` | High-volume property/fuzz suite (#161): 8 graph shapes × extreme weight regimes × multi-source bounded calls vs. per-source oracles, plus seeded scale runs (150k-node sparse, 300×300 grid, opt-in 2M) |
 | `edgeCases.test.mjs` | Deterministic disconnection fixtures (#162): isolated/sink/self-loop-only sources, single-node and multi-chain components, wrong-direction bridges, tiny-vs-giant components, source switching across components — each vs. a hand-computed map and the oracle |
+| `tieBreak.test.mjs` | Deterministic tie-breaking (#163): composite-key order, canonical relaxation, edge-order-permutation invariance (full runs and bounded partial calls), strict Lemma 3.1 via `boundKey`, hops/preds vs. a lexicographic Dijkstra oracle |
 | `findPivots.test.mjs` | Algorithm 1 (`FindPivots`) contracts incl. seeded oracle stress |
 | `baseCase.test.mjs` | Algorithm 2 (`BaseCase`) bounded mini-Dijkstra contracts |
 | `blockList.test.mjs` | Lemma 3.3 block-based partial-sort structure `D` |

--- a/test/baseCase.test.mjs
+++ b/test/baseCase.test.mjs
@@ -2,6 +2,7 @@ import { describe, test, expect } from "@jest/globals";
 import { baseCase } from "../src/baseCase.mjs";
 import { BMSSP } from "../src/bmssp.mjs";
 import { dijkstra } from "../src/dijkstra.mjs";
+import { compareKeys, makeTies, orderKey } from "../src/tieBreak.mjs";
 
 // Small deterministic PRNG so stress-test failures are reproducible
 function mulberry32(seed) {
@@ -139,7 +140,7 @@ describe("baseCase partial (the k + 1 cap is hit)", () => {
     expect(shortestPaths.get(2)).toBe(2);
   });
 
-  test("ties at the boundary are all excluded (strictly-closer filter)", () => {
+  test("boundary ties are broken deterministically by the composite order (#163)", () => {
     const edges = [
       [0, 1, 5],
       [0, 2, 5],
@@ -153,10 +154,13 @@ describe("baseCase partial (the k + 1 cap is hit)", () => {
       adjacency,
       2,
     );
-    // Settled = {0} plus two of the distance-5 leaves; B' = 5, and every
-    // leaf sits exactly on the boundary, so only the source is returned
+    // Settled = {0} plus the two smallest-keyed distance-5 leaves (1, 2);
+    // the boundary is leaf 2's key [5, 1, 2] and the strictly-closer filter
+    // keeps leaf 1 — under scalar ties, smaller ids settle first. (Before
+    // #163 every tied leaf was excluded and only the source came back.)
     expect(result.bound).toBe(5);
-    expect(result.vertices).toEqual(new Set([0]));
+    expect(result.boundKey).toEqual([5, 1, 2]);
+    expect(result.vertices).toEqual(new Set([0, 1]));
   });
 
   test("the k + 1 cap still respects the bound B", () => {
@@ -252,19 +256,26 @@ describe("baseCase vs Dijkstra oracle (seeded)", () => {
       // A bound somewhere inside the distance distribution, and a small cap
       const B = finite[Math.floor(finite.length * 0.6)] + 0.5;
       const k = 1 + Math.floor(rand() * 8);
+      const ties = makeTies();
       const result = baseCase(
         B,
         new Set([0]),
         bmssp.shortestPaths,
         bmssp.adjacency,
         k,
+        ties,
       );
       // B' never exceeds B, and B' = B means full success under the bound
       expect(result.bound).toBeLessThanOrEqual(B);
-      // Every returned vertex is complete (d̂ = true distance) and below B'
+      // Every returned vertex is complete (d̂ = true distance) and strictly
+      // below B' in the composite order (#163) — in the scalar view a
+      // returned vertex may tie the boundary's length, never exceed it
       for (const v of result.vertices) {
         expect(bmssp.shortestPaths.get(v)).toBe(oracle.get(v));
-        expect(oracle.get(v)).toBeLessThan(result.bound);
+        expect(oracle.get(v)).toBeLessThanOrEqual(result.bound);
+        expect(
+          compareKeys(orderKey(v, bmssp.shortestPaths, ties), result.boundKey),
+        ).toBeLessThan(0);
       }
       // Completeness: everything with a true distance below B' is returned
       for (const [v, d] of oracle) {

--- a/test/tieBreak.test.mjs
+++ b/test/tieBreak.test.mjs
@@ -1,0 +1,408 @@
+import { describe, test, expect } from "@jest/globals";
+import {
+  compareKeys,
+  toBound,
+  makeTies,
+  orderKey,
+  relaxEdge,
+} from "../src/tieBreak.mjs";
+import { BMSSP } from "../src/bmssp.mjs";
+import { dijkstra } from "../src/dijkstra.mjs";
+
+// Small deterministic PRNG so stress-test failures are reproducible
+function mulberry32(seed) {
+  let a = seed >>> 0;
+  return function () {
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// Seeded Fisher-Yates shuffle (copy) — permutes the edge list to probe
+// iteration-order independence
+function shuffled(edges, rand) {
+  const copy = edges.map((e) => [...e]);
+  for (let i = copy.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(rand() * (i + 1));
+    [copy[i], copy[j]] = [copy[j], copy[i]];
+  }
+  return copy;
+}
+
+// Seeded random graph drenched in ties: tiny integer weights (0-2) make
+// equal-length paths and zero-weight plateaus the norm
+function tiedEdges(rand, n, m) {
+  const edges = [[0, 1 + Math.floor(rand() * (n - 1)), 1]];
+  for (let i = 1; i < m; i += 1) {
+    edges.push([
+      Math.floor(rand() * n),
+      Math.floor(rand() * n),
+      Math.floor(rand() * 3),
+    ]);
+  }
+  return edges;
+}
+
+// Reference oracle for the canonical labels: an O(n^2) Dijkstra over the
+// lexicographic (length, hops) metric. Returns per-vertex distance and the
+// minimal hop count among all shortest paths.
+function lexDijkstra(edges, nodeIDs, source) {
+  const adj = new Map();
+  for (const id of nodeIDs) adj.set(id, []);
+  for (const [from, to, weight] of edges) adj.get(from).push([to, weight]);
+  const dist = new Map();
+  const hop = new Map();
+  for (const id of nodeIDs) {
+    dist.set(id, Infinity);
+    hop.set(id, Infinity);
+  }
+  dist.set(source, 0);
+  hop.set(source, 0);
+  const done = new Set();
+  for (;;) {
+    let best = null;
+    for (const id of nodeIDs) {
+      if (done.has(id) || dist.get(id) === Infinity) continue;
+      if (
+        best === null ||
+        dist.get(id) < dist.get(best) ||
+        (dist.get(id) === dist.get(best) && hop.get(id) < hop.get(best))
+      ) {
+        best = id;
+      }
+    }
+    if (best === null) break;
+    done.add(best);
+    for (const [v, weight] of adj.get(best)) {
+      const nd = dist.get(best) + weight;
+      const nh = hop.get(best) + 1;
+      if (nd < dist.get(v) || (nd === dist.get(v) && nh < hop.get(v))) {
+        dist.set(v, nd);
+        hop.set(v, nh);
+      }
+    }
+  }
+  return { dist, hop };
+}
+
+describe("compareKeys — lexicographic composite order", () => {
+  test("length dominates, then hops, then id", () => {
+    expect(compareKeys([1, 9, 9], [2, 0, 0])).toBeLessThan(0);
+    expect(compareKeys([1, 2, 9], [1, 3, 0])).toBeLessThan(0);
+    expect(compareKeys([1, 2, 3], [1, 2, 4])).toBeLessThan(0);
+    expect(compareKeys([1, 2, 3], [1, 2, 3])).toBe(0);
+    expect(compareKeys([2, 0, 0], [1, 9, 9])).toBeGreaterThan(0);
+  });
+
+  test("handles Infinity components (no NaN subtraction traps)", () => {
+    expect(compareKeys([Infinity, 0, 1], [Infinity, 0, 2])).toBeLessThan(0);
+    expect(compareKeys([Infinity, 0, 1], [Infinity, 0, 1])).toBe(0);
+    expect(
+      compareKeys([5, 1, 1], [Infinity, -Infinity, -Infinity]),
+    ).toBeLessThan(0);
+  });
+});
+
+describe("toBound — scalar bounds keep strict semantics", () => {
+  test("a scalar bound sits below every real key of the same length", () => {
+    const bound = toBound(10);
+    // Any real path of length 10 is NOT below the bound…
+    expect(compareKeys([10, 0, 0], bound)).toBeGreaterThan(0);
+    // …every shorter path is
+    expect(compareKeys([9.5, 999, 999], bound)).toBeLessThan(0);
+  });
+
+  test("composite bounds pass through unchanged", () => {
+    const key = [4, 2, 7];
+    expect(toBound(key)).toBe(key);
+  });
+});
+
+describe("relaxEdge — canonical relaxation", () => {
+  test("updates d̂, hops and preds together on improvement", () => {
+    const dHat = new Map([
+      [0, 0],
+      [1, Infinity],
+    ]);
+    const ties = makeTies();
+    const result = relaxEdge(0, 1, 5, dHat, ties);
+    expect(result).toEqual({ key: [5, 1, 1], improved: true });
+    expect(dHat.get(1)).toBe(5);
+    expect(ties.hops.get(1)).toBe(1);
+    expect(ties.preds.get(1)).toBe(0);
+  });
+
+  test("equal-length candidates win only on fewer hops, then smaller pred", () => {
+    const dHat = new Map([
+      [0, 0],
+      [7, 3],
+      [3, 3],
+      [9, 3],
+      [5, 6],
+    ]);
+    const ties = makeTies(
+      new Map([
+        [7, 1],
+        [3, 1],
+        [9, 1],
+        [5, 2],
+      ]),
+      new Map([[5, 7]]),
+    );
+    // Same length (3 + 3 = 6), same hops (3), pred 9 > current pred 7: no
+    expect(relaxEdge(9, 5, 3, dHat, ties)).toBeNull();
+    expect(ties.preds.get(5)).toBe(7);
+    // Same length, same hops, pred 3 < current pred 7: canonical update
+    expect(relaxEdge(3, 5, 3, dHat, ties)).toEqual({
+      key: [6, 2, 5],
+      improved: true,
+    });
+    expect(ties.preds.get(5)).toBe(3);
+    // Re-relaxation from the now-canonical pred reports exact equality —
+    // the caller's re-enqueue signal — without touching the labels
+    expect(relaxEdge(3, 5, 3, dHat, ties)).toEqual({
+      key: [6, 2, 5],
+      improved: false,
+    });
+    expect(ties.preds.get(5)).toBe(3);
+  });
+
+  test("a zero-weight edge strictly increases the key: cycles cannot loop", () => {
+    const dHat = new Map([
+      [0, 2],
+      [1, 2],
+    ]);
+    const ties = makeTies(
+      new Map([
+        [0, 1],
+        [1, 2],
+      ]),
+      new Map([
+        [0, 5],
+        [1, 0],
+      ]),
+    );
+    // 1 -> 0 with weight 0: candidate [2, 3, 1] vs current [2, 1, 5] — the
+    // extra hops lose outright
+    expect(relaxEdge(1, 0, 0, dHat, ties)).toBeNull();
+    // 0 -> 1 with weight 0 reproduces 1's canonical label exactly: reported
+    // as equality, no update — so the cycle is quiescent, never looping
+    expect(relaxEdge(0, 1, 0, dHat, ties)).toEqual({
+      key: [2, 2, 1],
+      improved: false,
+    });
+    expect(ties.hops.get(1)).toBe(2);
+  });
+
+  test("a source (no stored pred) never loses an equal-(length, hops) tie", () => {
+    const dHat = new Map([
+      [4, 0],
+      [2, 5],
+    ]);
+    const ties = makeTies(new Map([[2, 0]]), new Map());
+    // Vertex 2 is an externally seeded hop-0 source at distance 5; an
+    // equal-length, equal-hops... any candidate has hops >= 1 > 0, and even
+    // a shorter-hop tie would face the -Infinity pred sentinel
+    expect(relaxEdge(4, 2, 5, dHat, ties)).toBeNull();
+    expect(dHat.get(2)).toBe(5);
+  });
+
+  test("the optional bound gates the update entirely (paper's < B)", () => {
+    const dHat = new Map([
+      [0, 0],
+      [1, Infinity],
+    ]);
+    const ties = makeTies();
+    expect(relaxEdge(0, 1, 5, dHat, ties, toBound(5))).toBeNull();
+    expect(dHat.get(1)).toBe(Infinity);
+    expect(ties.preds.has(1)).toBe(false);
+    expect(relaxEdge(0, 1, 5, dHat, ties, toBound(5.1))).toEqual({
+      key: [5, 1, 1],
+      improved: true,
+    });
+  });
+
+  test("orderKey defaults: missing labels read as hop-0, distance Infinity", () => {
+    const dHat = new Map([[3, 4]]);
+    const ties = makeTies();
+    expect(orderKey(3, dHat, ties)).toEqual([4, 0, 3]);
+    expect(orderKey(99, dHat, ties)).toEqual([Infinity, 0, 99]);
+  });
+});
+
+describe("determinism (#163): edge order never changes the outcome", () => {
+  test("full runs on tie-heavy graphs: identical d̂, hops and preds across permutations", () => {
+    const rand = mulberry32(1630);
+    for (let round = 0; round < 15; round += 1) {
+      const n = 20 + Math.floor(rand() * 30);
+      const edges = tiedEdges(rand, n, n * 4);
+      const reference = new BMSSP(edges);
+      reference.calculateShortestPaths(0);
+      for (let p = 0; p < 3; p += 1) {
+        const permuted = new BMSSP(shuffled(edges, rand));
+        permuted.calculateShortestPaths(0);
+        for (const v of reference.nodeIDs) {
+          expect(permuted.shortestPaths.get(v)).toBe(
+            reference.shortestPaths.get(v),
+          );
+          expect(permuted.hops.get(v)).toBe(reference.hops.get(v));
+          expect(permuted.preds.get(v)).toBe(reference.preds.get(v));
+        }
+      }
+    }
+  });
+
+  test("bounded partial calls: identical bound, boundKey and completed set across permutations", () => {
+    const rand = mulberry32(1631);
+    for (let round = 0; round < 15; round += 1) {
+      const n = 25 + Math.floor(rand() * 25);
+      const edges = tiedEdges(rand, n, n * 4);
+      const probe = new BMSSP(edges);
+      const oracle = dijkstra(probe.graph, probe.nodeIDs, 0);
+      const finite = [...oracle.values()]
+        .filter((d) => d < Infinity)
+        .sort((a, b) => a - b);
+      // A boundary deliberately placed ON a tied distance value
+      const B = finite[Math.floor(finite.length * 0.5)];
+      const run = (graphEdges) => {
+        const bmssp = new BMSSP(graphEdges);
+        bmssp.initializeShortestPaths();
+        bmssp.shortestPaths.set(0, 0);
+        bmssp.hops.set(0, 0);
+        return bmssp.bmssp(bmssp.topLevel, B, new Set([0]));
+      };
+      const reference = run(edges);
+      for (let p = 0; p < 3; p += 1) {
+        const permuted = run(shuffled(edges, rand));
+        expect(permuted.bound).toBe(reference.bound);
+        expect(permuted.boundKey).toEqual(reference.boundKey);
+        expect(permuted.vertices).toEqual(reference.vertices);
+      }
+    }
+  });
+});
+
+describe("strict Lemma 3.1 (#163): no boundary ties in the composite order", () => {
+  test("returned vertices sit strictly below boundKey even on tie-heavy graphs", () => {
+    const rand = mulberry32(1632);
+    for (let round = 0; round < 20; round += 1) {
+      const n = 20 + Math.floor(rand() * 30);
+      const edges = tiedEdges(rand, n, n * 4);
+      const bmssp = new BMSSP(edges);
+      const oracle = dijkstra(bmssp.graph, bmssp.nodeIDs, 0);
+      const finite = [...oracle.values()]
+        .filter((d) => d < Infinity)
+        .sort((a, b) => a - b);
+      const B = finite[Math.floor(finite.length * 0.6)];
+      bmssp.initializeShortestPaths();
+      bmssp.shortestPaths.set(0, 0);
+      bmssp.hops.set(0, 0);
+      const { bound, boundKey, vertices } = bmssp.bmssp(
+        bmssp.topLevel,
+        B,
+        new Set([0]),
+      );
+      for (const v of vertices) {
+        // Complete, scalar-below-or-tying the bound, strictly below the key
+        expect(bmssp.shortestPaths.get(v)).toBe(oracle.get(v));
+        expect(oracle.get(v)).toBeLessThanOrEqual(
+          typeof bound === "number" ? bound : bound[0],
+        );
+        expect(
+          compareKeys(orderKey(v, bmssp.shortestPaths, bmssp.ties), boundKey),
+        ).toBeLessThan(0);
+      }
+      // Strict completeness: every reachable vertex whose key is below
+      // boundKey must be in the returned set
+      for (const [v, d] of oracle) {
+        if (d === Infinity) continue;
+        if (
+          bmssp.shortestPaths.get(v) === d &&
+          compareKeys(orderKey(v, bmssp.shortestPaths, bmssp.ties), boundKey) <
+            0
+        ) {
+          expect(vertices.has(v)).toBe(true);
+        }
+      }
+    }
+  });
+
+  test("zero-weight clusters (the old stall scenario) keep the strict contract", () => {
+    // The pre-#163 escape-hatch graph: a zero-weight cluster at the source
+    const edges = [
+      [0, 1, 0],
+      [1, 0, 0],
+      [1, 2, 0],
+      [2, 3, 1],
+      [3, 4, 2],
+    ];
+    const bmssp = new BMSSP(edges);
+    bmssp.initializeShortestPaths();
+    bmssp.shortestPaths.set(0, 0);
+    bmssp.hops.set(0, 0);
+    // Bound tied exactly on the cluster's distance 0: only the cluster
+    // members with key strictly below [0, -Inf, -Inf]... none — so a bound
+    // above 0 must complete the whole cluster, strictly ordered by hops
+    const { bound, vertices } = bmssp.bmssp(bmssp.topLevel, 1, new Set([0]));
+    expect(bound).toBe(1);
+    expect(vertices).toEqual(new Set([0, 1, 2]));
+    expect(bmssp.hops.get(1)).toBe(1);
+    expect(bmssp.hops.get(2)).toBe(2);
+  });
+});
+
+describe("canonical labels (#163): hops and preds are the lexicographic optimum", () => {
+  test("hops equal the minimal edge count among shortest paths (lex oracle)", () => {
+    const rand = mulberry32(1633);
+    for (let round = 0; round < 15; round += 1) {
+      const n = 15 + Math.floor(rand() * 25);
+      const edges = tiedEdges(rand, n, n * 4);
+      const bmssp = new BMSSP(edges);
+      bmssp.calculateShortestPaths(0);
+      const { dist, hop } = lexDijkstra(bmssp.graph, bmssp.nodeIDs, 0);
+      for (const v of bmssp.nodeIDs) {
+        expect(bmssp.shortestPaths.get(v)).toBe(dist.get(v));
+        if (dist.get(v) < Infinity) {
+          expect(bmssp.hops.get(v)).toBe(hop.get(v));
+        }
+      }
+    }
+  });
+
+  test("preds form a tree of tight edges choosing the smallest optimal parent", () => {
+    const rand = mulberry32(1634);
+    for (let round = 0; round < 15; round += 1) {
+      const n = 15 + Math.floor(rand() * 25);
+      const edges = tiedEdges(rand, n, n * 4);
+      const bmssp = new BMSSP(edges);
+      bmssp.calculateShortestPaths(0);
+      const { dist, hop } = lexDijkstra(bmssp.graph, bmssp.nodeIDs, 0);
+      for (const v of bmssp.nodeIDs) {
+        if (v === 0 || dist.get(v) === Infinity) continue;
+        // The canonical parent is the smallest-id in-neighbor u with a
+        // (length, hops)-tight edge into v
+        let expected = null;
+        for (const [from, to, weight] of bmssp.graph) {
+          if (to !== v) continue;
+          if (
+            dist.get(from) + weight === dist.get(v) &&
+            hop.get(from) + 1 === hop.get(v)
+          ) {
+            if (expected === null || from < expected) expected = from;
+          }
+        }
+        expect(bmssp.preds.get(v)).toBe(expected);
+        // Walking the pred chain reaches the source without cycles
+        let cursor = v;
+        let steps = 0;
+        while (cursor !== 0) {
+          cursor = bmssp.preds.get(cursor);
+          steps += 1;
+          expect(steps).toBeLessThanOrEqual(bmssp.nodeIDs.size);
+        }
+      }
+    }
+  });
+});


### PR DESCRIPTION
Closes #163

## Summary

Implements the issue's `(length, #vertices, vertex sequence)` tie-break as composite **`[length, hops, id]` keys** compared lexicographically (`src/tieBreak.mjs`), threaded through the entire algorithm. `hops` makes zero-weight extensions strictly increasing (no tight cycles, no equal-sum loops); the `id` component — predecessor id inside relaxation, own id in frontier order — is an O(1) stand-in for the paper's full vertex-sequence comparison. Distinct ids make every frontier comparison strict, which is exactly what Assumption 2.1 grants the paper.

**What this buys, replacing all six documented tie manifestations:**

- **Canonical relaxation** (`relaxEdge`): `d̂`, `hops` and `preds` update in lockstep; each vertex's predecessor is the smallest optimal parent — deterministic regardless of edge/iteration order. The paper's `≤` re-relaxation survives as a canonical *re-enqueue signal* (exact label equality from the recorded setter only), which is the mechanism that re-queues vertices labeled-but-not-completed by deeper calls.
- **All pre-#163 tie guards removed**: the out-of-scope pivot skip (now a scope filter for direct multi-source callers only), the boundary-tied `d̂ == Bi` re-insert, the completed-vertex equal-sum guard (provably dead for strict improvements), and the **stall escape hatch** — a child's `U` is provably nonempty now, so the uncapped-`baseCase` fallback is gone.
- **Strict Lemma 3.1 restored**: results carry a composite `boundKey`; every returned vertex is strictly below it. Public scalar API unchanged (`bound` is the projection; the documented `d(v) ≤ bound` scalar caveat remains the external contract).
- **`findPivots`' forest is just the canonical pred pointers** — the #44-era DAG and tight-cycle ambiguities are impossible by construction.
- **`preds`/`hops` now live on the class** — groundwork for #169 (path reconstruction).

`MinHeap` and `BlockList` gained an optional comparator (default numeric — their existing 34 tests pass unchanged).

## Tests / lint

- **129 tests — 128 passing + 1 XL skipped**, 100% statement coverage, ~3 s; lint clean.
- New `test/tieBreak.test.mjs` (16): unit coverage of the order module, **edge-order-permutation invariance** (full runs *and* bounded partial calls return identical `d̂`/`hops`/`preds`/`boundKey`/`U` on tie-heavy 0–2-weight graphs), **strict Lemma 3.1** via `boundKey`, the old zero-weight-cluster stall scenario, and `hops`/`preds` verified against an independent O(n²) lexicographic-(length, hops) Dijkstra oracle.
- Two `baseCase` tests updated to the new strict-composite contract (boundary ties now broken deterministically instead of excluded wholesale).
- `FUZZ_ROUNDS=25` (several thousand graphs) and `FUZZ_XL=1` (2M nodes, ~33 s — ~10% composite-key overhead vs. the ~30 s scalar baseline) both pass.

**No version bump** — enhancement; milestone 1.1.0 still has #164/#165/#166 open (semver convention, #186).

## Roadmap proposals

1. **Re-scope #169 (path reconstruction, 1.2.0):** `BMSSP.preds` now holds a deterministic canonical shortest-path tree — propose editing #169's description down to exposing a public `reconstructPath(target)` walk over it.
2. **Comment on #168 (micro-optimizations, 1.2.0):** the composite keys cost ~10% on the 2M-node XL round; the hot spots are per-relaxation array allocations in `relaxEdge` and `compareKeys` calls in the heap/block-list — worth listing as a concrete optimization target (packed number encoding or key reuse).

🤖 Generated with [Claude Code](https://claude.com/claude-code)