### PR TITLE
feat(#169): add shortest-path reconstruction

### DIFF
--- a/.claude/knowledge/05-codebase-map.md
+++ b/.claude/knowledge/05-codebase-map.md
@@ -1,14 +1,12 @@
 # 05 — Codebase Map (current state)
 
-<!-- BOOKMARK-COMMIT: ef5153b54f2cd06883ded48785bae13eb27787ba -->
-<!-- PENDING-PR-BRANCH: feat/163-deterministic-tie-break -->
-<!-- Last validated: 2026-07-17 (Phase C of the #163 PR). Describes the tree as it will
-     exist once that PR merges: new src/tieBreak.mjs (composite [length, hops, id]
-     keys realizing Assumption 2.1), canonical relaxation through baseCase /
-     findPivots / bmssp, comparator support in MinHeap / BlockList, the pre-#163
-     degenerate-tie guards removed, test/tieBreak.test.mjs added. No version bump
-     (enhancement; milestone 1.1.0 still open — semver convention, 06 "Release
-     mechanics"). -->
+<!-- BOOKMARK-COMMIT: e25d89795947484726a72ae394ac19d502f86942 -->
+<!-- PENDING-PR-BRANCH: northset/bmssp-js-169 -->
+<!-- Last validated: 2026-07-19 (Phase C of the #169 PR). Describes the tree as it will
+     exist once that PR merges: BMSSP.reconstructPath(target) exposes the canonical
+     predecessor tree already maintained since #163; path-oracle tests and public usage
+     documentation are included. No version bump (mid-milestone enhancement; milestone
+     1.2.0 remains open — semver convention, 06 "Release mechanics"). -->
 
 Snapshot of what exists in `bmssp-js` today, so you know what to build on vs. what's missing.
 
@@ -71,6 +69,7 @@ test/
   fuzz.test.mjs           # #161: 18 high-volume fuzz tests — shapes × weight regimes × multi-source × seeded scale; FUZZ_ROUNDS / FUZZ_XL env vars
   edgeCases.test.mjs      # #162: 9 deterministic disconnection fixtures — isolated/sink sources, many components, source switching
   tieBreak.test.mjs       # #163: 16 tests — key order, canonical relaxEdge, edge-order determinism, strict Lemma 3.1, lex-oracle hops/preds
+  pathReconstruction.test.mjs # #169: 3 public-API tests — Dijkstra path oracle, unreachable/pre-run/source switching, target validation
   blockList.test.mjs      # #42: 18 BlockList tests incl. a seeded random stress test
   heap.test.mjs           # #41: 16 MinHeap tests incl. a seeded stress test vs. a naive queue
   baseCase.test.mjs       # #40: 13 BaseCase tests incl. seeded oracle-comparison stress
@@ -121,6 +120,8 @@ class BMSSP {
                                    //      scalar bound out (boundKey always composite)
   calculateShortestPaths(startNode)// #43: validates, sets d̂[start] = 0 (hop 0), runs
                                    //      bmssp(topLevel, Infinity, {startNode}) — NO Dijkstra
+  reconstructPath(target)          // #169: source→target path from canonical preds; [] before
+                                   //      a run or when unreachable; throws for unknown target
 }
 ```
 
@@ -322,6 +323,10 @@ implementation is tested against — and, since #43, no longer part of the BMSSP
   equality against an independent O(n²) lexicographic-(length, hops) Dijkstra oracle
   (hops = minimal edge count among shortest paths; preds = smallest optimal parent, chain
   reaching the source acyclically).
+- `test/pathReconstruction.test.mjs` (3, #169): the public `reconstructPath(target)` API
+  checked against an independent Dijkstra path oracle, including competing paths, an
+  unreachable vertex, calls before a run, source switching on one instance, and rejection
+  of a target that is not in the graph.
 - `test/edgeCases.test.mjs` (9, #162): deterministic hand-built disconnection fixtures,
   each checked against a hand-computed full distance map **and** the Dijkstra oracle
   (Infinity entries included): self-loop-only source, sink source (adjacency keeps an
@@ -343,7 +348,7 @@ implementation is tested against — and, since #43, no longer part of the BMSSP
   **opt-in `FUZZ_XL=1` sparse n = 2M round** (~33 s, `test.skip` otherwise). Every failure
   message carries the round's seed for reproduction. **`FUZZ_ROUNDS=<x>`** multiplies all
   round counts (default 1 ≈ 0.5 s; 25 ≈ 10 s, several thousand graphs).
-- Current suite: **129 tests — 128 passing + 1 XL skipped by default**, 100% statement
+- Current suite: **132 tests — 131 passing + 1 XL skipped by default**, 100% statement
   coverage, ~3 s wall-clock. No graph data files: every generated test graph comes from a
   seed; the #162 fixtures are hand-built and fully deterministic.
 
@@ -369,7 +374,9 @@ comparison-count mode); the raw baseline is also on #170 as a comment.
 | Main `BMSSP(l, B, S)` recursion + `k,t` derivation | `src/bmssp.mjs` | #43 | ✅ done (PR #181) — **1.0.0 milestone complete** |
 | Property/fuzz suite vs. the oracle | `test/fuzz.test.mjs` | #161 | ✅ done (PR #184, 1.0.1) |
 | Deterministic disconnection edge cases | `test/edgeCases.test.mjs` | #162 | ✅ done (PR #187, no bump) |
-| Deterministic tie-breaking (Assumption 2.1) | `src/tieBreak.mjs` + all modules | #163 | ✅ done (this PR, no bump) |
+| Deterministic tie-breaking (Assumption 2.1) | `src/tieBreak.mjs` + all modules | #163 | ✅ done (PR #188, no bump) |
+| Public shortest-path reconstruction | `BMSSP.reconstructPath()` + `test/pathReconstruction.test.mjs` | #169 | ✅ done-pending-merge (this PR, no bump) |
 
-Milestone `1.1.0` (correctness hardening) is in progress: #163 lands with this PR; next up
-are #165, #164, #166 — see [06-milestones-roadmap.md](06-milestones-roadmap.md).
+Milestone `1.1.0` (correctness hardening) remains in progress with #165, #164 and #166
+open. Milestone `1.2.0` is also in progress: #169 lands with this PR; see
+[06-milestones-roadmap.md](06-milestones-roadmap.md).

--- a/.claude/knowledge/06-milestones-roadmap.md
+++ b/.claude/knowledge/06-milestones-roadmap.md
@@ -1,10 +1,9 @@
 # 06 — Milestones Roadmap
 
-<!-- SYNCED-FROM-GITHUB: 2026-07-17 (#163 session: PRs #186 semver convention and #187
-     edge cases merged, #162 closed; milestones 1.1.0/1.2.0/2.0.0 open with 4/5/3 open
-     issues; #163 done-pending-merge in this PR) -->
-<!-- Current package version: 1.0.1 (released 2026-07-16; the #163 PR ships no bump under
-     the semver convention — enhancement, milestone still open) -->
+<!-- SYNCED-FROM-GITHUB: 2026-07-19 (#163 closed by merged PR #188; milestones
+     1.1.0/1.2.0/2.0.0 open with 3/5/3 open issues; #169 done-pending-merge in this PR) -->
+<!-- Current package version: 1.0.1 (released 2026-07-16; the #169 PR ships no bump under
+     the semver convention — mid-milestone enhancement, milestone still open) -->
 
 Maps GitHub **milestones** and **issues** (Sirivasv/bmssp-js) to the paper's building blocks,
 with a dependency-aware build order. This is the "intent" side of the knowledge base (what to
@@ -40,20 +39,17 @@ it runs the same Phase C reconciliation directly on `main`.
 
 ## 📋 Roadmap proposals (pending user approval)
 
-From the #163 PR (Phase C, 2026-07-17):
-
-1. **Re-scope #169 (path reconstruction, milestone 1.2.0):** #163 already ships the
-   canonical predecessor map — `BMSSP.preds` holds a deterministic shortest-path tree
-   (smallest optimal parent, verified against a lexicographic oracle). Propose editing
-   #169's description: the remaining work is only exposing a public
-   `reconstructPath(target)` (walk `preds` backwards), not building `Pred[]` itself.
-2. **Comment on #168 (micro-optimizations, milestone 1.2.0):** #163's composite keys cost
-   ~10% on the 2M-node XL round (~30 s → ~33 s) — the hot spots are the per-relaxation
-   array allocations in `relaxEdge` and `compareKeys` calls in the heap/block-list. Worth
-   listing as a concrete optimization target (e.g. packed number encoding or key reuse).
+From the #169 PR (Phase C, 2026-07-19): **none.** The live #169 description was already
+re-scoped after #163 to exactly the public `reconstructPath(target)` API and path-oracle
+tests implemented here. The other learning from #163 — composite-key allocation and
+comparison overhead — is already recorded by the maintainer on #168. This PR does not
+change the remaining milestone slicing, dependencies, or release cadence, so no further
+GitHub edit is warranted.
 
 _Phase C writes proposed GitHub edits here (and in the PR body); Phase E executes the
 approved ones — one confirmation each — and clears them from this list._
+_(The #188-PR proposals — re-scope **#169** and add the measured optimization note to
+**#168** — were executed 2026-07-17.)_
 _(The #187-PR proposal — empty-graph validation note on **#165** — was approved and
 executed 2026-07-17.)_
 
@@ -75,12 +71,16 @@ executed 2026-07-17.)_
   and dates preserved), `main` + all 21 tags force-pushed with ruleset 7764713
   temporarily disabled. **All commit SHAs before 2026-07-17 changed**; old SHAs in
   closed PRs/issues no longer resolve. Repo-local git config now signs future commits.
-- **Milestone `1.1.0` — correctness hardening** (in progress). #162 merged (PR #187).
-  **#163 done-pending-merge** (this PR): `src/tieBreak.mjs` composite `[length, hops, id]`
+- **Milestone `1.1.0` — correctness hardening** (in progress). #162 merged (PR #187) and
+  #163 merged (PR #188): `src/tieBreak.mjs` composite `[length, hops, id]`
   keys realize Assumption 2.1 end-to-end — canonical relaxation (d̂/hops/preds in
   lockstep), strict pull separators, all pre-#163 tie guards removed (incl. the stall
   escape hatch), strict Lemma 3.1 restored, full edge-order determinism proven by test.
   No bump. Next: **#165** (input validation), then #164, #166.
+- **Milestone `1.2.0` — performance & ergonomics** (in progress). **#169
+  done-pending-merge** (this PR): public `BMSSP.reconstructPath(target)` walks the existing
+  canonical predecessor map, with independent path-oracle coverage and public usage docs.
+  No bump; four other issues remain after this PR.
 - **Semver release convention (user-directed 2026-07-17, PR #186):** bumps only on bug
   fix (patch) or milestone-closing PR (minor/major) — see "Release mechanics" below.
 - **2026-07-16 reflection session (post-release):** measured the BMSSP-vs-Dijkstra
@@ -120,20 +120,20 @@ Recommended order (cheapest protection first, then the deep work):
 |---|---|---|---|---|
 | 1 | 161 | Property/fuzz tests: BMSSP vs Dijkstra on random graphs | enhancement · help wanted | ✅ merged (PR #184, 1.0.1) |
 | 2 | 162 | Edge-case tests: disconnected graphs and unreachable nodes | enhancement · help wanted | ✅ merged (PR #187, no bump) |
-| 3 | 163 | Deterministic tie-breaking for equal-length paths (Assumption 2.1) | enhancement · help wanted | ✅ done-pending-merge (this PR, no bump): composite keys in `src/tieBreak.mjs`, all six tie manifestations resolved by construction |
+| 3 | 163 | Deterministic tie-breaking for equal-length paths (Assumption 2.1) | enhancement · help wanted | ✅ merged (PR #188, no bump): composite keys in `src/tieBreak.mjs`, all six tie manifestations resolved by construction |
 | 4 | 165 | Input validation for the BMSSP constructor | good first issue · help wanted | — |
 | 5 | 164 | Optional constant-degree transform (in/out-degree ≤ 2) | enhancement · help wanted | — |
 | 6 | 166 | JSDoc / API docs for the new modules | documentation · good first issue | `bmssp()` / `deriveParameters()` ship with JSDoc already |
 
 ## Milestone `1.2.0` (milestone #3) — performance & ergonomics
 
-| # | Issue | Labels |
-|---|---|---|
-| 167 | Restore Lemma 3.3's exact asymptotics in BlockList (balanced-BST bound index + linear-time selection) | enhancement · help wanted |
-| 168 | Adjacency and relaxation micro-optimizations | enhancement · help wanted |
-| 169 | Optional shortest-path reconstruction (`Pred[]` → paths) | enhancement · help wanted |
-| 170 | BMSSP-vs-Dijkstra benchmark comparison | enhancement · help wanted |
-| 182 | Investigate BMSSP performance cliffs: high-fanout (star) graphs and recursion-level transitions | enhancement · help wanted |
+| # | Issue | Labels | Notes |
+|---|---|---|---|
+| 167 | Restore Lemma 3.3's exact asymptotics in BlockList (balanced-BST bound index + linear-time selection) | enhancement · help wanted | — |
+| 168 | Adjacency and relaxation micro-optimizations | enhancement · help wanted | — |
+| 169 | Optional shortest-path reconstruction (`Pred[]` → paths) | enhancement · help wanted | ✅ done-pending-merge (this PR, no bump): public API + independent path oracle |
+| 170 | BMSSP-vs-Dijkstra benchmark comparison | enhancement · help wanted | — |
+| 182 | Investigate BMSSP performance cliffs: high-fanout (star) graphs and recursion-level transitions | enhancement · help wanted | — |
 
 _Note:_ the seeded **benchmark harness already exists** (`benchmarks/`, `npm run bench`),
 and the measured head-to-head lives in `benchmarks/HEAD-TO-HEAD.md`. #170 is now scoped to

--- a/.claude/knowledge/07-glossary.md
+++ b/.claude/knowledge/07-glossary.md
@@ -1,7 +1,7 @@
 # 07 — Glossary
 
-<!-- Updated on: 2026-07-17 (terms last extended in the roadNet-CA removal PR #185:
-     FUZZ_XL, seeded scale runs; roadNet-CA itself removed and purged from history) -->
+<!-- Updated on: 2026-07-19 (terms last extended in the #169 PR: reconstructPath and the
+     independent path oracle used to validate source-to-target node sequences) -->
 
 > **Lifecycle: dynamic — updated in Phase C of every PR.** When a PR introduces new symbols
 > or terms (module names, data-structure fields, paper notation newly used in code), add
@@ -60,6 +60,9 @@ Quick lookup for the symbols and terms used across the paper, the notes, and the
 - **BaseCase / FindPivots / BMSSP** — Algorithm 2 / Algorithm 1 / Algorithm 3. See §02.
 - **BlockList (`D`)** — Lemma 3.3 semi-sorted structure. See §03-B.
 - **Oracle** — the reference `dijkstra()` in `src/dijkstra.mjs`; ground truth for tests.
+- **Path oracle** (#169) — the independent Dijkstra implementation local to
+  `test/pathReconstruction.test.mjs`; it tracks complete node sequences and compares them
+  with `BMSSP.reconstructPath()`, without reading the production `preds` map.
 
 ## Code / repo terms
 
@@ -160,6 +163,10 @@ Quick lookup for the symbols and terms used across the paper, the notes, and the
   through `baseCase`/`findPivots`/`relaxEdge`; the `BMSSP` class owns one as `this.ties`
   (`this.hops`, `this.preds`), cleared by `initializeShortestPaths()`. Missing entries
   read as hop-0 / no-pred, so externally seeded sources need no setup.
+- **`reconstructPath(target)`** (#169) — public `BMSSP` method that walks the canonical
+  `preds` chain from `target` to the latest calculation's source, then reverses it into a
+  source-to-target node sequence. Returns `[]` before a calculation or for an unreachable
+  target; throws when `target` is not a known graph node.
 - **`boundKey`** (#163) — the composite boundary in `baseCase`/`bmssp` results: every
   returned vertex's order key is strictly below it. The scalar `bound` is its projection
   (a returned vertex may tie `bound`'s length, never exceed it).

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ with every building block shipped, tested, and released individually:
 | `FindPivots(B, S)` — Algorithm 1, frontier shrinking ([#44](https://github.com/Sirivasv/bmssp-js/issues/44)) | `src/findPivots.mjs` | ✅ done |
 | `BMSSP(l, B, S)` — Algorithm 3, the main recursion ([#43](https://github.com/Sirivasv/bmssp-js/issues/43)) | `src/bmssp.mjs` | ✅ done — **1.0.0** |
 | Deterministic tie-breaking — Assumption 2.1 realized ([#163](https://github.com/Sirivasv/bmssp-js/issues/163)) | `src/tieBreak.mjs` | ✅ done |
+| Shortest-path reconstruction ([#169](https://github.com/Sirivasv/bmssp-js/issues/169)) | `BMSSP.reconstructPath()` | ✅ done |
 
 > **Honest note:** the paper's win is asymptotic, and this repo optimizes for correctness
 > and readability, not raw speed. Measured head-to-head (algorithm time only, graph
@@ -84,7 +85,11 @@ const graph = new BMSSP([
 
 graph.calculateShortestPaths(0);
 console.log(graph.shortestPaths); // Map(3) { 0 => 0, 1 => 50, 2 => 25 }
+console.log(graph.reconstructPath(1)); // [0, 1]
 ```
+
+`reconstructPath(target)` uses the latest `calculateShortestPaths()` run. It returns `[]`
+when the target is unreachable (or before any run) and throws for a node outside the graph.
 
 A reference `dijkstra` implementation is also exported. See the `examples/` directory for
 more.
@@ -135,7 +140,7 @@ graphs in a few seconds), and set `FUZZ_XL=1` for an additional 2-million-node r
 | --- | --- | --- |
 | [`1.0.0`](https://github.com/Sirivasv/bmssp-js/milestones) | First end-to-end functional BMSSP (issues #40–#45) | ✅ done |
 | `1.1.0` | Correctness hardening — fuzz tests, edge cases, tie-breaking, input validation | 🔨 current focus |
-| `1.2.0` | Performance & ergonomics — exact Lemma 3.3 asymptotics, path reconstruction, BMSSP-vs-Dijkstra benchmarks | planned |
+| `1.2.0` | Performance & ergonomics — exact Lemma 3.3 asymptotics, path reconstruction, BMSSP-vs-Dijkstra benchmarks | 🔨 in progress |
 | `2.0.0` | API generalization — public multi-source/bounded entry point, flexible inputs | planned |
 
 Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) and the

--- a/src/bmssp.mjs
+++ b/src/bmssp.mjs
@@ -264,6 +264,30 @@ class BMSSP {
     this.hops.set(startNode, 0);
     this.bmssp(this.topLevel, Infinity, new Set([startNode]));
   }
+
+  /**
+   * Reconstruct the canonical shortest path from the most recent source to
+   * target. Returns an empty array when target is unreachable or no shortest
+   * path run has completed yet.
+   *
+   * @param {number} target - A node in the graph
+   * @returns {number[]} Node IDs from the source through target
+   * @throws {Error} If target is not in the graph
+   */
+  reconstructPath(target) {
+    if (!this.nodeIDs.has(target)) {
+      throw new Error("Target node not found in the graph");
+    }
+    if (this.shortestPaths.get(target) === Infinity) return [];
+
+    const path = [target];
+    let current = target;
+    while (this.preds.has(current)) {
+      current = this.preds.get(current);
+      path.push(current);
+    }
+    return path.reverse();
+  }
 }
 
 export { BMSSP };

--- a/test/README.md
+++ b/test/README.md
@@ -18,6 +18,7 @@ equal the Dijkstra oracle's** (`src/dijkstra.mjs`).
 | File | Covers |
 | --- | --- |
 | `main.test.mjs` | `BMSSP` class contracts (constructor, `nodeIDs`, adjacency, `shortestPaths`, error handling) + full-map BMSSP-vs-Dijkstra equality on a seeded 10k-node sparse graph |
+| `pathReconstruction.test.mjs` | Public `reconstructPath` API: source-to-target paths vs. a Dijkstra oracle, unreachable nodes, source switching, and target validation |
 | `bmssp.test.mjs` | Algorithm 3 recursion: parameter derivation, hand-built graphs, degenerate ties, the Lemma 3.1 bounded-call contract, seeded stress |
 | `fuzz.test.mjs` | High-volume property/fuzz suite (#161): 8 graph shapes × extreme weight regimes × multi-source bounded calls vs. per-source oracles, plus seeded scale runs (150k-node sparse, 300×300 grid, opt-in 2M) |
 | `edgeCases.test.mjs` | Deterministic disconnection fixtures (#162): isolated/sink/self-loop-only sources, single-node and multi-chain components, wrong-direction bridges, tiny-vs-giant components, source switching across components — each vs. a hand-computed map and the oracle |

--- a/test/pathReconstruction.test.mjs
+++ b/test/pathReconstruction.test.mjs
@@ -1,0 +1,76 @@
+import { describe, test, expect } from "@jest/globals";
+import { BMSSP } from "../index.mjs";
+
+function dijkstraPaths(graph, nodeIDs, source) {
+  const adjacency = new Map([...nodeIDs].map((node) => [node, []]));
+  for (const [from, to, weight] of graph) {
+    adjacency.get(from).push([to, weight]);
+  }
+
+  const distances = new Map([...nodeIDs].map((node) => [node, Infinity]));
+  const paths = new Map([[source, [source]]]);
+  const visited = new Set();
+  distances.set(source, 0);
+
+  for (;;) {
+    let current = null;
+    for (const node of nodeIDs) {
+      if (
+        !visited.has(node) &&
+        distances.get(node) < Infinity &&
+        (current === null || distances.get(node) < distances.get(current))
+      ) {
+        current = node;
+      }
+    }
+    if (current === null) break;
+    visited.add(current);
+
+    for (const [next, weight] of adjacency.get(current)) {
+      const candidate = distances.get(current) + weight;
+      if (candidate < distances.get(next)) {
+        distances.set(next, candidate);
+        paths.set(next, [...paths.get(current), next]);
+      }
+    }
+  }
+
+  return paths;
+}
+
+const graph = [
+  [0, 1, 7],
+  [0, 2, 2],
+  [2, 1, 1],
+  [1, 3, 1],
+  [2, 3, 9],
+  [4, 5, 1],
+];
+
+describe("BMSSP reconstructPath", () => {
+  test("matches Dijkstra-derived paths for reachable and unreachable targets", () => {
+    const bmssp = new BMSSP(graph);
+    bmssp.calculateShortestPaths(0);
+    const expected = dijkstraPaths(graph, bmssp.nodeIDs, 0);
+
+    for (const target of bmssp.nodeIDs) {
+      expect(bmssp.reconstructPath(target)).toEqual(expected.get(target) ?? []);
+    }
+  });
+
+  test("uses the source from the most recent shortest-path run", () => {
+    const bmssp = new BMSSP(graph);
+    expect(bmssp.reconstructPath(5)).toEqual([]);
+
+    bmssp.calculateShortestPaths(4);
+    expect(bmssp.reconstructPath(5)).toEqual([4, 5]);
+    expect(bmssp.reconstructPath(0)).toEqual([]);
+  });
+
+  test("rejects a target outside the graph", () => {
+    const bmssp = new BMSSP(graph);
+    expect(() => bmssp.reconstructPath(99)).toThrow(
+      "Target node not found in the graph",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- expose `BMSSP.reconstructPath(target)` over the canonical predecessor map
- return the source-to-target node sequence, or `[]` for an unreachable target
- validate reconstructed paths against an independent Dijkstra path oracle

## Checks

- `npm test -- test/pathReconstruction.test.mjs --runInBand --coverageDirectory=/tmp/coverage` — current base: expected feature-absence failure; patched: 3 passed in the clean network-off verifier
- `npm test -- --runInBand --coverageDirectory=/tmp/coverage` — 131 passed, 1 skipped in separate network-off validation
- `npm run lint` — passed in separate network-off validation

## Roadmap proposals

None. The live #169 description was already re-scoped after #163 to exactly this public API
and its path-oracle tests, while the measured composite-key overhead is already recorded by
the maintainer on #168. This change does not alter the remaining milestone slicing,
dependencies, or release cadence.

Closes #169

No version bump: this is a mid-milestone enhancement.

---
AI assistance was used. This change was reviewed by Northset, and I accept responsibility for this submission.

<!-- northset-receipt:M-1034:start -->
### Verification

[Northset proof-of-pass receipt M-1034](https://northset-oss.github.io/verification-pilot/receipts/M-1034/)  
This record covers Northset’s own contribution; it is not maintainer verification.
Maintainers can request a separate, private run for a PR already in their queue at oss@northset.ai.
For repositories already onboarded with Northset, adding `northset-verify` to a PR requests a run on that PR.
<!-- northset-receipt:M-1034:end -->
