### PR TITLE
docs: agent-friendly contributing guide + refresh SECURITY/README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,41 +1,98 @@
 # Contributing to bmssp-js
 
-Thank you for your interest in contributing to **bmssp-js**! Your help is appreciated.
+Thank you for your interest in contributing to **bmssp-js**! This is a community-driven,
+readable JavaScript implementation of the BMSSP shortest-paths algorithm, and help is
+genuinely welcome — whether you write the code yourself or pair with an AI agent.
 
-## Getting Started
+## Two ways to contribute
+
+### 1. With an AI agent — any model
+
+This repo is deliberately built so that **any coding agent, running any model, can pick up
+the work without ever reading the source paper, the PDF, or any external article.**
+Everything an agent needs is checked into the repository:
+
+- **[`.claude/CLAUDE.md`](.claude/CLAUDE.md)** — the operational entrypoint. It describes the
+  complete working lifecycle (session start → implement → pre-PR sync → open PR → release)
+  as explicit, literal checklists, so nothing depends on the model guessing.
+- **[`.claude/knowledge/`](.claude/knowledge/)** — a self-contained "mental map" of the
+  algorithm:
+  - `01–04` — **fixed** knowledge: a verified transcription of the paper (overview,
+    algorithms, data structures) plus consolidated intuition. Read these instead of the paper.
+  - `05` — what the code looks like **today** (module inventory + APIs).
+  - `06` — the milestones/issues roadmap and build order (what to work on next).
+  - `07` — a glossary of every symbol and term.
+  - [`.claude/knowledge/README.md`](.claude/knowledge/README.md) — an index and a
+    per-task reading map ("implementing issue X → read exactly these sections").
+
+To contribute this way, just point your agent at the repository and let it read
+`.claude/CLAUDE.md` first. The file is written to be model-agnostic on purpose — Claude,
+or any other assistant, should be able to follow it start to finish. The knowledge base is
+part of the project: if your work changes the code, the same lifecycle asks you (or your
+agent) to keep `05`/`06`/`07` and this `README`/docs in sync **inside the same PR**.
+
+### 2. By hand
+
+You don't need an AI agent to contribute. The knowledge base doubles as human-readable
+documentation — start with [`.claude/knowledge/README.md`](.claude/knowledge/README.md)
+and the root [`README.md`](README.md).
+
+## Getting started
 
 1. **Fork the repository** and clone it locally.
-2. Install dependencies:
-  ```bash
-  npm install
-  ```
-3. Create a new branch for your feature or bugfix:
-  ```bash
-  git checkout -b your-feature-name
-  ```
+2. Install dependencies (Node.js with npm; the package is ESM-only, `.mjs`):
+   ```bash
+   npm install
+   ```
+3. Create a branch for your feature or bugfix:
+   ```bash
+   git checkout -b your-feature-name
+   ```
 
 ## Development
 
-- Follow the existing code style and conventions.
-- Write clear, concise commit messages.
-- Add or update tests as appropriate.
+- Follow the existing code style and conventions (ES Modules, `.mjs` throughout).
+- Add or update tests with every change — see below.
+- **Correctness is the top priority.** BMSSP's output must match the Dijkstra oracle
+  (`src/dijkstra.mjs`) exactly, for every node. The seeded fuzz suite exists to protect
+  that contract.
+- Keep the knowledge base (`.claude/knowledge/05`–`07`), this file, and the `README` in
+  sync with your change, in the same PR — don't leave a docs update for later.
+- Write clear, focused commit messages.
 
-## Running Tests
+## Running the checks
 
-Run all tests with:
+Before opening a PR, both of these must pass:
+
 ```bash
-npm test
+npm test          # Jest suite — every graph is seeded, so every failure is reproducible
+npm run lint      # Prettier + ESLint
 ```
 
-## Submitting Changes
+Useful extras:
+
+```bash
+npm run format    # auto-format with Prettier
+npm run bench     # seeded micro-benchmarks (see benchmarks/README.md)
+```
+
+## Submitting changes
 
 1. Push your branch to your fork.
 2. Open a pull request against the `main` branch.
-3. Describe your changes and reference any related issues.
+3. Describe your change, reference any related issues (`Closes #<issue>`), and confirm that
+   tests and lint pass.
+4. One PR should carry the whole increment: code + tests + docs. If review feedback needs
+   changes, push to the same branch.
+
+Good places to start are the
+[`help wanted` / `good first issue` labels](https://github.com/Sirivasv/bmssp-js/issues)
+and the roadmap in [`.claude/knowledge/06-milestones-roadmap.md`](.claude/knowledge/06-milestones-roadmap.md).
 
 ## Code of Conduct
 
-Please be respectful and considerate in all interactions.
+Please be respectful and considerate in all interactions — see
+[CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -138,8 +138,19 @@ graphs in a few seconds), and set `FUZZ_XL=1` for an additional 2-million-node r
 | `1.2.0` | Performance & ergonomics — exact Lemma 3.3 asymptotics, path reconstruction, BMSSP-vs-Dijkstra benchmarks | planned |
 | `2.0.0` | API generalization — public multi-source/bounded entry point, flexible inputs | planned |
 
+## Contributing (humans and AI agents welcome)
+
 Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) and the
 [`help wanted` / `good first issue` labels](https://github.com/Sirivasv/bmssp-js/issues).
+
+This repo is built to be **agent-friendly, model-agnostic**: everything a coding assistant
+needs to contribute is checked in, so you can point **any AI running any model** at the
+project and it can start working **without ever reading the source paper**. Have your agent
+read [`.claude/CLAUDE.md`](.claude/CLAUDE.md) first — it lays out the full working lifecycle
+as literal, follow-along checklists — backed by a self-contained knowledge base under
+[`.claude/knowledge/`](.claude/knowledge/) (a verified transcription of the paper, the
+current codebase map, the roadmap, and a glossary). Prefer to work by hand? The same
+knowledge base reads as plain documentation.
 
 ## Other implementations on GitHub
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,9 +2,14 @@
 
 ## Supported Versions
 
+Security fixes are applied to the latest released `1.x` line. Older `0.x` pre-release
+versions are no longer supported — please upgrade to the current release on
+[npm](https://www.npmjs.com/package/bmssp).
+
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.x     | :white_check_mark: |
+| 1.x     | :white_check_mark: |
+| 0.x     | :x:                |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
## Summary

Refreshes the public-facing docs to reflect the project's current state and, most
importantly, to advertise that **anyone with any model can read `.claude/CLAUDE.md` and
start contributing with their AI** — no need to read the source paper.

- **CONTRIBUTING.md** — rewritten around **two contribution paths**, leading with the
  model-agnostic AI-agent workflow: point any assistant at the repo, have it read
  `.claude/CLAUDE.md` (the literal lifecycle checklists) backed by the self-contained
  `.claude/knowledge/` base (01–04 verified paper transcription, 05 codebase map, 06
  roadmap, 07 glossary). Also refreshes dev commands (`test`/`lint`/`format`/`bench`),
  ESM/`.mjs` notes, and the Dijkstra-oracle correctness contract. The by-hand path is
  kept too.
- **SECURITY.md** — the supported-versions table said `0.x`; now supports the released
  `1.x` line and marks `0.x` pre-releases unsupported, with an upgrade pointer.
- **README.md** — adds a "Contributing (humans and AI agents welcome)" section surfacing
  the same agent-friendly, model-agnostic story.

## Tests / lint

Docs-only change. `npm run lint` passes (Prettier + ESLint over `.mjs`/`.js`); no code
touched.

## Version

No bump — per the semver convention this PR neither fixes a bug nor closes a milestone's
last issue.

## Roadmap proposals

None.