### PR TITLE
feat(#165): validate BMSSP constructor input

### DIFF
--- a/.claude/knowledge/05-codebase-map.md
+++ b/.claude/knowledge/05-codebase-map.md
@@ -1,12 +1,12 @@
 # 05 — Codebase Map (current state)
 
-<!-- BOOKMARK-COMMIT: e25d89795947484726a72ae394ac19d502f86942 -->
-<!-- PENDING-PR-BRANCH: northset/bmssp-js-169 -->
-<!-- Last validated: 2026-07-19 (Phase C of the #169 PR). Describes the tree as it will
-     exist once that PR merges: BMSSP.reconstructPath(target) exposes the canonical
-     predecessor tree already maintained since #163; path-oracle tests and public usage
-     documentation are included. No version bump (mid-milestone enhancement; milestone
-     1.2.0 remains open — semver convention, 06 "Release mechanics"). -->
+<!-- BOOKMARK-COMMIT: 033733f2b2f37b2fc7ab02adab895bc693978253 -->
+<!-- PENDING-PR-BRANCH: northset/m-1052-input-validation -->
+<!-- Last validated: 2026-07-20 (Phase C of the #165 PR). Describes the tree as it will
+     exist once that PR merges: the BMSSP constructor rejects malformed edge arrays,
+     non-numeric node IDs, and invalid weights while preserving empty-graph construction.
+     No version bump (mid-milestone enhancement; milestone 1.1.0 remains open — semver
+     convention, 06 "Release mechanics"). -->
 
 Snapshot of what exists in `bmssp-js` today, so you know what to build on vs. what's missing.
 
@@ -64,7 +64,7 @@ src/
   baseCase.mjs            # #40: BaseCase(B, S) — Algorithm 2 bounded mini-Dijkstra on composite keys
   findPivots.mjs          # #44: FindPivots(B, S) — Algorithm 1 frontier shrink, canonical-pred forest
 test/
-  main.test.mjs           # Jest tests: constructor, nodeIDs, adjacency, shortestPaths, BMSSP-vs-Dijkstra (seeded 10k sparse)
+  main.test.mjs           # Jest tests: constructor validation, nodeIDs, adjacency, shortestPaths, BMSSP-vs-Dijkstra (seeded 10k sparse)
   bmssp.test.mjs          # #43: 15 recursion tests — params, hand graphs, ties, Lemma 3.1 contract, seeded stress
   fuzz.test.mjs           # #161: 18 high-volume fuzz tests — shapes × weight regimes × multi-source × seeded scale; FUZZ_ROUNDS / FUZZ_XL env vars
   edgeCases.test.mjs      # #162: 9 deterministic disconnection fixtures — isolated/sink sources, many components, source switching
@@ -101,7 +101,8 @@ direct `git push origin main` is rejected, including for docs-only bookkeeping c
 
 ```js
 class BMSSP {
-  constructor(inputGraph)          // inputGraph = array of [from, to, weight]
+  constructor(inputGraph)          // validates an array of [from, to, weight]: finite numeric
+                                   // node IDs, finite non-negative weights; [] remains valid
   //   this.graph          : deep-copied edge array
   //   this.nodeIDs        : Set of all node IDs (from both endpoints)
   //   this.shortestPaths  : Map<nodeId, distance>, initialized to Infinity  ← this is d̂[·]
@@ -124,6 +125,12 @@ class BMSSP {
                                    //      a run or when unreachable; throws for unknown target
 }
 ```
+
+**Constructor input validation (#165).** `inputGraph` must be an array; every entry must be
+an exact three-element `[from, to, weight]` array. Node IDs and weights must be finite
+numbers, and weights must be non-negative. Failures identify the offending edge index.
+An empty edge list remains valid and preserves the #162 contract: construction succeeds,
+then `calculateShortestPaths()` rejects any start node because the graph has no nodes.
 
 **`bmssp(l, B, S)` (#43):** level 0 delegates to `baseCase`. At level ≥ 1: `findPivots`
 shrinks the frontier; pivots seed a `BlockList(M = 2^((l-1)·t), B, compareKeys)`; the loop
@@ -295,7 +302,8 @@ implementation is tested against — and, since #43, no longer part of the BMSSP
 
 ## Tests — the contract
 
-- `test/main.test.mjs` (12): constructor/nodeIDs/adjacency/shortestPaths contracts, plus the
+- `test/main.test.mjs` (16): constructor input-validation failures (#165), nodeIDs,
+  adjacency, and shortestPaths contracts, plus the
   **key one** — "BMSSP vs Dijkstra" on a **seeded 10k-node sparse graph** (`sparseRandom(10_000,
   3, 1601)`, already `topLevel` 3): for a fixed source, `myBMSSP.shortestPaths` must equal
   `dijkstra(...)` for every node. (Until 2026-07-17 this ran on `roadNet-CA.txt`, an 87 MB
@@ -348,7 +356,7 @@ implementation is tested against — and, since #43, no longer part of the BMSSP
   **opt-in `FUZZ_XL=1` sparse n = 2M round** (~33 s, `test.skip` otherwise). Every failure
   message carries the round's seed for reproduction. **`FUZZ_ROUNDS=<x>`** multiplies all
   round counts (default 1 ≈ 0.5 s; 25 ≈ 10 s, several thousand graphs).
-- Current suite: **132 tests — 131 passing + 1 XL skipped by default**, 100% statement
+- Current suite: **136 tests — 135 passing + 1 XL skipped by default**, 100% statement
   coverage, ~3 s wall-clock. No graph data files: every generated test graph comes from a
   seed; the #162 fixtures are hand-built and fully deterministic.
 
@@ -375,8 +383,9 @@ comparison-count mode); the raw baseline is also on #170 as a comment.
 | Property/fuzz suite vs. the oracle | `test/fuzz.test.mjs` | #161 | ✅ done (PR #184, 1.0.1) |
 | Deterministic disconnection edge cases | `test/edgeCases.test.mjs` | #162 | ✅ done (PR #187, no bump) |
 | Deterministic tie-breaking (Assumption 2.1) | `src/tieBreak.mjs` + all modules | #163 | ✅ done (PR #188, no bump) |
-| Public shortest-path reconstruction | `BMSSP.reconstructPath()` + `test/pathReconstruction.test.mjs` | #169 | ✅ done-pending-merge (this PR, no bump) |
+| Public shortest-path reconstruction | `BMSSP.reconstructPath()` + `test/pathReconstruction.test.mjs` | #169 | ✅ done (PR #189, no bump) |
+| Constructor input validation | `BMSSP` constructor + `test/main.test.mjs` | #165 | ✅ done-pending-merge (this PR, no bump) |
 
-Milestone `1.1.0` (correctness hardening) remains in progress with #165, #164 and #166
-open. Milestone `1.2.0` is also in progress: #169 lands with this PR; see
+Milestone `1.1.0` (correctness hardening) remains in progress with #164 and #166 open
+after this PR. Milestone `1.2.0` remains in progress with #169 merged; see
 [06-milestones-roadmap.md](06-milestones-roadmap.md).

--- a/.claude/knowledge/06-milestones-roadmap.md
+++ b/.claude/knowledge/06-milestones-roadmap.md
@@ -1,8 +1,8 @@
 # 06 — Milestones Roadmap
 
-<!-- SYNCED-FROM-GITHUB: 2026-07-19 (#163 closed by merged PR #188; milestones
-     1.1.0/1.2.0/2.0.0 open with 3/5/3 open issues; #169 done-pending-merge in this PR) -->
-<!-- Current package version: 1.0.1 (released 2026-07-16; the #169 PR ships no bump under
+<!-- SYNCED-FROM-GITHUB: 2026-07-20 (#169 closed by merged PR #189; milestones
+     1.1.0/1.2.0/2.0.0 open with 3/4/3 open issues; #165 done-pending-merge in this PR) -->
+<!-- Current package version: 1.0.1 (released 2026-07-16; the #165 PR ships no bump under
      the semver convention — mid-milestone enhancement, milestone still open) -->
 
 Maps GitHub **milestones** and **issues** (Sirivasv/bmssp-js) to the paper's building blocks,
@@ -39,12 +39,10 @@ it runs the same Phase C reconciliation directly on `main`.
 
 ## 📋 Roadmap proposals (pending user approval)
 
-From the #169 PR (Phase C, 2026-07-19): **none.** The live #169 description was already
-re-scoped after #163 to exactly the public `reconstructPath(target)` API and path-oracle
-tests implemented here. The other learning from #163 — composite-key allocation and
-comparison overhead — is already recorded by the maintainer on #168. This PR does not
-change the remaining milestone slicing, dependencies, or release cadence, so no further
-GitHub edit is warranted.
+From the #165 PR (Phase C, 2026-07-20): **none.** The implementation follows the live issue
+exactly and preserves the empty-graph behavior already clarified by the maintainer after
+#162. It does not change the scope or dependencies of #164 or #166, the remaining 1.1.0
+work, so no further GitHub edit is warranted.
 
 _Phase C writes proposed GitHub edits here (and in the PR body); Phase E executes the
 approved ones — one confirmation each — and clears them from this list._
@@ -71,16 +69,18 @@ executed 2026-07-17.)_
   and dates preserved), `main` + all 21 tags force-pushed with ruleset 7764713
   temporarily disabled. **All commit SHAs before 2026-07-17 changed**; old SHAs in
   closed PRs/issues no longer resolve. Repo-local git config now signs future commits.
-- **Milestone `1.1.0` — correctness hardening** (in progress). #162 merged (PR #187) and
-  #163 merged (PR #188): `src/tieBreak.mjs` composite `[length, hops, id]`
+- **Milestone `1.1.0` — correctness hardening** (in progress). #162 merged (PR #187),
+  #163 merged (PR #188), and **#165 done-pending-merge** (this PR): constructor input
+  validation rejects malformed edges, non-numeric node IDs, and invalid weights while
+  preserving empty-graph construction. `src/tieBreak.mjs` composite `[length, hops, id]`
   keys realize Assumption 2.1 end-to-end — canonical relaxation (d̂/hops/preds in
   lockstep), strict pull separators, all pre-#163 tie guards removed (incl. the stall
   escape hatch), strict Lemma 3.1 restored, full edge-order determinism proven by test.
-  No bump. Next: **#165** (input validation), then #164, #166.
-- **Milestone `1.2.0` — performance & ergonomics** (in progress). **#169
-  done-pending-merge** (this PR): public `BMSSP.reconstructPath(target)` walks the existing
-  canonical predecessor map, with independent path-oracle coverage and public usage docs.
-  No bump; four other issues remain after this PR.
+  No bump. Next: #164, then #166.
+- **Milestone `1.2.0` — performance & ergonomics** (in progress). **#169 merged**
+  (PR #189): public `BMSSP.reconstructPath(target)` walks the existing canonical
+  predecessor map, with independent path-oracle coverage and public usage docs. Four
+  issues remain.
 - **Semver release convention (user-directed 2026-07-17, PR #186):** bumps only on bug
   fix (patch) or milestone-closing PR (minor/major) — see "Release mechanics" below.
 - **2026-07-16 reflection session (post-release):** measured the BMSSP-vs-Dijkstra
@@ -121,7 +121,7 @@ Recommended order (cheapest protection first, then the deep work):
 | 1 | 161 | Property/fuzz tests: BMSSP vs Dijkstra on random graphs | enhancement · help wanted | ✅ merged (PR #184, 1.0.1) |
 | 2 | 162 | Edge-case tests: disconnected graphs and unreachable nodes | enhancement · help wanted | ✅ merged (PR #187, no bump) |
 | 3 | 163 | Deterministic tie-breaking for equal-length paths (Assumption 2.1) | enhancement · help wanted | ✅ merged (PR #188, no bump): composite keys in `src/tieBreak.mjs`, all six tie manifestations resolved by construction |
-| 4 | 165 | Input validation for the BMSSP constructor | good first issue · help wanted | — |
+| 4 | 165 | Input validation for the BMSSP constructor | good first issue · help wanted | ✅ done-pending-merge (this PR, no bump): validates graph shape, node IDs, and weights; preserves empty graphs |
 | 5 | 164 | Optional constant-degree transform (in/out-degree ≤ 2) | enhancement · help wanted | — |
 | 6 | 166 | JSDoc / API docs for the new modules | documentation · good first issue | `bmssp()` / `deriveParameters()` ship with JSDoc already |
 
@@ -131,7 +131,7 @@ Recommended order (cheapest protection first, then the deep work):
 |---|---|---|---|
 | 167 | Restore Lemma 3.3's exact asymptotics in BlockList (balanced-BST bound index + linear-time selection) | enhancement · help wanted | — |
 | 168 | Adjacency and relaxation micro-optimizations | enhancement · help wanted | — |
-| 169 | Optional shortest-path reconstruction (`Pred[]` → paths) | enhancement · help wanted | ✅ done-pending-merge (this PR, no bump): public API + independent path oracle |
+| 169 | Optional shortest-path reconstruction (`Pred[]` → paths) | enhancement · help wanted | ✅ merged (PR #189, no bump): public API + independent path oracle |
 | 170 | BMSSP-vs-Dijkstra benchmark comparison | enhancement · help wanted | — |
 | 182 | Investigate BMSSP performance cliffs: high-fanout (star) graphs and recursion-level transitions | enhancement · help wanted | — |
 

--- a/.claude/knowledge/07-glossary.md
+++ b/.claude/knowledge/07-glossary.md
@@ -1,7 +1,7 @@
 # 07 — Glossary
 
-<!-- Updated on: 2026-07-19 (terms last extended in the #169 PR: reconstructPath and the
-     independent path oracle used to validate source-to-target node sequences) -->
+<!-- Updated on: 2026-07-20 (terms last extended in the #165 PR: the constructor input
+     contract for graph shape, node IDs, weights, and empty graphs) -->
 
 > **Lifecycle: dynamic — updated in Phase C of every PR.** When a PR introduces new symbols
 > or terms (module names, data-structure fields, paper notation newly used in code), add
@@ -66,6 +66,10 @@ Quick lookup for the symbols and terms used across the paper, the notes, and the
 
 ## Code / repo terms
 
+- **Constructor input contract (#165)** — `new BMSSP(inputGraph)` requires an array of exact
+  `[from, to, weight]` arrays. Both node IDs and the weight must be finite numbers, and the
+  weight must be non-negative; failures identify the offending edge index. `[]` remains a
+  valid empty graph, whose `calculateShortestPaths()` call rejects every start node.
 - **`adjacency`** (#45) — `Map<nodeId, Array<[to, weight]>>` field on the `BMSSP` class:
   a node's outgoing edges, so lookups are O(1) instead of scanning the whole edge array.
   Every known node has an entry (empty array for sinks). Built in the constructor.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ with every building block shipped, tested, and released individually:
 | `BMSSP(l, B, S)` — Algorithm 3, the main recursion ([#43](https://github.com/Sirivasv/bmssp-js/issues/43)) | `src/bmssp.mjs` | ✅ done — **1.0.0** |
 | Deterministic tie-breaking — Assumption 2.1 realized ([#163](https://github.com/Sirivasv/bmssp-js/issues/163)) | `src/tieBreak.mjs` | ✅ done |
 | Shortest-path reconstruction ([#169](https://github.com/Sirivasv/bmssp-js/issues/169)) | `BMSSP.reconstructPath()` | ✅ done |
+| Constructor input validation ([#165](https://github.com/Sirivasv/bmssp-js/issues/165)) | `BMSSP` constructor | ✅ done |
 
 > **Honest note:** the paper's win is asymptotic, and this repo optimizes for correctness
 > and readability, not raw speed. Measured head-to-head (algorithm time only, graph
@@ -72,7 +73,8 @@ npm install bmssp
 ## Usage
 
 The package is ESM-only (`.mjs`). Graphs are arrays of `[from, to, weight]` edges with
-numeric node IDs and non-negative weights:
+finite numeric node IDs and finite, non-negative weights. The constructor rejects malformed
+edges with an error that identifies their array index; an empty edge array remains valid:
 
 ```javascript
 import { BMSSP } from "bmssp";

--- a/src/bmssp.mjs
+++ b/src/bmssp.mjs
@@ -11,6 +11,10 @@ import {
 
 class BMSSP {
   constructor(inputGraph) {
+    if (!Array.isArray(inputGraph)) {
+      throw new Error("Input graph must be an array of edges");
+    }
+
     // Main graph represented as an array of edges
     this.graph = [];
     // Set to store unique node IDs
@@ -29,7 +33,21 @@ class BMSSP {
     this.preds = new Map();
     this.ties = makeTies(this.hops, this.preds);
 
-    for (let edge of inputGraph) {
+    for (let [index, edge] of inputGraph.entries()) {
+      if (!Array.isArray(edge) || edge.length !== 3) {
+        throw new Error(`Edge at index ${index} must be [from, to, weight]`);
+      }
+
+      const [from, to, weight] = edge;
+      if (!Number.isFinite(from) || !Number.isFinite(to)) {
+        throw new Error(`Edge at index ${index} must have numeric node IDs`);
+      }
+      if (!Number.isFinite(weight) || weight < 0) {
+        throw new Error(
+          `Edge at index ${index} must have a non-negative numeric weight`,
+        );
+      }
+
       // Create a deep copy of each edge array
       this.graph.push([...edge]);
 

--- a/test/main.test.mjs
+++ b/test/main.test.mjs
@@ -17,6 +17,30 @@ describe("BMSSP constructor", () => {
   test("initializes the graph correctly", () => {
     expect(myBMSSP.graph).toEqual(mediumSparse);
   });
+
+  test("rejects a non-array input graph", () => {
+    expect(() => new BMSSP("not an edge array")).toThrow(
+      "Input graph must be an array of edges",
+    );
+  });
+
+  test("rejects malformed edges", () => {
+    expect(() => new BMSSP([[0, 1]])).toThrow(
+      "Edge at index 0 must be [from, to, weight]",
+    );
+  });
+
+  test("rejects non-numeric node IDs", () => {
+    expect(() => new BMSSP([["0", 1, 5]])).toThrow(
+      "Edge at index 0 must have numeric node IDs",
+    );
+  });
+
+  test("rejects negative weights", () => {
+    expect(() => new BMSSP([[0, 1, -1]])).toThrow(
+      "Edge at index 0 must have a non-negative numeric weight",
+    );
+  });
 });
 
 describe("BMSSP nodeIDs", () => {


### PR DESCRIPTION
## Summary

- validate that constructor input is an array of `[from, to, weight]` edges
- reject malformed edges, invalid node IDs, and negative or non-finite weights with edge-indexed errors
- preserve empty-graph construction and add regression coverage for every requested failure mode
- refresh the codebase map, roadmap, glossary, and public README for #165

## Checks

- `npm test -- test/main.test.mjs --runInBand --no-cache` — 16 passed
- `npm test -- --runInBand --no-cache` — 135 passed, 1 skipped; 100% statement coverage
- `npm run lint` — passed

## Roadmap proposals

None. The implementation follows the live issue exactly and preserves the empty-graph behavior already clarified by the maintainer after #162. It does not change the scope or dependencies of #164 or #166, the remaining 1.1.0 work.

Closes #165

No version bump: this is a mid-milestone input-validation enhancement.

---
AI assistance was used. This change was reviewed by Northset, and I accept responsibility for this submission.

<!-- northset-receipt:M-1052:start -->
### Verification

[Northset proof-of-pass receipt M-1052](https://northset-oss.github.io/verification-pilot/receipts/M-1052/)  
This record covers Northset’s own contribution; it is not maintainer verification.
Maintainers can request a separate, private run for a PR already in their queue at oss@northset.ai.
For repositories already onboarded with Northset, adding `northset-verify` to a PR requests a run on that PR.
<!-- northset-receipt:M-1052:end -->
