### PR TITLE
feat(#164): opt-in constant-degree transform (in/out-degree ≤ 2)

### DIFF
--- a/.claude/knowledge/05-codebase-map.md
+++ b/.claude/knowledge/05-codebase-map.md
@@ -1,12 +1,15 @@
 # 05 — Codebase Map (current state)
 
-<!-- BOOKMARK-COMMIT: 033733f2b2f37b2fc7ab02adab895bc693978253 -->
-<!-- PENDING-PR-BRANCH: northset/m-1052-input-validation -->
-<!-- Last validated: 2026-07-20 (Phase C of the #165 PR). Describes the tree as it will
-     exist once that PR merges: the BMSSP constructor rejects malformed edge arrays,
-     non-numeric node IDs, and invalid weights while preserving empty-graph construction.
-     No version bump (mid-milestone enhancement; milestone 1.1.0 remains open — semver
-     convention, 06 "Release mechanics"). -->
+<!-- BOOKMARK-COMMIT: b36c05944cb011e3667da7802032599868dbfc81 -->
+<!-- PENDING-PR-BRANCH: feat/164-constant-degree-transform -->
+<!-- Last validated: 2026-07-21 (Phase C of the #164 PR). Describes the tree as it will
+     exist once that PR merges: adds the opt-in constant-degree transform
+     (src/constantDegree.mjs), re-exported from index.mjs. This same rewrite folds in the
+     Phase A reconciliation missed at the top of main: #165 (constructor input validation)
+     merged as PR #191 (commit 39f7494), and three dependabot workflow bumps (#192/#193/#194,
+     .github/workflows/** only) landed on top — the bookmark now sits at that HEAD (b36c059).
+     No version bump (mid-milestone enhancement; milestone 1.1.0 remains open with #166 —
+     semver convention, 06 "Release mechanics"). -->
 
 Snapshot of what exists in `bmssp-js` today, so you know what to build on vs. what's missing.
 
@@ -54,10 +57,11 @@ feature branch name. Step 2 above then fast-paths the post-merge session start.
 ## Layout
 
 ```
-index.mjs                 # re-exports { BMSSP } and { dijkstra }
+index.mjs                 # re-exports { BMSSP }, { dijkstra } and { constantDegreeTransform }
 src/
   bmssp.mjs               # BMSSP class — full Algorithm 3 recursion (#43); wires the pieces below
   dijkstra.mjs            # reference Dijkstra (array binary-heap) — DONE, used as oracle
+  constantDegree.mjs      # #164: opt-in constant-degree transform (in/out-degree ≤ 2); public, re-exported
   tieBreak.mjs            # #163: composite [length, hops, id] keys — Assumption 2.1 realized (compareKeys/toBound/relaxEdge)
   blockList.mjs           # #42: Lemma 3.3 block-based partial-sort structure D (comparator-aware since #163)
   heap.mjs                # #41: indexed binary min-heap (MinHeap) for BaseCase (comparator-aware since #163)
@@ -69,6 +73,7 @@ test/
   fuzz.test.mjs           # #161: 18 high-volume fuzz tests — shapes × weight regimes × multi-source × seeded scale; FUZZ_ROUNDS / FUZZ_XL env vars
   edgeCases.test.mjs      # #162: 9 deterministic disconnection fixtures — isolated/sink sources, many components, source switching
   tieBreak.test.mjs       # #163: 16 tests — key order, canonical relaxEdge, edge-order determinism, strict Lemma 3.1, lex-oracle hops/preds
+  constantDegree.test.mjs # #164: 11 tests — degree ≤ 2 on hand + seeded shapes (incl. star hub), distance preservation via oracle, BMSSP-on-transform, determinism, empty/validation
   pathReconstruction.test.mjs # #169: 3 public-API tests — Dijkstra path oracle, unreachable/pre-run/source switching, target validation
   blockList.test.mjs      # #42: 18 BlockList tests incl. a seeded random stress test
   heap.test.mjs           # #41: 16 MinHeap tests incl. a seeded stress test vs. a naive queue
@@ -300,6 +305,33 @@ with lazy stale-entry skipping (no `DecreaseKey`). Builds its own adjacency list
 array (independent of the class's `this.adjacency`). This is the **ground truth** the BMSSP
 implementation is tested against — and, since #43, no longer part of the BMSSP code path.
 
+## `src/constantDegree.mjs` — constant-degree transform (#164)
+
+```js
+constantDegreeTransform(graph)   // → { edges, copiesOf, originalOf, sourceCopy, collapse }
+// graph      : [from, to, weight][] — same input contract as the BMSSP constructor
+//              (validated identically; [] is valid → empty transform)
+// edges      : the rewritten graph, in/out-degree ≤ 2, fresh integer copy IDs from 0
+// copiesOf   : Map<originalId, copyId[]> — a vertex's port copies, in allocation order
+// originalOf : Map<copyId, originalId> — the exact inverse of copiesOf
+// sourceCopy(orig) : a canonical copy to start a run from (any works; throws for unknown)
+// collapse(dist)   : fold a transformed distance Map back onto original IDs (min over a
+//                    vertex's copies — all copies share one value, so the min is exact)
+export { constantDegreeTransform };   // PUBLIC — re-exported from index.mjs (unlike the
+                                      // algorithm-internal heap/blockList/baseCase/… modules)
+```
+
+Realizes the paper's Preliminaries assumption (§01): every vertex split into a **zero-weight
+directed cycle** of one **port copy per incident edge endpoint**. The cycle gives each copy
+exactly one in- and one out-cycle-edge, so a copy that also hosts a single original endpoint
+reaches degree 2 on that side and 1 on the other — never more (a lone copy needs no cycle).
+Because the cycle costs nothing to traverse, all copies of a vertex are mutually reachable at
+zero added distance, so each copy's distance equals the original vertex's: **distance-preserving**.
+**Opt-in and correctness-independent** — nothing in `bmssp.mjs`/`baseCase.mjs`/`findPivots.mjs`
+calls it; BMSSP is correct on the untransformed graph. A caller opts in by transforming the
+graph, running from `sourceCopy(source)`, and `collapse()`-ing the result. Output is
+edge-order deterministic (copies allocated in edge order); ~2m copies, ~3m edges — O(m).
+
 ## Tests — the contract
 
 - `test/main.test.mjs` (16): constructor input-validation failures (#165), nodeIDs,
@@ -331,6 +363,16 @@ implementation is tested against — and, since #43, no longer part of the BMSSP
   equality against an independent O(n²) lexicographic-(length, hops) Dijkstra oracle
   (hops = minimal edge count among shortest paths; preds = smallest optimal parent, chain
   reaching the source acyclically).
+- `test/constantDegree.test.mjs` (11, #164): the opt-in `constantDegreeTransform`. Degree
+  bound (in/out ≤ 2) on a hand-built hub and on all five seeded benchmark shapes — the
+  **star** hub (degree ~2(n−1) before) is the key case; per-endpoint copy counts and the
+  copiesOf/originalOf inverse; zero-weight cycle edges (and a single-copy vertex getting no
+  cycle). Distance preservation checked by `collapse`-ing a transformed-graph distance map
+  back onto original IDs and comparing to the **Dijkstra oracle on the original** — from
+  *every* source, across the five shapes plus self-loop/zero-weight fixtures — and separately
+  with **BMSSP itself** run on the transform. Determinism (collapsed distances invariant
+  under edge-list permutation), the empty-graph transform, and constructor-parity input
+  validation round it out.
 - `test/pathReconstruction.test.mjs` (3, #169): the public `reconstructPath(target)` API
   checked against an independent Dijkstra path oracle, including competing paths, an
   unreachable vertex, calls before a run, source switching on one instance, and rejection
@@ -356,8 +398,9 @@ implementation is tested against — and, since #43, no longer part of the BMSSP
   **opt-in `FUZZ_XL=1` sparse n = 2M round** (~33 s, `test.skip` otherwise). Every failure
   message carries the round's seed for reproduction. **`FUZZ_ROUNDS=<x>`** multiplies all
   round counts (default 1 ≈ 0.5 s; 25 ≈ 10 s, several thousand graphs).
-- Current suite: **136 tests — 135 passing + 1 XL skipped by default**, 100% statement
-  coverage, ~3 s wall-clock. No graph data files: every generated test graph comes from a
+- Current suite: **147 tests — 146 passing + 1 XL skipped by default**, 100% statement
+  coverage, ~7 s wall-clock (the #164 distance-preservation sweeps run BMSSP/Dijkstra from
+  every source). No graph data files: every generated test graph comes from a
   seed; the #162 fixtures are hand-built and fully deterministic.
 
 ## Benchmarks (`benchmarks/`, `npm run bench`)
@@ -384,8 +427,9 @@ comparison-count mode); the raw baseline is also on #170 as a comment.
 | Deterministic disconnection edge cases | `test/edgeCases.test.mjs` | #162 | ✅ done (PR #187, no bump) |
 | Deterministic tie-breaking (Assumption 2.1) | `src/tieBreak.mjs` + all modules | #163 | ✅ done (PR #188, no bump) |
 | Public shortest-path reconstruction | `BMSSP.reconstructPath()` + `test/pathReconstruction.test.mjs` | #169 | ✅ done (PR #189, no bump) |
-| Constructor input validation | `BMSSP` constructor + `test/main.test.mjs` | #165 | ✅ done-pending-merge (this PR, no bump) |
+| Constructor input validation | `BMSSP` constructor + `test/main.test.mjs` | #165 | ✅ merged (PR #191, no bump) |
+| Optional constant-degree transform (in/out-degree ≤ 2) | `src/constantDegree.mjs` + `test/constantDegree.test.mjs` | #164 | ✅ done-pending-merge (this PR, no bump) |
 
-Milestone `1.1.0` (correctness hardening) remains in progress with #164 and #166 open
-after this PR. Milestone `1.2.0` remains in progress with #169 merged; see
-[06-milestones-roadmap.md](06-milestones-roadmap.md).
+Milestone `1.1.0` (correctness hardening) remains in progress with **only #166 open**
+after this PR — its closing PR will bump **minor → 1.1.0**. Milestone `1.2.0` remains in
+progress with #169 merged; see [06-milestones-roadmap.md](06-milestones-roadmap.md).

--- a/.claude/knowledge/06-milestones-roadmap.md
+++ b/.claude/knowledge/06-milestones-roadmap.md
@@ -1,8 +1,9 @@
 # 06 — Milestones Roadmap
 
-<!-- SYNCED-FROM-GITHUB: 2026-07-20 (#169 closed by merged PR #189; milestones
-     1.1.0/1.2.0/2.0.0 open with 3/4/3 open issues; #165 done-pending-merge in this PR) -->
-<!-- Current package version: 1.0.1 (released 2026-07-16; the #165 PR ships no bump under
+<!-- SYNCED-FROM-GITHUB: 2026-07-21 (#165 closed by merged PR #191 + dependabot workflow
+     bumps #192/#193/#194 landed on main; milestones 1.1.0/1.2.0/2.0.0 open with 2/4/3 open
+     issues; #164 done-pending-merge in this PR → leaves #166 as 1.1.0's last open issue) -->
+<!-- Current package version: 1.0.1 (released 2026-07-16; the #164 PR ships no bump under
      the semver convention — mid-milestone enhancement, milestone still open) -->
 
 Maps GitHub **milestones** and **issues** (Sirivasv/bmssp-js) to the paper's building blocks,
@@ -39,13 +40,23 @@ it runs the same Phase C reconciliation directly on `main`.
 
 ## 📋 Roadmap proposals (pending user approval)
 
-From the #165 PR (Phase C, 2026-07-20): **none.** The implementation follows the live issue
-exactly and preserves the empty-graph behavior already clarified by the maintainer after
-#162. It does not change the scope or dependencies of #164 or #166, the remaining 1.1.0
-work, so no further GitHub edit is warranted.
+From the #164 PR (Phase C, 2026-07-21):
+
+1. **Re-scope #166** (JSDoc / API docs — 1.1.0's last open issue). Since it was filed, three
+   PRs have already shipped thorough JSDoc: `bmssp()` / `deriveParameters()` (#43),
+   `reconstructPath()` (#169), and now the whole `src/constantDegree.mjs` (#164, this PR).
+   Propose editing #166's description to name the modules still lacking JSDoc — `heap.mjs`,
+   `blockList.mjs`, `baseCase.mjs`, `findPivots.mjs`, `tieBreak.mjs` — plus a single
+   consolidated public-API doc, so the issue reflects the actual remaining work. **#166 is
+   now the last open 1.1.0 issue, so its PR closes the milestone → minor bump to `1.1.0`.**
+2. **Note the new public export on #173** (2.0.0 "Stabilize the public API surface"). The
+   public surface grew in #164: `index.mjs` now exports `constantDegreeTransform` alongside
+   `BMSSP` and `dijkstra`. Propose adding a line to #173 so the 1.0→2.0 API-stabilization
+   work explicitly covers the transform's signature and return shape.
 
 _Phase C writes proposed GitHub edits here (and in the PR body); Phase E executes the
 approved ones — one confirmation each — and clears them from this list._
+_(The #165-PR proposals — none — needed no execution.)_
 _(The #188-PR proposals — re-scope **#169** and add the measured optimization note to
 **#168** — were executed 2026-07-17.)_
 _(The #187-PR proposal — empty-graph validation note on **#165** — was approved and
@@ -70,13 +81,18 @@ executed 2026-07-17.)_
   temporarily disabled. **All commit SHAs before 2026-07-17 changed**; old SHAs in
   closed PRs/issues no longer resolve. Repo-local git config now signs future commits.
 - **Milestone `1.1.0` — correctness hardening** (in progress). #162 merged (PR #187),
-  #163 merged (PR #188), and **#165 done-pending-merge** (this PR): constructor input
-  validation rejects malformed edges, non-numeric node IDs, and invalid weights while
-  preserving empty-graph construction. `src/tieBreak.mjs` composite `[length, hops, id]`
-  keys realize Assumption 2.1 end-to-end — canonical relaxation (d̂/hops/preds in
-  lockstep), strict pull separators, all pre-#163 tie guards removed (incl. the stall
-  escape hatch), strict Lemma 3.1 restored, full edge-order determinism proven by test.
-  No bump. Next: #164, then #166.
+  #163 merged (PR #188), **#165 merged** (PR #191: constructor input validation rejects
+  malformed edges, non-numeric node IDs, and invalid weights while preserving empty-graph
+  construction), and **#164 done-pending-merge** (this PR): the opt-in constant-degree
+  transform (`src/constantDegree.mjs`, re-exported from `index.mjs`) rewrites any graph to
+  in/out-degree ≤ 2 by splitting each vertex into a zero-weight port cycle — distance-
+  preserving, correctness-independent, verified degree-bounded and oracle-equal from every
+  source across the five seeded shapes (incl. the star hub). No bump. **Only #166 (JSDoc)
+  now remains — its PR closes the milestone (minor → `1.1.0`).**
+- **Phase A reconciliation (2026-07-21):** the #165 PR (#191) and three dependabot workflow
+  bumps (#192/#193/#194, `.github/workflows/**` only) had landed on `main` without a
+  post-merge session-start marker flip. The #164 PR folds that in: `05`'s bookmark now sits
+  at `b36c059` and the "pending" framing for #165 is cleared.
 - **Milestone `1.2.0` — performance & ergonomics** (in progress). **#169 merged**
   (PR #189): public `BMSSP.reconstructPath(target)` walks the existing canonical
   predecessor map, with independent path-oracle coverage and public usage docs. Four
@@ -121,9 +137,9 @@ Recommended order (cheapest protection first, then the deep work):
 | 1 | 161 | Property/fuzz tests: BMSSP vs Dijkstra on random graphs | enhancement · help wanted | ✅ merged (PR #184, 1.0.1) |
 | 2 | 162 | Edge-case tests: disconnected graphs and unreachable nodes | enhancement · help wanted | ✅ merged (PR #187, no bump) |
 | 3 | 163 | Deterministic tie-breaking for equal-length paths (Assumption 2.1) | enhancement · help wanted | ✅ merged (PR #188, no bump): composite keys in `src/tieBreak.mjs`, all six tie manifestations resolved by construction |
-| 4 | 165 | Input validation for the BMSSP constructor | good first issue · help wanted | ✅ done-pending-merge (this PR, no bump): validates graph shape, node IDs, and weights; preserves empty graphs |
-| 5 | 164 | Optional constant-degree transform (in/out-degree ≤ 2) | enhancement · help wanted | — |
-| 6 | 166 | JSDoc / API docs for the new modules | documentation · good first issue | `bmssp()` / `deriveParameters()` ship with JSDoc already |
+| 4 | 165 | Input validation for the BMSSP constructor | good first issue · help wanted | ✅ merged (PR #191, no bump): validates graph shape, node IDs, and weights; preserves empty graphs |
+| 5 | 164 | Optional constant-degree transform (in/out-degree ≤ 2) | enhancement · help wanted | ✅ done-pending-merge (this PR, no bump): `src/constantDegree.mjs`, opt-in + distance-preserving, re-exported |
+| 6 | 166 | JSDoc / API docs for the new modules | documentation · good first issue | **1.1.0's last open issue → its PR closes the milestone (minor).** `bmssp()`/`deriveParameters()`/`reconstructPath()`/`constantDegree.mjs` already ship JSDoc; see Roadmap proposal 1 to re-scope to `heap`/`blockList`/`baseCase`/`findPivots`/`tieBreak` + a consolidated API doc |
 
 ## Milestone `1.2.0` (milestone #3) — performance & ergonomics
 

--- a/.claude/knowledge/07-glossary.md
+++ b/.claude/knowledge/07-glossary.md
@@ -1,7 +1,8 @@
 # 07 — Glossary
 
-<!-- Updated on: 2026-07-20 (terms last extended in the #165 PR: the constructor input
-     contract for graph shape, node IDs, weights, and empty graphs) -->
+<!-- Updated on: 2026-07-21 (terms last extended in the #164 PR: the constant-degree
+     transform — port copies, zero-weight cycle, constantDegreeTransform and its
+     sourceCopy/collapse/copiesOf/originalOf surface) -->
 
 > **Lifecycle: dynamic — updated in Phase C of every PR.** When a PR introduces new symbols
 > or terms (module names, data-structure fields, paper notation newly used in code), add
@@ -57,6 +58,13 @@ Quick lookup for the symbols and terms used across the paper, the notes, and the
   (`B' < B`, returns only vertices below `B'`).
 - **Constant-degree transform** — reduces any graph to in/out-degree ≤ 2 by splitting each
   vertex into a zero-weight cycle. Needed for the paper's bounds; optional in practice.
+  Implemented in `src/constantDegree.mjs` (#164) — see "`constantDegreeTransform`" below.
+- **Port copy** (#164) — one copy of a vertex created per incident edge endpoint by the
+  constant-degree transform. Each port copy hosts exactly one original edge endpoint, so
+  threading the copies onto a zero-weight cycle caps in/out-degree at 2.
+- **Zero-weight cycle** (#164) — the directed cycle of a vertex's port copies added by the
+  transform; costs nothing to traverse, so all copies of a vertex share one distance, making
+  the transform distance-preserving.
 - **BaseCase / FindPivots / BMSSP** — Algorithm 2 / Algorithm 1 / Algorithm 3. See §02.
 - **BlockList (`D`)** — Lemma 3.3 semi-sorted structure. See §03-B.
 - **Oracle** — the reference `dijkstra()` in `src/dijkstra.mjs`; ground truth for tests.
@@ -70,6 +78,16 @@ Quick lookup for the symbols and terms used across the paper, the notes, and the
   `[from, to, weight]` arrays. Both node IDs and the weight must be finite numbers, and the
   weight must be non-negative; failures identify the offending edge index. `[]` remains a
   valid empty graph, whose `calculateShortestPaths()` call rejects every start node.
+- **`constantDegreeTransform(graph)`** (#164) — `src/constantDegree.mjs`, the opt-in
+  constant-degree transform. Validates `graph` exactly like the BMSSP constructor, then
+  returns `{ edges, copiesOf, originalOf, sourceCopy, collapse }`: `edges` is the rewritten
+  in/out-degree-≤-2 graph (fresh integer copy IDs from 0, ~2m copies / ~3m edges, O(m));
+  `copiesOf` maps an original ID to its port copies and `originalOf` is the inverse;
+  `sourceCopy(orig)` returns a canonical start copy (any works — the zero-weight cycle
+  equalizes them); `collapse(distances)` folds a transformed distance map back onto original
+  IDs (min over a vertex's copies). **Public** — re-exported from `index.mjs` (unlike the
+  algorithm-internal modules). Correctness-independent: BMSSP never calls it. Usage:
+  `const t = constantDegreeTransform(g); …run from t.sourceCopy(s)…; t.collapse(dist)`.
 - **`adjacency`** (#45) — `Map<nodeId, Array<[to, weight]>>` field on the `BMSSP` class:
   a node's outgoing edges, so lookups are O(1) instead of scanning the whole edge array.
   Every known node has an entry (empty array for sinks). Built in the constructor.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ with every building block shipped, tested, and released individually:
 | Deterministic tie-breaking — Assumption 2.1 realized ([#163](https://github.com/Sirivasv/bmssp-js/issues/163)) | `src/tieBreak.mjs` | ✅ done |
 | Shortest-path reconstruction ([#169](https://github.com/Sirivasv/bmssp-js/issues/169)) | `BMSSP.reconstructPath()` | ✅ done |
 | Constructor input validation ([#165](https://github.com/Sirivasv/bmssp-js/issues/165)) | `BMSSP` constructor | ✅ done |
+| Opt-in constant-degree transform, in/out-degree ≤ 2 ([#164](https://github.com/Sirivasv/bmssp-js/issues/164)) | `constantDegreeTransform()` | ✅ done |
 
 > **Honest note:** the paper's win is asymptotic, and this repo optimizes for correctness
 > and readability, not raw speed. Measured head-to-head (algorithm time only, graph
@@ -96,6 +97,32 @@ when the target is unreachable (or before any run) and throws for a node outside
 A reference `dijkstra` implementation is also exported. See the `examples/` directory for
 more.
 
+### Optional: constant-degree transform
+
+The paper's bound assumes every vertex has in-degree and out-degree ≤ 2. That preprocessing
+is **not** required for correctness here — BMSSP is validated on arbitrary graphs — but it is
+available opt-in via `constantDegreeTransform`, which rewrites any graph into that shape by
+splitting each vertex into a zero-weight cycle of "port" copies. The rewrite is
+distance-preserving, so you run on the transformed graph and fold the result back onto your
+original node IDs:
+
+```javascript
+import { BMSSP, constantDegreeTransform } from "bmssp";
+
+const t = constantDegreeTransform([
+  [0, 1, 50],
+  [0, 2, 25],
+  [1, 2, 75],
+]);
+
+const g = new BMSSP(t.edges); // every node now has in/out-degree ≤ 2
+g.calculateShortestPaths(t.sourceCopy(0)); // start from a copy of original node 0
+console.log(t.collapse(g.shortestPaths)); // Map(3) { 0 => 0, 1 => 50, 2 => 25 }
+```
+
+`collapse` maps the transformed graph's distances back to the original node IDs; `sourceCopy`
+picks a valid start copy for an original node.
+
 ### Using the Docker image
 
 Run the bundled example:
@@ -141,7 +168,7 @@ graphs in a few seconds), and set `FUZZ_XL=1` for an additional 2-million-node r
 | Milestone | Theme | Status |
 | --- | --- | --- |
 | [`1.0.0`](https://github.com/Sirivasv/bmssp-js/milestones) | First end-to-end functional BMSSP (issues #40–#45) | ✅ done |
-| `1.1.0` | Correctness hardening — fuzz tests, edge cases, tie-breaking, input validation | 🔨 current focus |
+| `1.1.0` | Correctness hardening — fuzz tests, edge cases, tie-breaking, input validation, constant-degree transform | 🔨 current focus |
 | `1.2.0` | Performance & ergonomics — exact Lemma 3.3 asymptotics, path reconstruction, BMSSP-vs-Dijkstra benchmarks | 🔨 in progress |
 | `2.0.0` | API generalization — public multi-source/bounded entry point, flexible inputs | planned |
 

--- a/index.mjs
+++ b/index.mjs
@@ -1,2 +1,3 @@
 export { BMSSP } from "./src/bmssp.mjs";
 export { dijkstra } from "./src/dijkstra.mjs";
+export { constantDegreeTransform } from "./src/constantDegree.mjs";

--- a/src/constantDegree.mjs
+++ b/src/constantDegree.mjs
@@ -1,0 +1,136 @@
+// Constant-degree transform — the paper's Preliminaries (knowledge/01 §
+// "Preliminaries / model assumptions"; term in knowledge/07). The
+// O(m·log^(2/3) n) bound is argued on a graph whose vertices all have
+// in-degree AND out-degree <= 2. This module rewrites any graph into that
+// shape while preserving every distance.
+//
+// OPT-IN, by design. Nothing in the core algorithm calls this: BMSSP is
+// correct on the untransformed graph (validated node-by-node against the
+// Dijkstra oracle). The transform only realizes the paper's structural
+// precondition for callers who want it — it changes constants, never
+// correctness (issue #164, milestone 1.1.0).
+
+// How it works: split each vertex into one "port" copy per incident edge
+// endpoint and thread those copies onto a zero-weight directed cycle. A cycle
+// gives every copy exactly one incoming and one outgoing cycle edge; a copy
+// that additionally hosts a single original endpoint therefore reaches
+// degree 2 on that one side and stays at 1 on the other — never more. Because
+// the cycle costs nothing to traverse, all copies of a vertex are mutually
+// reachable at zero added distance, so each copy's shortest distance equals
+// the original vertex's: the rewrite is distance-preserving.
+
+/**
+ * Rewrite a directed graph so every vertex has in-degree and out-degree <= 2,
+ * preserving all shortest-path distances.
+ *
+ * @param {Array<[number, number, number]>} graph - [from, to, weight] edges,
+ *   the same input contract as the BMSSP constructor: an array of exact
+ *   three-element arrays with finite numeric node IDs and finite, non-negative
+ *   weights. An empty array is valid.
+ * @returns {{
+ *   edges: Array<[number, number, number]>,
+ *   copiesOf: Map<number, number[]>,
+ *   originalOf: Map<number, number>,
+ *   sourceCopy: (original: number) => number,
+ *   collapse: (transformedDistances: Map<number, number>) => Map<number, number>
+ * }}
+ *   - `edges`: the transformed graph (fresh integer copy IDs from 0).
+ *   - `copiesOf`: original node ID -> its copy IDs, in allocation order.
+ *   - `originalOf`: copy ID -> the original node ID it belongs to.
+ *   - `sourceCopy(original)`: a canonical copy to start a run from (any copy
+ *     works — the zero-weight cycle equalizes them); throws for an unknown
+ *     node.
+ *   - `collapse(distances)`: fold a transformed-graph distance map back onto
+ *     the original node IDs (the min over each vertex's copies; all copies
+ *     share the same value, so the min is exact).
+ */
+function constantDegreeTransform(graph) {
+  if (!Array.isArray(graph)) {
+    throw new Error("Input graph must be an array of edges");
+  }
+
+  let nextCopyId = 0;
+  // original node ID -> its copy IDs, in allocation order
+  const copiesOf = new Map();
+  // copy ID -> the original node ID it belongs to
+  const originalOf = new Map();
+  // per original edge, the out-port copy of `from` and the in-port copy of `to`
+  const outCopyForEdge = new Array(graph.length);
+  const inCopyForEdge = new Array(graph.length);
+
+  const allocateCopy = (originalId) => {
+    const id = nextCopyId;
+    nextCopyId += 1;
+    originalOf.set(id, originalId);
+    let copies = copiesOf.get(originalId);
+    if (copies === undefined) {
+      copies = [];
+      copiesOf.set(originalId, copies);
+    }
+    copies.push(id);
+    return id;
+  };
+
+  // One copy per edge endpoint, allocated in edge order so the whole transform
+  // is deterministic: the out-port at `from`, the in-port at `to`. Validate
+  // exactly like the BMSSP constructor so the transform can front any graph.
+  graph.forEach((edge, index) => {
+    if (!Array.isArray(edge) || edge.length !== 3) {
+      throw new Error(`Edge at index ${index} must be [from, to, weight]`);
+    }
+    const [from, to, weight] = edge;
+    if (!Number.isFinite(from) || !Number.isFinite(to)) {
+      throw new Error(`Edge at index ${index} must have numeric node IDs`);
+    }
+    if (!Number.isFinite(weight) || weight < 0) {
+      throw new Error(
+        `Edge at index ${index} must have a non-negative numeric weight`,
+      );
+    }
+    outCopyForEdge[index] = allocateCopy(from);
+    inCopyForEdge[index] = allocateCopy(to);
+  });
+
+  const edges = [];
+
+  // Zero-weight directed cycle through each vertex's copies. A vertex with a
+  // single incident endpoint has one copy and needs no cycle.
+  for (const copies of copiesOf.values()) {
+    if (copies.length < 2) continue;
+    for (let i = 0; i < copies.length; i += 1) {
+      const next = copies[(i + 1) % copies.length];
+      edges.push([copies[i], next, 0]);
+    }
+  }
+
+  // Each original edge connects its own out-copy to its own in-copy, weight
+  // unchanged.
+  graph.forEach(([, , weight], index) => {
+    edges.push([outCopyForEdge[index], inCopyForEdge[index], weight]);
+  });
+
+  const sourceCopy = (original) => {
+    const copies = copiesOf.get(original);
+    if (copies === undefined) {
+      throw new Error(`Node ${original} is not in the graph`);
+    }
+    return copies[0];
+  };
+
+  const collapse = (transformedDistances) => {
+    const result = new Map();
+    for (const [original, copies] of copiesOf) {
+      let best = Infinity;
+      for (const copy of copies) {
+        const d = transformedDistances.get(copy);
+        if (d !== undefined && d < best) best = d;
+      }
+      result.set(original, best);
+    }
+    return result;
+  };
+
+  return { edges, copiesOf, originalOf, sourceCopy, collapse };
+}
+
+export { constantDegreeTransform };

--- a/test/constantDegree.test.mjs
+++ b/test/constantDegree.test.mjs
@@ -1,0 +1,232 @@
+import { describe, test, expect } from "@jest/globals";
+import { BMSSP, dijkstra, constantDegreeTransform } from "../index.mjs";
+import {
+  sparseRandom,
+  denseRandom,
+  grid,
+  chain,
+  star,
+} from "../benchmarks/generators.mjs";
+
+// Constant-degree transform (#164): rewrite any graph to in/out-degree <= 2 by
+// splitting each vertex into a zero-weight cycle of port copies, preserving
+// every distance. The transform is opt-in — correctness of BMSSP does NOT
+// depend on it — so these tests prove two things: the degree bound holds, and
+// distances survive the rewrite, checked against the Dijkstra oracle on the
+// original graph (the contract the issue asks for).
+
+// In- and out-degree of every node in an edge array.
+function degrees(edges) {
+  const out = new Map();
+  const inc = new Map();
+  const bump = (map, id) => map.set(id, (map.get(id) ?? 0) + 1);
+  const seen = (id) => {
+    if (!out.has(id)) out.set(id, 0);
+    if (!inc.has(id)) inc.set(id, 0);
+  };
+  for (const [from, to] of edges) {
+    seen(from);
+    seen(to);
+    bump(out, from);
+    bump(inc, to);
+  }
+  return { out, inc };
+}
+
+function expectDegreeBounded(edges) {
+  const { out, inc } = degrees(edges);
+  for (const d of out.values()) expect(d).toBeLessThanOrEqual(2);
+  for (const d of inc.values()) expect(d).toBeLessThanOrEqual(2);
+}
+
+// Distances on the transformed graph, folded back onto original node IDs,
+// must equal distances on the original graph — via the Dijkstra oracle.
+// runner(edges, nodeIDs, source) returns a Map<nodeId, distance>.
+function expectDistancePreserving(graph, runner) {
+  const original = new BMSSP(graph);
+  const t = constantDegreeTransform(graph);
+  const transformed = new BMSSP(t.edges);
+
+  for (const source of original.nodeIDs) {
+    const expected = dijkstra(graph, original.nodeIDs, source);
+    const rawTransformed = runner(
+      t.edges,
+      transformed.nodeIDs,
+      t.sourceCopy(source),
+    );
+    const collapsed = t.collapse(rawTransformed);
+
+    expect(collapsed.size).toBe(expected.size);
+    for (const [node, distance] of expected) {
+      expect(collapsed.get(node)).toBe(distance);
+    }
+  }
+}
+
+describe("constantDegreeTransform: degree bound", () => {
+  test("brings a high-degree hub down to in/out-degree <= 2", () => {
+    // Node 0 starts with out-degree 3 and in-degree 1.
+    const { edges } = constantDegreeTransform([
+      [0, 1, 5],
+      [0, 2, 6],
+      [0, 3, 7],
+      [4, 0, 8],
+    ]);
+    expectDegreeBounded(edges);
+  });
+
+  test("caps degree on every seeded benchmark shape, including the star hub", () => {
+    for (const graph of [
+      sparseRandom(400, 3, 71),
+      denseRandom(120, 16, 72),
+      grid(12, 73),
+      chain(300, 74),
+      star(300, 75), // hub node 0 has degree ~2*(n-1) before the transform
+    ]) {
+      const { edges } = constantDegreeTransform(graph);
+      expectDegreeBounded(edges);
+    }
+  });
+
+  test("gives each vertex exactly one copy per incident edge endpoint", () => {
+    // Node 0: two out-endpoints + one in-endpoint = 3 copies.
+    const { copiesOf, originalOf } = constantDegreeTransform([
+      [0, 1, 1],
+      [0, 2, 1],
+      [3, 0, 1],
+    ]);
+    expect(copiesOf.get(0).length).toBe(3);
+    expect(copiesOf.get(1).length).toBe(1);
+    expect(copiesOf.get(2).length).toBe(1);
+    expect(copiesOf.get(3).length).toBe(1);
+    // originalOf is the exact inverse of copiesOf.
+    for (const [original, copies] of copiesOf) {
+      for (const copy of copies) expect(originalOf.get(copy)).toBe(original);
+    }
+  });
+
+  test("cycle edges are zero-weight; a single-copy vertex needs no cycle", () => {
+    const { edges, copiesOf } = constantDegreeTransform([
+      [0, 1, 4],
+      [0, 2, 9],
+    ]);
+    // Node 0 has two copies -> a 2-cycle of zero-weight edges; nodes 1 and 2
+    // are single copies with no cycle. So exactly two zero-weight edges.
+    const zeroWeightEdges = edges.filter(([, , w]) => w === 0);
+    expect(zeroWeightEdges.length).toBe(2);
+    const [a, b] = copiesOf.get(0);
+    expect(zeroWeightEdges).toEqual(
+      expect.arrayContaining([
+        [a, b, 0],
+        [b, a, 0],
+      ]),
+    );
+    expect(copiesOf.get(1).length).toBe(1);
+  });
+});
+
+describe("constantDegreeTransform: distance preservation (Dijkstra oracle)", () => {
+  test("a hand graph with a competing multi-hop path", () => {
+    const graph = [
+      [0, 1, 50],
+      [1, 2, 75],
+      [0, 2, 25],
+    ];
+    const t = constantDegreeTransform(graph);
+    const transformed = new BMSSP(t.edges);
+    const raw = dijkstra(t.edges, transformed.nodeIDs, t.sourceCopy(0));
+    const collapsed = t.collapse(raw);
+    expect(collapsed.get(0)).toBe(0);
+    expect(collapsed.get(1)).toBe(50);
+    expect(collapsed.get(2)).toBe(25);
+  });
+
+  test("preserves distances across every seeded benchmark shape", () => {
+    for (const graph of [
+      sparseRandom(300, 3, 81),
+      denseRandom(90, 12, 82),
+      grid(10, 83),
+      chain(200, 84),
+      star(200, 85),
+    ]) {
+      expectDistancePreserving(graph, dijkstra);
+    }
+  });
+
+  test("handles self-loops and zero-weight original edges", () => {
+    expectDistancePreserving(
+      [
+        [0, 0, 3], // self-loop
+        [0, 1, 0], // zero-weight edge
+        [1, 2, 5],
+        [2, 1, 0],
+      ],
+      dijkstra,
+    );
+  });
+});
+
+describe("constantDegreeTransform: BMSSP runs on the transformed graph", () => {
+  test("BMSSP on the transform matches the oracle on the original", () => {
+    // Ties the transform to the real algorithm, not just the oracle.
+    const runBMSSP = (edges, _nodeIDs, source) => {
+      const bmssp = new BMSSP(edges);
+      bmssp.calculateShortestPaths(source);
+      return bmssp.shortestPaths;
+    };
+    for (const graph of [
+      sparseRandom(250, 3, 91),
+      grid(9, 92),
+      star(150, 93),
+    ]) {
+      expectDistancePreserving(graph, runBMSSP);
+    }
+  });
+});
+
+describe("constantDegreeTransform: determinism and edge cases", () => {
+  test("collapsed distances are invariant under edge-list permutation", () => {
+    const graph = sparseRandom(200, 3, 101);
+    const shuffled = [...graph].reverse();
+
+    const base = new BMSSP(graph);
+    const source = [...base.nodeIDs][0];
+
+    const collapse = (g) => {
+      const t = constantDegreeTransform(g);
+      const transformed = new BMSSP(t.edges);
+      const raw = dijkstra(t.edges, transformed.nodeIDs, t.sourceCopy(source));
+      return t.collapse(raw);
+    };
+
+    const a = collapse(graph);
+    const b = collapse(shuffled);
+    expect(a.size).toBe(b.size);
+    for (const [node, distance] of a) {
+      expect(b.get(node)).toBe(distance);
+    }
+  });
+
+  test("an empty graph transforms to an empty graph", () => {
+    const t = constantDegreeTransform([]);
+    expect(t.edges).toEqual([]);
+    expect(t.copiesOf.size).toBe(0);
+    expect(t.collapse(new Map()).size).toBe(0);
+    expect(() => t.sourceCopy(0)).toThrow("Node 0 is not in the graph");
+  });
+
+  test("rejects malformed input like the BMSSP constructor", () => {
+    expect(() => constantDegreeTransform("nope")).toThrow(
+      "Input graph must be an array of edges",
+    );
+    expect(() => constantDegreeTransform([[0, 1]])).toThrow(
+      "Edge at index 0 must be [from, to, weight]",
+    );
+    expect(() => constantDegreeTransform([["0", 1, 5]])).toThrow(
+      "Edge at index 0 must have numeric node IDs",
+    );
+    expect(() => constantDegreeTransform([[0, 1, -1]])).toThrow(
+      "Edge at index 0 must have a non-negative numeric weight",
+    );
+  });
+});


### PR DESCRIPTION
Closes #164.

## Summary

Adds `src/constantDegree.mjs` — the paper's Preliminaries transform that rewrites any directed graph so every vertex has **in-degree and out-degree ≤ 2**, the structural precondition the O(m·log^(2/3) n) bound assumes. Each vertex is split into a **zero-weight directed cycle** of one **port copy per incident edge endpoint**; a copy that also hosts one original endpoint reaches degree 2 on that side and stays at 1 on the other, never more. Because the cycle costs nothing to traverse, all copies of a vertex share one distance — the rewrite is **distance-preserving**.

**Opt-in and correctness-independent.** Nothing in the core algorithm calls it; BMSSP stays correct on the untransformed graph (still validated node-by-node against the Dijkstra oracle). The function is **re-exported from `index.mjs`** as a public utility. A caller opts in by transforming the graph, running from `sourceCopy(source)`, and `collapse()`-ing the result back onto original node IDs:

```js
const t = constantDegreeTransform(graph);
const g = new BMSSP(t.edges);
g.calculateShortestPaths(t.sourceCopy(source));
const distances = t.collapse(g.shortestPaths); // keyed by original node IDs
```

Returns `{ edges, copiesOf, originalOf, sourceCopy, collapse }`. O(m): ~2m copies, ~3m edges. Output is edge-order deterministic.

## Tests / lint

`test/constantDegree.test.mjs` — 11 tests:
- Degree ≤ 2 on a hand-built hub and **all five seeded benchmark shapes**, including the **star hub** (degree ~2(n−1) before the transform).
- Per-endpoint copy counts, the `copiesOf`/`originalOf` inverse, zero-weight cycle edges, single-copy vertices needing no cycle.
- **Distance preservation from every source** via the Dijkstra oracle on the original graph — across the five shapes plus self-loop / zero-weight fixtures — and separately with **BMSSP itself** run on the transform.
- Edge-order determinism, empty-graph transform, and constructor-parity input validation.

Full suite: **146 passing + 1 XL skipped**, 100% statement coverage (`constantDegree.mjs` 100%), `npm run lint` clean. The README opt-in snippet is verified to run.

## Version

**No bump** — mid-milestone enhancement. #164 is one of two open 1.1.0 issues; **#166 remains, so the milestone stays open** (its closing PR will be the minor → `1.1.0` release). Per the semver convention in `06` → "Release mechanics".

## Docs / KB sync (Phase C)

- `05` — new module + test section, gaps table, bookmark flipped to `b36c059`.
- `06` — reconciled: **#165 merged (PR #191)** and **dependabot workflow bumps #192/#193/#194** folded in (they had landed on `main` without a post-merge marker flip); **#164 done-pending-merge**; #166 is now 1.1.0's last open issue.
- `07` — `constantDegreeTransform`, port copy, zero-weight cycle terms.
- `README.md` — status-table row + opt-in usage section.

## Roadmap proposals (Phase C — for Phase E, not executed here)

1. **Re-scope #166** (1.1.0's last open issue): `bmssp()`/`deriveParameters()` (#43), `reconstructPath()` (#169) and now all of `constantDegree.mjs` (#164) already ship JSDoc. Edit #166 to name the modules still lacking it — `heap`, `blockList`, `baseCase`, `findPivots`, `tieBreak` — plus one consolidated public-API doc. Its PR closes the milestone (minor → `1.1.0`).
2. **Note the new public export on #173** (2.0.0 "Stabilize the public API surface"): `index.mjs` now exports `constantDegreeTransform`; the API-stabilization work should cover its signature and return shape.

> Note: feature-branch commit is unsigned (SSH signing can't complete non-interactively in the agent session). The squash-merge via the GitHub UI applies the verified signature on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)