### PR TITLE
docs(#166): JSDoc for public exports + public-API docs page

### DIFF
--- a/.claude/knowledge/05-codebase-map.md
+++ b/.claude/knowledge/05-codebase-map.md
@@ -1,15 +1,14 @@
 # 05 — Codebase Map (current state)
 
-<!-- BOOKMARK-COMMIT: b36c05944cb011e3667da7802032599868dbfc81 -->
-<!-- PENDING-PR-BRANCH: feat/164-constant-degree-transform -->
-<!-- Last validated: 2026-07-21 (Phase C of the #164 PR). Describes the tree as it will
-     exist once that PR merges: adds the opt-in constant-degree transform
-     (src/constantDegree.mjs), re-exported from index.mjs. This same rewrite folds in the
-     Phase A reconciliation missed at the top of main: #165 (constructor input validation)
-     merged as PR #191 (commit 39f7494), and three dependabot workflow bumps (#192/#193/#194,
-     .github/workflows/** only) landed on top — the bookmark now sits at that HEAD (b36c059).
-     No version bump (mid-milestone enhancement; milestone 1.1.0 remains open with #166 —
-     semver convention, 06 "Release mechanics"). -->
+<!-- BOOKMARK-COMMIT: a1dac45cc2aa4f48e708fe2e0e05a964c0f858a5 -->
+<!-- PENDING-PR-BRANCH: docs/166-public-api-docs -->
+<!-- Last validated: 2026-07-21 (Phase C of the #166 PR). Describes the tree as it will
+     exist once that PR merges: JSDoc on index.mjs's three public re-exports and a full
+     rewrite of docs/index.html into a public-API reference (was a stale landing page
+     pointing at the wrong repo). No src/ or test/ changes. #166 is milestone 1.1.0's last
+     open issue → this PR closes the milestone → minor bump to 1.1.0 (semver convention,
+     06 "Release mechanics"). This rewrite also folds in the session's Phase A fast path:
+     the #164 PR merged as PR #195 (merge commit a1dac45 == the bookmark). -->
 
 Snapshot of what exists in `bmssp-js` today, so you know what to build on vs. what's missing.
 
@@ -57,7 +56,8 @@ feature branch name. Step 2 above then fast-paths the post-merge session start.
 ## Layout
 
 ```
-index.mjs                 # re-exports { BMSSP }, { dijkstra } and { constantDegreeTransform }
+index.mjs                 # re-exports { BMSSP }, { dijkstra } and { constantDegreeTransform },
+                          # each with public-API JSDoc (#166); internals stay unexported
 src/
   bmssp.mjs               # BMSSP class — full Algorithm 3 recursion (#43); wires the pieces below
   dijkstra.mjs            # reference Dijkstra (array binary-heap) — DONE, used as oracle
@@ -91,7 +91,9 @@ benchmarks/               # dependency-free benchmark harness, `npm run bench`
   HEAD-TO-HEAD.md         #   measured BMSSP-vs-Dijkstra (1.0.0): wall-clock + comparison counts
 examples/
   main.mjs                # tiny usage example (constructs BMSSP, prints .graph)
-docs/index.html           # published docs page
+docs/index.html           # public-API reference (GitHub Pages via static.yml) — rewritten in
+                          # #166 from a stale landing page (wrong repo link, stray </svg>);
+                          # documents the three exports only, internals explicitly excluded
 ```
 
 Tooling: Jest (`npm test`, needs `--experimental-vm-modules`, already in the `test` script),
@@ -428,8 +430,11 @@ comparison-count mode); the raw baseline is also on #170 as a comment.
 | Deterministic tie-breaking (Assumption 2.1) | `src/tieBreak.mjs` + all modules | #163 | ✅ done (PR #188, no bump) |
 | Public shortest-path reconstruction | `BMSSP.reconstructPath()` + `test/pathReconstruction.test.mjs` | #169 | ✅ done (PR #189, no bump) |
 | Constructor input validation | `BMSSP` constructor + `test/main.test.mjs` | #165 | ✅ merged (PR #191, no bump) |
-| Optional constant-degree transform (in/out-degree ≤ 2) | `src/constantDegree.mjs` + `test/constantDegree.test.mjs` | #164 | ✅ done-pending-merge (this PR, no bump) |
+| Optional constant-degree transform (in/out-degree ≤ 2) | `src/constantDegree.mjs` + `test/constantDegree.test.mjs` | #164 | ✅ merged (PR #195, no bump) |
+| JSDoc on `index.mjs` exports + public-API docs page | `index.mjs` + `docs/index.html` | #166 | ✅ done-pending-merge (this PR, **minor → 1.1.0**) |
 
-Milestone `1.1.0` (correctness hardening) remains in progress with **only #166 open**
-after this PR — its closing PR will bump **minor → 1.1.0**. Milestone `1.2.0` remains in
-progress with #169 merged; see [06-milestones-roadmap.md](06-milestones-roadmap.md).
+Milestone `1.1.0` (correctness hardening) **completes with this PR** — #166 was its last
+open issue, so this PR bumps **minor → 1.1.0** and its merge triggers the 1.1.0 release
+(Phase E) plus closing the milestone on GitHub (proposed). Milestone `1.2.0` becomes the
+current focus (#167, #168, #170, #182 open); see
+[06-milestones-roadmap.md](06-milestones-roadmap.md).

--- a/.claude/knowledge/06-milestones-roadmap.md
+++ b/.claude/knowledge/06-milestones-roadmap.md
@@ -1,10 +1,11 @@
 # 06 — Milestones Roadmap
 
-<!-- SYNCED-FROM-GITHUB: 2026-07-21 (#165 closed by merged PR #191 + dependabot workflow
-     bumps #192/#193/#194 landed on main; milestones 1.1.0/1.2.0/2.0.0 open with 2/4/3 open
-     issues; #164 done-pending-merge in this PR → leaves #166 as 1.1.0's last open issue) -->
-<!-- Current package version: 1.0.1 (released 2026-07-16; the #164 PR ships no bump under
-     the semver convention — mid-milestone enhancement, milestone still open) -->
+<!-- SYNCED-FROM-GITHUB: 2026-07-21 Phase C of the #166 PR (#164 closed by merged PR #195;
+     milestones 1.1.0/1.2.0/2.0.0 open with 1/4/3 open issues on GitHub; #166 —
+     1.1.0's last open issue — is done-pending-merge in this PR) -->
+<!-- Current package version: 1.1.0 (bumped in the #166 PR — milestone-closing minor;
+     release fires in Phase E after the user confirms the merge. Last released: 1.0.1,
+     2026-07-16) -->
 
 Maps GitHub **milestones** and **issues** (Sirivasv/bmssp-js) to the paper's building blocks,
 with a dependency-aware build order. This is the "intent" side of the knowledge base (what to
@@ -40,22 +41,19 @@ it runs the same Phase C reconciliation directly on `main`.
 
 ## 📋 Roadmap proposals (pending user approval)
 
-From the #164 PR (Phase C, 2026-07-21):
+From the #166 PR (Phase C, 2026-07-21):
 
-1. **Re-scope #166** (JSDoc / API docs — 1.1.0's last open issue). Since it was filed, three
-   PRs have already shipped thorough JSDoc: `bmssp()` / `deriveParameters()` (#43),
-   `reconstructPath()` (#169), and now the whole `src/constantDegree.mjs` (#164, this PR).
-   Propose editing #166's description to name the modules still lacking JSDoc — `heap.mjs`,
-   `blockList.mjs`, `baseCase.mjs`, `findPivots.mjs`, `tieBreak.mjs` — plus a single
-   consolidated public-API doc, so the issue reflects the actual remaining work. **#166 is
-   now the last open 1.1.0 issue, so its PR closes the milestone → minor bump to `1.1.0`.**
-2. **Note the new public export on #173** (2.0.0 "Stabilize the public API surface"). The
-   public surface grew in #164: `index.mjs` now exports `constantDegreeTransform` alongside
-   `BMSSP` and `dijkstra`. Propose adding a line to #173 so the 1.0→2.0 API-stabilization
-   work explicitly covers the transform's signature and return shape.
+1. **Close milestone `1.1.0` (milestone #2) on GitHub** once this PR merges — #166 was its
+   last open issue and milestones don't auto-close. (`gh api -X PATCH
+   repos/Sirivasv/bmssp-js/milestones/2 -f state=closed`.)
 
 _Phase C writes proposed GitHub edits here (and in the PR body); Phase E executes the
 approved ones — one confirmation each — and clears them from this list._
+_(The #164-PR proposals — re-scope **#166** and the new-export note on **#173** — were
+approved 2026-07-21 and found **already executed on GitHub**: #166's live body already
+scopes the remaining work to `index.mjs` JSDoc + the `docs/` page (all `src/` modules
+verified to carry JSDoc), and #173's body already carries the 2026-07-21
+`constantDegreeTransform` update. No writes were needed.)_
 _(The #165-PR proposals — none — needed no execution.)_
 _(The #188-PR proposals — re-scope **#169** and add the measured optimization note to
 **#168** — were executed 2026-07-17.)_
@@ -89,6 +87,14 @@ executed 2026-07-17.)_
   preserving, correctness-independent, verified degree-bounded and oracle-equal from every
   source across the five seeded shapes (incl. the star hub). No bump. **Only #166 (JSDoc)
   now remains — its PR closes the milestone (minor → `1.1.0`).**
+- **Phase A reconciliation (2026-07-21, this session):** PR #195 (the #164 branch) merged
+  as `main` HEAD `a1dac45`; `05`'s bookmark fast-path flipped. No pending release found
+  (`package.json` 1.0.1 == latest tag).
+- **#166 done-pending-merge (this PR, 2026-07-21):** JSDoc on `index.mjs`'s three public
+  re-exports and a full rewrite of `docs/index.html` into a public-API reference (the old
+  page was a generic landing page linking to the wrong repo). No `src/`/`test/` changes.
+  **Last open 1.1.0 issue → minor bump to `1.1.0` in this PR**; on merge: release 1.1.0
+  (Phase E) and close the milestone (Roadmap proposal 1).
 - **Phase A reconciliation (2026-07-21):** the #165 PR (#191) and three dependabot workflow
   bumps (#192/#193/#194, `.github/workflows/**` only) had landed on `main` without a
   post-merge session-start marker flip. The #164 PR folds that in: `05`'s bookmark now sits
@@ -128,9 +134,9 @@ executed 2026-07-17.)_
 - Each sub-piece (#40/#41/#42/#44/#45) shipped with focused unit tests. ✅
 - `npm run lint` clean; ESM + Prettier style preserved. ✅
 
-## Milestone `1.1.0` (milestone #2) — correctness hardening — NEXT
+## Milestone `1.1.0` (milestone #2) — correctness hardening — ✅ COMPLETE PENDING #166 MERGE
 
-Recommended order (cheapest protection first, then the deep work):
+All six issues done (build order as executed — cheapest protection first, then the deep work):
 
 | Order | # | Issue | Labels | Notes |
 |---|---|---|---|---|
@@ -138,10 +144,14 @@ Recommended order (cheapest protection first, then the deep work):
 | 2 | 162 | Edge-case tests: disconnected graphs and unreachable nodes | enhancement · help wanted | ✅ merged (PR #187, no bump) |
 | 3 | 163 | Deterministic tie-breaking for equal-length paths (Assumption 2.1) | enhancement · help wanted | ✅ merged (PR #188, no bump): composite keys in `src/tieBreak.mjs`, all six tie manifestations resolved by construction |
 | 4 | 165 | Input validation for the BMSSP constructor | good first issue · help wanted | ✅ merged (PR #191, no bump): validates graph shape, node IDs, and weights; preserves empty graphs |
-| 5 | 164 | Optional constant-degree transform (in/out-degree ≤ 2) | enhancement · help wanted | ✅ done-pending-merge (this PR, no bump): `src/constantDegree.mjs`, opt-in + distance-preserving, re-exported |
-| 6 | 166 | JSDoc / API docs for the new modules | documentation · good first issue | **1.1.0's last open issue → its PR closes the milestone (minor).** `bmssp()`/`deriveParameters()`/`reconstructPath()`/`constantDegree.mjs` already ship JSDoc; see Roadmap proposal 1 to re-scope to `heap`/`blockList`/`baseCase`/`findPivots`/`tieBreak` + a consolidated API doc |
+| 5 | 164 | Optional constant-degree transform (in/out-degree ≤ 2) | enhancement · help wanted | ✅ merged (PR #195, no bump): `src/constantDegree.mjs`, opt-in + distance-preserving, re-exported |
+| 6 | 166 | JSDoc / API docs for the new modules | documentation · good first issue | ✅ done-pending-merge (this PR, **minor → `1.1.0`**): JSDoc on `index.mjs`'s re-exports + `docs/index.html` rewritten as the public-API reference (`BMSSP`, `dijkstra`, `constantDegreeTransform`; internals stay out). **Closes milestone 1.1.0** |
 
-## Milestone `1.2.0` (milestone #3) — performance & ergonomics
+## Milestone `1.2.0` (milestone #3) — performance & ergonomics — NEXT
+
+Suggested build order: **#170 first** (harness integration turns the one-off HEAD-TO-HEAD
+measurement into a repeatable tool), then **#182** (use that tool to investigate the two
+measured cliffs), then **#167 / #168** (the optimizations the investigation informs).
 
 | # | Issue | Labels | Notes |
 |---|---|---|---|

--- a/.claude/knowledge/07-glossary.md
+++ b/.claude/knowledge/07-glossary.md
@@ -1,8 +1,9 @@
 # 07 — Glossary
 
-<!-- Updated on: 2026-07-21 (terms last extended in the #164 PR: the constant-degree
-     transform — port copies, zero-weight cycle, constantDegreeTransform and its
-     sourceCopy/collapse/copiesOf/originalOf surface) -->
+<!-- Updated on: 2026-07-21 (#166 PR: no new symbols — the PR adds JSDoc to index.mjs and
+     rewrites docs/index.html; added the "Docs page" repo term. Terms last extended in the
+     #164 PR: the constant-degree transform — port copies, zero-weight cycle,
+     constantDegreeTransform and its sourceCopy/collapse/copiesOf/originalOf surface) -->
 
 > **Lifecycle: dynamic — updated in Phase C of every PR.** When a PR introduces new symbols
 > or terms (module names, data-structure fields, paper notation newly used in code), add
@@ -231,3 +232,8 @@ Quick lookup for the symbols and terms used across the paper, the notes, and the
 - **Performance cliffs (#182)** — two measured regimes where the head-to-head ratio breaks
   from its ~1.6–2× pattern: star graphs (superlinear blowup, 67.8× at n = 500k) and the
   `topLevel = ⌈log₂n / t⌉` 3→4 transition (5× at n = 4M on sparse). Milestone 1.2.0.
+- **Docs page (#166)** — `docs/index.html`, the GitHub-Pages-published public-API reference
+  (deployed by `static.yml` on `docs/**` changes). Documents exactly the three `index.mjs`
+  exports — `BMSSP` (constructor contract, `calculateShortestPaths`, `reconstructPath`),
+  `dijkstra`, `constantDegreeTransform` — and explicitly keeps algorithm internals out.
+  Static, dependency-free HTML.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ console.log(graph.reconstructPath(1)); // [0, 1]
 when the target is unreachable (or before any run) and throws for a node outside the graph.
 
 A reference `dijkstra` implementation is also exported. See the `examples/` directory for
-more.
+more, or the [public API reference](https://sirivasv.github.io/bmssp-js/) for the complete
+documented surface.
 
 ### Optional: constant-degree transform
 
@@ -168,8 +169,8 @@ graphs in a few seconds), and set `FUZZ_XL=1` for an additional 2-million-node r
 | Milestone | Theme | Status |
 | --- | --- | --- |
 | [`1.0.0`](https://github.com/Sirivasv/bmssp-js/milestones) | First end-to-end functional BMSSP (issues #40–#45) | ✅ done |
-| `1.1.0` | Correctness hardening — fuzz tests, edge cases, tie-breaking, input validation, constant-degree transform | 🔨 current focus |
-| `1.2.0` | Performance & ergonomics — exact Lemma 3.3 asymptotics, path reconstruction, BMSSP-vs-Dijkstra benchmarks | 🔨 in progress |
+| `1.1.0` | Correctness hardening — fuzz tests, edge cases, tie-breaking, input validation, constant-degree transform, API docs | ✅ done |
+| `1.2.0` | Performance & ergonomics — exact Lemma 3.3 asymptotics, BMSSP-vs-Dijkstra benchmarks, performance-cliff investigation | 🔨 current focus |
 | `2.0.0` | API generalization — public multi-source/bounded entry point, flexible inputs | planned |
 
 ## Contributing (humans and AI agents welcome)

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,8 +2,9 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Tsinghua SSSP - BMSSP - Landing Page</title>
+    <title>bmssp — BMSSP shortest paths for JavaScript</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="JavaScript implementation of BMSSP, the O(m log^(2/3) n) single-source shortest-paths algorithm — public API documentation.">
     <style>
         body {
             margin: 0;
@@ -14,35 +15,63 @@
             display: flex;
             flex-direction: column;
             align-items: center;
-            justify-content: center;
         }
         .container {
             background: #fff;
             border-radius: 18px;
             box-shadow: 0 4px 24px rgba(0,0,0,0.08);
             padding: 2.5rem 2rem;
-            max-width: 420px;
-            text-align: center;
+            margin: 2rem 1rem;
+            max-width: 760px;
+            width: calc(100% - 2rem);
+            box-sizing: border-box;
         }
+        header { text-align: center; }
         h1 {
             font-size: 2.2rem;
             margin-bottom: 0.5rem;
             color: #3a0ca3;
         }
-        p {
-            font-size: 1.1rem;
-            margin-bottom: 1.5rem;
+        h2 {
+            font-size: 1.4rem;
+            color: #3a0ca3;
+            border-bottom: 2px solid #e0e7ff;
+            padding-bottom: 0.3rem;
+            margin-top: 2.2rem;
+        }
+        h3 {
+            font-size: 1.05rem;
+            color: #22223b;
+            margin-bottom: 0.3rem;
+        }
+        p, li {
+            font-size: 1rem;
+            line-height: 1.55;
             color: #4a4e69;
         }
+        .tagline { font-size: 1.1rem; }
+        a { color: #4361ee; }
+        code {
+            font-family: 'Cascadia Code', Consolas, Menlo, monospace;
+            font-size: 0.92em;
+            background: #eef1ff;
+            border-radius: 4px;
+            padding: 0.08em 0.35em;
+        }
+        pre {
+            background: #22223b;
+            color: #f0fdfa;
+            border-radius: 10px;
+            padding: 1rem 1.2rem;
+            overflow-x: auto;
+        }
+        pre code { background: none; color: inherit; padding: 0; }
         .graphics {
-            margin: 1.5rem 0;
+            margin: 1.2rem 0 0.4rem;
             display: flex;
             justify-content: center;
         }
-        .node-graph {
-            width: 120px;
-            height: 120px;
-        }
+        .node-graph { width: 110px; height: 110px; }
         .btn {
             display: inline-block;
             padding: 0.7em 1.5em;
@@ -54,43 +83,164 @@
             text-decoration: none;
             transition: background 0.2s;
             cursor: pointer;
+            margin: 0.3rem 0.35rem;
         }
-        .btn:hover {
-            background: #3a0ca3;
+        .btn:hover { background: #3a0ca3; }
+        .btn.secondary { background: #4cc9f0; color: #22223b; }
+        .btn.secondary:hover { background: #3ab8de; }
+        .note {
+            background: #f0fdfa;
+            border-left: 4px solid #4cc9f0;
+            border-radius: 0 8px 8px 0;
+            padding: 0.7rem 1rem;
+            margin: 1rem 0;
         }
         footer {
-            margin-top: 2rem;
+            margin: 0 0 2rem;
             font-size: 0.95rem;
-            color: #adb5bd;
+            color: #6c757d;
+            text-align: center;
         }
+        footer a { color: #6c757d; }
     </style>
 </head>
 <body>
     <div class="container">
-        <h1>Tsinghua SSSP - BMSSP JS</h1>
+        <header>
+            <h1>bmssp</h1>
+            <p class="tagline">
+                A JavaScript (ESM) implementation of <strong>BMSSP</strong> —
+                <strong>B</strong>ounded <strong>M</strong>ulti-<strong>S</strong>ource
+                <strong>S</strong>hortest <strong>P</strong>aths — the deterministic
+                O(m·log<sup>2/3</sup> n) single-source shortest-paths algorithm from
+                <a href="https://dl.acm.org/doi/10.1145/3717823.3718179" target="_blank" rel="noopener">
+                    “Breaking the Sorting Barrier for Directed Single-Source Shortest Paths”</a>
+                (Duan, Mao, Mao, Shu, Yin — 2025), the first to beat Dijkstra on sparse directed graphs.
+            </p>
+            <div class="graphics">
+                <!-- SVG: stylized graph with nodes and edges -->
+                <svg class="node-graph" viewBox="0 0 120 120" role="img" aria-label="Stylized graph">
+                    <line x1="60" y1="20" x2="30" y2="60" stroke="#adb5bd" stroke-width="3"/>
+                    <line x1="60" y1="20" x2="90" y2="60" stroke="#adb5bd" stroke-width="3"/>
+                    <line x1="30" y1="60" x2="60" y2="100" stroke="#adb5bd" stroke-width="3"/>
+                    <line x1="90" y1="60" x2="60" y2="100" stroke="#adb5bd" stroke-width="3"/>
+                    <circle cx="60" cy="20" r="12" fill="#4361ee" />
+                    <circle cx="30" cy="60" r="10" fill="#4cc9f0" />
+                    <circle cx="90" cy="60" r="10" fill="#4cc9f0" />
+                    <circle cx="60" cy="100" r="12" fill="#3a0ca3" />
+                </svg>
+            </div>
+            <p>
+                <a class="btn" href="https://github.com/Sirivasv/bmssp-js" target="_blank" rel="noopener">GitHub</a>
+                <a class="btn secondary" href="https://www.npmjs.com/package/bmssp" target="_blank" rel="noopener">npm</a>
+                <a class="btn secondary" href="https://hub.docker.com/r/sirivasv/bmssp-js" target="_blank" rel="noopener">Docker&nbsp;Hub</a>
+            </p>
+        </header>
+
+        <h2>Install</h2>
+        <pre><code>npm install bmssp</code></pre>
         <p>
-            Implementation of the Single Source Shortest Path (SSSP) algorithm - Bounded Multiple Source Shortest Paths (BMSSP), originally published by Tsinghua University's research.
+            The package is ESM-only. Graphs are arrays of <code>[from, to, weight]</code>
+            edges with finite numeric node IDs and finite, non-negative weights.
         </p>
+
+        <h2>Quick start</h2>
+<pre><code>import { BMSSP } from "bmssp";
+
+const graph = new BMSSP([
+  [0, 1, 50],
+  [1, 2, 75],
+  [0, 2, 25],
+]);
+
+graph.calculateShortestPaths(0);
+graph.shortestPaths;      // Map(3) { 0 => 0, 1 => 50, 2 => 25 }
+graph.reconstructPath(1); // [0, 1]</code></pre>
+
+        <h2>Public API</h2>
+        <p>The package has exactly three exports: <code>BMSSP</code>, <code>dijkstra</code>,
+           and <code>constantDegreeTransform</code>.</p>
+
+        <h3><code>new BMSSP(graph)</code></h3>
         <p>
-            Read the original paper:
-            <a href="https://dl.acm.org/doi/10.1145/3717823.3718179" target="_blank">
-                Tsinghua SSSP Paper
-            </a>
+            Validates and stores the edge list. Every entry must be an exact three-element
+            <code>[from, to, weight]</code> array; node IDs must be finite numbers and weights
+            finite and non-negative. Malformed input throws an <code>Error</code> identifying
+            the offending edge index. An empty edge array is valid (the graph then has no
+            nodes, so any start node is rejected later).
         </p>
-        <div class="graphics">
-            <!-- SVG: stylized graph with nodes and edges -->
-            <svg class="node-graph" viewBox="0 0 120 120">
-                <circle cx="60" cy="20" r="12" fill="#4361ee" />
-                <circle cx="30" cy="60" r="10" fill="#4cc9f0" />
-                <circle cx="90" cy="60" r="10" fill="#4cc9f0" />
-                <circle cx="60" cy="100" r="12" fill="#3a0ca3" />
-                <line x1="60" y1="20" x2="30" y2="60" stroke="#adb5bd" stroke-width="3"/>
-                <line x1="60" y1="20" x2="90" y2="60" stroke="#adb5bd" stroke-width="3"/>
-                <line x1="30" y1="60" x2="60" y2="100" stroke="#adb5bd" stroke-width="3"/>
-                <line x1="90" y1="60" x2="60" y2="100" stroke="#adb5bd" stroke-width="3"/>
-            </svg>
+
+        <h3><code>graph.calculateShortestPaths(source)</code></h3>
+        <p>
+            Computes shortest distances from <code>source</code> via the paper's method
+            (FindPivots → block list → recursive BMSSP with the bounded base case — not by
+            calling Dijkstra). Throws if <code>source</code> is not a node of the graph.
+            Results land in <code>graph.shortestPaths</code>, a
+            <code>Map&lt;nodeId, distance&gt;</code> holding a value for every node —
+            <code>Infinity</code> where unreachable. Distances and predecessor pointers are
+            canonical: deterministic regardless of edge-list order, even with ties and
+            zero-weight edges. Calling it again with a different source resets state and
+            recomputes.
+        </p>
+
+        <h3><code>graph.reconstructPath(target)</code></h3>
+        <p>
+            Returns the canonical shortest path from the most recent source to
+            <code>target</code> as an array of node IDs (<code>[source, …, target]</code>).
+            Returns <code>[]</code> when <code>target</code> is unreachable or no run has
+            completed yet; throws for a node that is not in the graph.
+        </p>
+
+        <h3><code>dijkstra(graph, nodeIDs, source)</code></h3>
+        <p>
+            The reference Dijkstra implementation used as the test suite's ground-truth
+            oracle, exported for comparison and independent checking. Takes the raw edge
+            array, a <code>Set</code> of node IDs, and a source; returns a
+            <code>Map&lt;nodeId, distance&gt;</code> (<code>Infinity</code> if unreachable).
+        </p>
+
+        <h3><code>constantDegreeTransform(graph)</code></h3>
+        <p>
+            Opt-in preprocessing that rewrites any graph so every vertex has in-degree and
+            out-degree ≤ 2 (the paper's preliminary assumption) by splitting each vertex into
+            a zero-weight cycle of “port” copies. Distance-preserving and never required for
+            correctness — BMSSP is validated on arbitrary graphs. Returns
+            <code>{ edges, copiesOf, originalOf, sourceCopy, collapse }</code>:
+        </p>
+<pre><code>import { BMSSP, constantDegreeTransform } from "bmssp";
+
+const t = constantDegreeTransform([
+  [0, 1, 50],
+  [0, 2, 25],
+  [1, 2, 75],
+]);
+
+const g = new BMSSP(t.edges);              // in/out-degree ≤ 2 everywhere
+g.calculateShortestPaths(t.sourceCopy(0)); // start from a copy of node 0
+t.collapse(g.shortestPaths);               // Map(3) { 0 => 0, 1 => 50, 2 => 25 }</code></pre>
+
+        <div class="note">
+            Algorithm internals — the Lemma 3.3 block list, the indexed min-heap,
+            <code>BaseCase</code>, <code>FindPivots</code>, and the tie-break helpers — are
+            deliberately <em>not</em> exported. They are implementation details, documented
+            in-source for contributors.
         </div>
-        <a class="btn" href="https://github.com/sirivasv/tsinghua-sssp" target="_blank">View on GitHub</a>
+
+        <h2>Correctness &amp; performance</h2>
+        <p>
+            Every release is validated node-by-node against the Dijkstra oracle on thousands
+            of seeded graphs (up to 2 million nodes). The paper's win is asymptotic: measured
+            head-to-head, Dijkstra still wins wall-clock at practical sizes, but in the
+            paper's own metric — comparisons between path lengths — this implementation does
+            fewer comparisons than Dijkstra from about n&nbsp;=&nbsp;1M on sparse graphs. See
+            <a href="https://github.com/Sirivasv/bmssp-js/blob/main/benchmarks/HEAD-TO-HEAD.md"
+               target="_blank" rel="noopener">benchmarks/HEAD-TO-HEAD.md</a> for the data and
+            methodology.
+        </p>
     </div>
+    <footer>
+        <a href="https://github.com/Sirivasv/bmssp-js" target="_blank" rel="noopener">bmssp-js</a>
+        · MPL-2.0 · Saul Ivan Rivas Vega
+    </footer>
 </body>
-</html></svg>
+</html>

--- a/index.mjs
+++ b/index.mjs
@@ -1,3 +1,41 @@
+// Public API of the `bmssp` package (ESM-only). Exactly three exports:
+// the BMSSP class, the reference `dijkstra`, and the opt-in
+// `constantDegreeTransform`. Algorithm-internal modules (the block list,
+// the indexed heap, BaseCase, FindPivots, the tie-break helpers) are
+// deliberately NOT re-exported — they are implementation details of the
+// recursion, not supported public API.
+
+/**
+ * BMSSP — the paper's Algorithm 3 behind a small class API.
+ *
+ * `new BMSSP(graph)` takes an array of `[from, to, weight]` edges with
+ * finite numeric node IDs and finite, non-negative weights (an empty array
+ * is valid; malformed edges throw with the offending index).
+ * `calculateShortestPaths(source)` computes canonical distances into the
+ * `shortestPaths` Map (`Infinity` for unreachable nodes), and
+ * `reconstructPath(target)` returns the canonical shortest path as an
+ * array of node IDs. Full JSDoc lives on the class in `src/bmssp.mjs`.
+ */
 export { BMSSP } from "./src/bmssp.mjs";
+
+/**
+ * Reference Dijkstra implementation — the oracle the BMSSP test suite is
+ * validated against, exported for comparison and independent checking.
+ *
+ * `dijkstra(graph, nodeIDs, source)` returns a `Map` from node ID to
+ * shortest distance (`Infinity` if unreachable). See `src/dijkstra.mjs`.
+ */
 export { dijkstra } from "./src/dijkstra.mjs";
+
+/**
+ * Opt-in constant-degree transform — rewrites any graph so every vertex
+ * has in-degree and out-degree <= 2 (the paper's preliminary assumption)
+ * by splitting each vertex into a zero-weight cycle of port copies. The
+ * rewrite is distance-preserving and never required for correctness.
+ *
+ * `constantDegreeTransform(graph)` returns
+ * `{ edges, copiesOf, originalOf, sourceCopy, collapse }`; run BMSSP on
+ * `edges` from `sourceCopy(source)` and `collapse()` the resulting
+ * distances back onto original node IDs. See `src/constantDegree.mjs`.
+ */
 export { constantDegreeTransform } from "./src/constantDegree.mjs";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bmssp",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bmssp",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "MPL-2.0",
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bmssp",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Javascript package implementation of the bmssp algorithm.",
   "main": "index.mjs",
   "keywords": [


### PR DESCRIPTION
Closes #166

## Summary

Milestone **1.1.0**'s last open issue. Two deliverables, matching the issue's re-scoped description:

- **`index.mjs`** — JSDoc on the three public re-exports (`BMSSP`, `dijkstra`, `constantDegreeTransform`), in the style of the module docs, plus a header note that algorithm internals (block list, heap, BaseCase, FindPivots, tie-break helpers) are deliberately not exported.
- **`docs/index.html`** — rewritten from a stale generic landing page (it linked to the wrong repo `sirivasv/tsinghua-sssp` and had a stray trailing `</svg>`) into a proper **public-API reference**: install, quick start, the `BMSSP` class (constructor input contract, `calculateShortestPaths`, `reconstructPath`), `dijkstra`, `constantDegreeTransform` with a usage example, an internals-are-private note, and the measured correctness/performance summary. Same visual identity, still static dependency-free HTML (deployed by `static.yml`).

No `src/` or `test/` changes.

## Version

**`1.0.1` → `1.1.0`** (`npm version minor`) — this PR closes milestone 1.1.0's last open issue, so it carries the milestone-closing minor bump per the semver convention. Release (tag + GitHub Release → npm + Docker Hub) follows after the merge is confirmed.

Also synced in this PR (Phase C): knowledge base `05`/`06`/`07` (including the Phase A marker flip from the merged #164 PR #195) and `README.md` (roadmap table: 1.1.0 ✅ done, 1.2.0 current focus; link to the published API reference).

## Test / lint

- `npm test`: **146 passed, 1 skipped (XL), 11 suites** ✅
- `npm run lint`: Prettier + ESLint clean ✅

## Roadmap proposals

1. **Close milestone `1.1.0` (milestone #2) on GitHub** once this PR merges — #166 was its last open issue and milestones don't auto-close.

(The two proposals from the #164 PR — re-scope #166, note the new export on #173 — were found already executed on GitHub and cleared from `06`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)