### PR TITLE
feat(#170): BMSSP-vs-Dijkstra head-to-head + comparison-count mode in the harness

### DIFF
--- a/.claude/knowledge/05-codebase-map.md
+++ b/.claude/knowledge/05-codebase-map.md
@@ -1,14 +1,16 @@
 # 05 — Codebase Map (current state)
 
-<!-- BOOKMARK-COMMIT: a1dac45cc2aa4f48e708fe2e0e05a964c0f858a5 -->
-<!-- PENDING-PR-BRANCH: docs/166-public-api-docs -->
-<!-- Last validated: 2026-07-21 (Phase C of the #166 PR). Describes the tree as it will
-     exist once that PR merges: JSDoc on index.mjs's three public re-exports and a full
-     rewrite of docs/index.html into a public-API reference (was a stale landing page
-     pointing at the wrong repo). No src/ or test/ changes. #166 is milestone 1.1.0's last
-     open issue → this PR closes the milestone → minor bump to 1.1.0 (semver convention,
-     06 "Release mechanics"). This rewrite also folds in the session's Phase A fast path:
-     the #164 PR merged as PR #195 (merge commit a1dac45 == the bookmark). -->
+<!-- BOOKMARK-COMMIT: d7d3080 -->
+<!-- PENDING-PR-BRANCH: feat/170-bmssp-dijkstra-benchmark -->
+<!-- Last validated: 2026-07-21 (Phase C of the #170 PR). Describes the tree as it will
+     exist once that PR merges: the benchmark harness runs the BMSSP-vs-Dijkstra
+     head-to-head itself (bmssp column + verified outputs in scenarios.bench.mjs, new
+     dijkstra-adj.mjs fair baseline, opt-in comparison-count mode via `npm run
+     bench:counts`), a comparison counter in src/tieBreak.mjs, a sparse-random-l4
+     level-transition scenario, and a fresh RESULTS.md. No bump (issue-closing, not a
+     bug fix, not 1.2.0's last issue). This file also carries the previous session's
+     Phase E marker flip (1.1.0 released 2026-07-21, milestone closed) that rides this
+     branch per branch protection. -->
 
 Snapshot of what exists in `bmssp-js` today, so you know what to build on vs. what's missing.
 
@@ -79,16 +81,19 @@ test/
   heap.test.mjs           # #41: 16 MinHeap tests incl. a seeded stress test vs. a naive queue
   baseCase.test.mjs       # #40: 13 BaseCase tests incl. seeded oracle-comparison stress
   findPivots.test.mjs     # #44: 12 FindPivots tests incl. two seeded oracle stress tests
+  benchmarks.test.mjs     # #170: 7 harness tests — dijkstra-adj vs shipped oracle, counters, tiny-scenario report shape + zero mismatches
   README.md               # test-suite principles (everything seeded, no data files) + file map
-benchmarks/               # dependency-free benchmark harness, `npm run bench`
-  generators.mjs          #   seeded graph builders + SCENARIOS registry (sparse/dense/grid/chain/star)
+benchmarks/               # dependency-free benchmark harness, `npm run bench` / `npm run bench:counts`
+  generators.mjs          #   seeded graph builders + SCENARIOS registry (sparse/dense/grid/chain/star/sparse-l4)
   bench-util.mjs          #   timing (timeMany) + markdown-table helpers
   adjacency.bench.mjs     #   adjacency map (#45) vs. linear edge scan
-  scenarios.bench.mjs     #   construct + Dijkstra timings per graph shape
-  run.mjs                 #   runs all benchmarks, prints markdown report
+  scenarios.bench.mjs     #   #170: head-to-head per shape — construct + dijkstra + bmssp timings, verified outputs
+  dijkstra-adj.mjs        #   #170: algorithm-only Dijkstra over prebuilt adjacency + comparison counter (fair baseline)
+  compare-counts.bench.mjs#   #170: comparison-count mode (COUNT_CASES: sparse 50k/200k/1M + grid 700)
+  run.mjs                 #   runs all benchmarks, prints markdown report; --counts adds count tables
   README.md               #   methodology + "when to use which" guidance
-  RESULTS.md              #   captured sample run
-  HEAD-TO-HEAD.md         #   measured BMSSP-vs-Dijkstra (1.0.0): wall-clock + comparison counts
+  RESULTS.md              #   captured `npm run bench:counts` report (2026-07-21)
+  HEAD-TO-HEAD.md         #   frozen 1.0.0 measurement record (up to n = 4M): wall-clock + comparison counts
 examples/
   main.mjs                # tiny usage example (constructs BMSSP, prints .graph)
 docs/index.html           # public-API reference (GitHub Pages via static.yml) — rewritten in
@@ -289,7 +294,10 @@ relaxEdge(u, v, w, dHat, ties, bound?) // canonical relaxation → { key, improv
                                    // improved=true updated d̂/hops/preds together;
                                    // improved=false = candidate exactly matches v's stored
                                    // label (u is the recorded setter) — the re-enqueue signal
-export { compareKeys, toBound, makeTies, orderKey, relaxEdge, NO_PRED };
+resetComparisonCount() / getComparisonCount() // #170: unconditional compareKeys call counter
+                                   // (the paper's cost metric); read by the benchmark harness
+export { compareKeys, toBound, makeTies, orderKey, relaxEdge, NO_PRED,
+         resetComparisonCount, getComparisonCount };
                                    // NOT re-exported from index.mjs — internal to the algorithm
 ```
 
@@ -355,7 +363,8 @@ edge-order deterministic (copies allocated in edge order); ~2m copies, ~3m edges
   `test/findPivots.test.mjs` (12): per-module contracts incl. seeded stress — see the
   module sections above. (Since #163 the baseCase partial-run tests assert the composite
   contract: strictly below `boundKey`, `≤` the scalar bound.)
-- `test/tieBreak.test.mjs` (16, #163): unit tests for `compareKeys`/`toBound`/`relaxEdge`
+- `test/tieBreak.test.mjs` (19, #163 + 3 counter tests from #170): unit tests for
+  `compareKeys`/`toBound`/`relaxEdge`
   (lexicographic order, scalar-bound infimum, canonical pred choice, zero-weight-cycle
   quiescence, the equality re-enqueue signal), then the system-level properties:
   **edge-order determinism** (full runs AND bounded partial calls return identical
@@ -400,20 +409,36 @@ edge-order deterministic (copies allocated in edge order); ~2m copies, ~3m edges
   **opt-in `FUZZ_XL=1` sparse n = 2M round** (~33 s, `test.skip` otherwise). Every failure
   message carries the round's seed for reproduction. **`FUZZ_ROUNDS=<x>`** multiplies all
   round counts (default 1 ≈ 0.5 s; 25 ≈ 10 s, several thousand graphs).
-- Current suite: **147 tests — 146 passing + 1 XL skipped by default**, 100% statement
-  coverage, ~7 s wall-clock (the #164 distance-preservation sweeps run BMSSP/Dijkstra from
-  every source). No graph data files: every generated test graph comes from a
+- `test/benchmarks.test.mjs` (7, #170): the harness itself. `dijkstraAdjacency` equals the
+  shipped `dijkstra` on seeded graphs, reports Infinity for unreachable nodes, rejects an
+  unknown source; both comparison counters count, reset, and are deterministic for a fixed
+  graph; `runScenarioBenchmark` and `runComparisonCountBenchmark` on tiny injected
+  scenarios return the expected columns with **zero mismatches**.
+- Current suite: **157 tests — 156 passing + 1 XL skipped by default**, ~100% statement
+  coverage, ~7.5 s wall-clock (the #164 distance-preservation sweeps run BMSSP/Dijkstra
+  from every source). No graph data files: every generated test graph comes from a
   seed; the #162 fixtures are hand-built and fully deterministic.
 
-## Benchmarks (`benchmarks/`, `npm run bench`)
+## Benchmarks (`benchmarks/`, `npm run bench` / `npm run bench:counts`)
 
-Deterministic (seeded) micro-benchmarks. `adjacency.bench.mjs` shows the #45 map is
-~thousands× faster per-node than a linear scan. `scenarios.bench.mjs` times construction +
-a Dijkstra run across five graph shapes. **`HEAD-TO-HEAD.md` records the measured
-BMSSP-vs-Dijkstra comparison** (2026-07-16): wall-clock tables by shape and size, the
-sparse scaling trend, and the comparison-count crossover (~n = 1M). #170 tracks folding
-both measurements into the harness itself (algorithm-only `bmssp` column + optional
-comparison-count mode); the raw baseline is also on #170 as a comment.
+Deterministic (seeded) micro-benchmarks; since #170 the harness runs the full
+BMSSP-vs-Dijkstra head-to-head itself:
+
+- `adjacency.bench.mjs`: the #45 map is ~thousands× faster per-node than a linear scan.
+- `scenarios.bench.mjs`: per shape, algorithm-only `dijkstra ms` / `bmssp ms` / `ratio`
+  columns — both sides consume the BMSSP instance's prebuilt adjacency (`dijkstra-adj.mjs`
+  is the fair baseline) and outputs are verified node-by-node (`mismatches` must be 0).
+  Scenario registry adds `sparse-random-l4` (n = 300k, degree 3): `topLevel` steps 3→4 at
+  exactly n = 2^18 + 1 and stays 4 until t reaches 7 (~n = 376k), so 300k sits inside the
+  #182 level-transition window (3.11× vs 2.79× at 50k on 2026-07-21 capture).
+- `compare-counts.bench.mjs` (opt-in, `npm run bench:counts` or `--counts`): comparisons
+  between path lengths — BMSSP counted via `tieBreak`'s unconditional `compareKeys`
+  counter, Dijkstra via matching counters in `dijkstra-adj.mjs`. One exact run per side
+  (counts are deterministic). 2026-07-21 capture reproduces the crossover: sparse 1.20× at
+  50k → 1.03× at 200k → **0.98× at 1M**; grid 700×700 stays 1.27×.
+- **`HEAD-TO-HEAD.md` is the frozen 1.0.0 measurement record** (2026-07-16, sizes to
+  n = 4M incl. star-500k 67.8× and the 4M cliff); `RESULTS.md` is the latest captured
+  harness report.
 
 ## Gaps to fill (the actual work)
 
@@ -431,10 +456,10 @@ comparison-count mode); the raw baseline is also on #170 as a comment.
 | Public shortest-path reconstruction | `BMSSP.reconstructPath()` + `test/pathReconstruction.test.mjs` | #169 | ✅ done (PR #189, no bump) |
 | Constructor input validation | `BMSSP` constructor + `test/main.test.mjs` | #165 | ✅ merged (PR #191, no bump) |
 | Optional constant-degree transform (in/out-degree ≤ 2) | `src/constantDegree.mjs` + `test/constantDegree.test.mjs` | #164 | ✅ merged (PR #195, no bump) |
-| JSDoc on `index.mjs` exports + public-API docs page | `index.mjs` + `docs/index.html` | #166 | ✅ done-pending-merge (this PR, **minor → 1.1.0**) |
+| JSDoc on `index.mjs` exports + public-API docs page | `index.mjs` + `docs/index.html` | #166 | ✅ merged (PR #196, **minor → 1.1.0**, released 2026-07-21) |
+| BMSSP-vs-Dijkstra head-to-head in the harness | `benchmarks/` + `src/tieBreak.mjs` counter | #170 | ✅ done-pending-merge (this PR, no bump) |
 
-Milestone `1.1.0` (correctness hardening) **completes with this PR** — #166 was its last
-open issue, so this PR bumps **minor → 1.1.0** and its merge triggers the 1.1.0 release
-(Phase E) plus closing the milestone on GitHub (proposed). Milestone `1.2.0` becomes the
-current focus (#167, #168, #170, #182 open); see
-[06-milestones-roadmap.md](06-milestones-roadmap.md).
+Milestone `1.1.0` (correctness hardening) is **closed** — released 2026-07-21 (npm +
+Docker Hub). Milestone `1.2.0` is the current focus: after #170 merges, #182
+(performance-cliff investigation, now armed with the harness's small-n reproductions)
+is next, then #167/#168; see [06-milestones-roadmap.md](06-milestones-roadmap.md).

--- a/.claude/knowledge/06-milestones-roadmap.md
+++ b/.claude/knowledge/06-milestones-roadmap.md
@@ -1,11 +1,13 @@
 # 06 — Milestones Roadmap
 
-<!-- SYNCED-FROM-GITHUB: 2026-07-21 Phase C of the #166 PR (#164 closed by merged PR #195;
-     milestones 1.1.0/1.2.0/2.0.0 open with 1/4/3 open issues on GitHub; #166 —
-     1.1.0's last open issue — is done-pending-merge in this PR) -->
-<!-- Current package version: 1.1.0 (bumped in the #166 PR — milestone-closing minor;
-     release fires in Phase E after the user confirms the merge. Last released: 1.0.1,
-     2026-07-16) -->
+<!-- SYNCED-FROM-GITHUB: 2026-07-21 Phase C of the #170 PR (verified live: milestone 1.1.0
+     CLOSED 6/6; 1.2.0 open with 4 open issues #167/#168/#170/#182; 2.0.0 open with 3
+     open issues #171/#172/#173; #170 is done-pending-merge in this PR) -->
+<!-- Current package version: 1.1.0 — released 2026-07-21 (tag + GitHub Release with
+     Announcements discussion #197 → npm + Docker Hub via publish.yml); tag matches -->
+<!-- Release-discussion convention (user-directed 2026-07-21): every GitHub Release also
+     creates a linked discussion — pass --discussion-category "Announcements" to
+     gh release create (the UI's "Create a discussion for this release" checkbox) -->
 
 Maps GitHub **milestones** and **issues** (Sirivasv/bmssp-js) to the paper's building blocks,
 with a dependency-aware build order. This is the "intent" side of the knowledge base (what to
@@ -41,11 +43,17 @@ it runs the same Phase C reconciliation directly on `main`.
 
 ## 📋 Roadmap proposals (pending user approval)
 
-From the #166 PR (Phase C, 2026-07-21):
+From the #170 PR (Phase C, 2026-07-21):
 
-1. **Close milestone `1.1.0` (milestone #2) on GitHub** once this PR merges — #166 was its
-   last open issue and milestones don't auto-close. (`gh api -X PATCH
-   repos/Sirivasv/bmssp-js/milestones/2 -f state=closed`.)
+1. **Comment on #182** with the harness's small-n reproductions so the investigation can
+   iterate in seconds instead of minutes: the star pathology is already 8.7× at n = 50k
+   (`star` scenario), and the `topLevel` 3→4 transition is reachable at n = 300k
+   (`sparse-random-l4`: 3.11× vs 2.79× at 50k — the window is exactly n ∈ (2^18, ~376k],
+   where t is still 6; t reaches 7 at ~n = 376k and topLevel drops back to 3). Both are
+   now standing regression sentinels in `npm run bench`.
+
+_(The #166-PR proposal — close milestone `1.1.0` — was approved and executed 2026-07-21:
+milestone #2 is closed on GitHub with 6/6 issues done.)_
 
 _Phase C writes proposed GitHub edits here (and in the PR body); Phase E executes the
 approved ones — one confirmation each — and clears them from this list._
@@ -90,19 +98,29 @@ executed 2026-07-17.)_
 - **Phase A reconciliation (2026-07-21, this session):** PR #195 (the #164 branch) merged
   as `main` HEAD `a1dac45`; `05`'s bookmark fast-path flipped. No pending release found
   (`package.json` 1.0.1 == latest tag).
-- **#166 done-pending-merge (this PR, 2026-07-21):** JSDoc on `index.mjs`'s three public
-  re-exports and a full rewrite of `docs/index.html` into a public-API reference (the old
-  page was a generic landing page linking to the wrong repo). No `src/`/`test/` changes.
-  **Last open 1.1.0 issue → minor bump to `1.1.0` in this PR**; on merge: release 1.1.0
-  (Phase E) and close the milestone (Roadmap proposal 1).
+- **#166 merged (PR #196, 2026-07-21):** JSDoc on `index.mjs`'s three public re-exports
+  and a full rewrite of `docs/index.html` into a public-API reference (the old page was a
+  generic landing page linking to the wrong repo). No `src/`/`test/` changes. Last open
+  1.1.0 issue → carried the minor bump; **1.1.0 released same day** (tag + GitHub Release
+  with Announcements discussion #197 → npm + Docker Hub) and **milestone 1.1.0 closed**.
 - **Phase A reconciliation (2026-07-21):** the #165 PR (#191) and three dependabot workflow
   bumps (#192/#193/#194, `.github/workflows/**` only) had landed on `main` without a
   post-merge session-start marker flip. The #164 PR folds that in: `05`'s bookmark now sits
   at `b36c059` and the "pending" framing for #165 is cleared.
 - **Milestone `1.2.0` — performance & ergonomics** (in progress). **#169 merged**
   (PR #189): public `BMSSP.reconstructPath(target)` walks the existing canonical
-  predecessor map, with independent path-oracle coverage and public usage docs. Four
-  issues remain.
+  predecessor map, with independent path-oracle coverage and public usage docs.
+- **#170 done-pending-merge (this PR, 2026-07-21):** the harness runs the head-to-head
+  itself. `scenarios.bench.mjs` gains algorithm-only `dijkstra ms`/`bmssp ms`/`ratio`
+  columns (both sides on the instance's prebuilt adjacency via the new
+  `benchmarks/dijkstra-adj.mjs`; outputs verified, `mismatches` column must be 0) plus a
+  `sparse-random-l4` scenario (n = 300k — inside the `topLevel` 3→4 window that starts at
+  n = 2^18 + 1). Opt-in `npm run bench:counts` (`compare-counts.bench.mjs`) reproduces
+  the comparison-count crossover exactly (sparse 1.20× at 50k → 1.03× at 200k → **0.98×
+  at 1M**) via an unconditional `compareKeys` counter in `src/tieBreak.mjs` and matching
+  counters in the bench Dijkstra. 7 new harness tests + 3 counter tests (suite 157).
+  Fresh `RESULTS.md` captured; `HEAD-TO-HEAD.md` marked as the frozen 1.0.0 record.
+  No bump (not a bug fix; #167/#168/#182 still open in 1.2.0).
 - **Semver release convention (user-directed 2026-07-17, PR #186):** bumps only on bug
   fix (patch) or milestone-closing PR (minor/major) — see "Release mechanics" below.
 - **2026-07-16 reflection session (post-release):** measured the BMSSP-vs-Dijkstra
@@ -134,7 +152,7 @@ executed 2026-07-17.)_
 - Each sub-piece (#40/#41/#42/#44/#45) shipped with focused unit tests. ✅
 - `npm run lint` clean; ESM + Prettier style preserved. ✅
 
-## Milestone `1.1.0` (milestone #2) — correctness hardening — ✅ COMPLETE PENDING #166 MERGE
+## Milestone `1.1.0` (milestone #2) — correctness hardening — ✅ CLOSED (released 2026-07-21)
 
 All six issues done (build order as executed — cheapest protection first, then the deep work):
 
@@ -145,28 +163,28 @@ All six issues done (build order as executed — cheapest protection first, then
 | 3 | 163 | Deterministic tie-breaking for equal-length paths (Assumption 2.1) | enhancement · help wanted | ✅ merged (PR #188, no bump): composite keys in `src/tieBreak.mjs`, all six tie manifestations resolved by construction |
 | 4 | 165 | Input validation for the BMSSP constructor | good first issue · help wanted | ✅ merged (PR #191, no bump): validates graph shape, node IDs, and weights; preserves empty graphs |
 | 5 | 164 | Optional constant-degree transform (in/out-degree ≤ 2) | enhancement · help wanted | ✅ merged (PR #195, no bump): `src/constantDegree.mjs`, opt-in + distance-preserving, re-exported |
-| 6 | 166 | JSDoc / API docs for the new modules | documentation · good first issue | ✅ done-pending-merge (this PR, **minor → `1.1.0`**): JSDoc on `index.mjs`'s re-exports + `docs/index.html` rewritten as the public-API reference (`BMSSP`, `dijkstra`, `constantDegreeTransform`; internals stay out). **Closes milestone 1.1.0** |
+| 6 | 166 | JSDoc / API docs for the new modules | documentation · good first issue | ✅ merged (PR #196, **minor → `1.1.0`**, released 2026-07-21): JSDoc on `index.mjs`'s re-exports + `docs/index.html` rewritten as the public-API reference (`BMSSP`, `dijkstra`, `constantDegreeTransform`; internals stay out). **Closed milestone 1.1.0** |
 
-## Milestone `1.2.0` (milestone #3) — performance & ergonomics — NEXT
+## Milestone `1.2.0` (milestone #3) — performance & ergonomics — CURRENT
 
-Suggested build order: **#170 first** (harness integration turns the one-off HEAD-TO-HEAD
-measurement into a repeatable tool), then **#182** (use that tool to investigate the two
-measured cliffs), then **#167 / #168** (the optimizations the investigation informs).
+Build order: ~~#170~~ (done-pending-merge), then **#182** (use the harness's small-n
+reproductions to investigate the two measured cliffs), then **#167 / #168** (the
+optimizations the investigation informs).
 
 | # | Issue | Labels | Notes |
 |---|---|---|---|
 | 167 | Restore Lemma 3.3's exact asymptotics in BlockList (balanced-BST bound index + linear-time selection) | enhancement · help wanted | — |
 | 168 | Adjacency and relaxation micro-optimizations | enhancement · help wanted | — |
 | 169 | Optional shortest-path reconstruction (`Pred[]` → paths) | enhancement · help wanted | ✅ merged (PR #189, no bump): public API + independent path oracle |
-| 170 | BMSSP-vs-Dijkstra benchmark comparison | enhancement · help wanted | — |
+| 170 | BMSSP-vs-Dijkstra benchmark comparison | enhancement · help wanted | ✅ done-pending-merge (this PR, no bump): head-to-head + count mode in the harness, verified outputs |
 | 182 | Investigate BMSSP performance cliffs: high-fanout (star) graphs and recursion-level transitions | enhancement · help wanted | — |
 
-_Note:_ the seeded **benchmark harness already exists** (`benchmarks/`, `npm run bench`),
-and the measured head-to-head lives in `benchmarks/HEAD-TO-HEAD.md`. #170 is now scoped to
-harness integration (algorithm-only `bmssp` column + optional comparison-count mode; full
-baseline recorded as a comment on the issue, 2026-07-16). #182 (new, 2026-07-16) carries
-the two measured pathologies: star-graph blowup (67.8× at n = 500k) and the `topLevel`
-3→4 transition cliff (5× at n = 4M); likely overlaps #167/#168.
+_Note:_ #182 carries the two measured pathologies (star blowup: 67.8× at n = 500k in the
+1.0.0 record, already 8.7× at n = 50k in the harness; the `topLevel` 3→4 transition: 5× at
+n = 4M in the record, 3.11× at n = 300k via `sparse-random-l4`); likely overlaps
+#167/#168. Since #170 the harness reruns both as regression sentinels on every
+`npm run bench`, and `npm run bench:counts` reproduces the comparison-count crossover
+(below 1.0 between n = 200k and n = 1M).
 
 ## Milestone `2.0.0` (milestone #4) — API-breaking generalization
 

--- a/.claude/knowledge/07-glossary.md
+++ b/.claude/knowledge/07-glossary.md
@@ -213,25 +213,46 @@ Quick lookup for the symbols and terms used across the paper, the notes, and the
 - **Dyadic-float regime** (#161) — fuzz weight regime using multiples of `1/256` (dyadic
   rationals) of bounded magnitude: every path sum is exact in float64, so float-weight
   testing keeps bit-exact oracle equality instead of needing tolerances.
-- **Benchmark harness** — `benchmarks/` (run via `npm run bench`): seeded graph
-  **generators** + a `SCENARIOS` registry (sparse-random / dense-random / grid / chain /
-  star), `timeMany` timing, and two benchmarks (adjacency-vs-scan, per-shape Dijkstra). Will
-  host the BMSSP-vs-Dijkstra comparison once #43 lands.
+- **Benchmark harness** — `benchmarks/` (run via `npm run bench`, or `npm run
+  bench:counts` for the count tables): seeded graph **generators** + a `SCENARIOS`
+  registry (sparse-random / dense-random / grid / chain / star / sparse-random-l4),
+  `timeMany` timing, and three benchmarks: adjacency-vs-scan, the per-shape
+  BMSSP-vs-Dijkstra head-to-head (#170), and the opt-in comparison-count mode (#170).
 - **Scenario** — a named, seeded graph shape in the benchmark registry used to probe where
   BMSSP's asymptotics would help vs. where Dijkstra dominates. See `benchmarks/README.md`.
-- **Head-to-head** — the measured BMSSP-vs-Dijkstra comparison
-  (`benchmarks/HEAD-TO-HEAD.md`, 2026-07-16). **Algorithm-only timing**: construction and
-  adjacency building are excluded for both sides; the Dijkstra variant consumes the BMSSP
-  instance's own prebuilt `adjacency` Map (the exported `dijkstra()` builds its own per
-  call — that's loading, not algorithm). Harness integration tracked in #170.
+- **`sparse-random-l4`** (#170) — the level-transition scenario: sparse degree-3 at
+  n = 300k, inside the `topLevel` 3→4 window `n ∈ (2^18, ~376k]` (where `t` is still 6;
+  at ~376k `t` reaches 7 and `topLevel` drops back to 3). A standing regression sentinel
+  for #182's transition cliff.
+- **Head-to-head** — the measured BMSSP-vs-Dijkstra comparison. **Algorithm-only
+  timing**: construction and adjacency building are excluded for both sides; the Dijkstra
+  baseline consumes the BMSSP instance's own prebuilt `adjacency` Map (the exported
+  `dijkstra()` builds its own per call — that's loading, not algorithm). Since #170 the
+  harness runs it per shape with node-by-node output verification (`mismatches` column);
+  `benchmarks/HEAD-TO-HEAD.md` is the frozen 1.0.0 record (2026-07-16, up to n = 4M),
+  `benchmarks/RESULTS.md` the latest capture.
+- **`dijkstraAdjacency(adjacency, nodeIDs, source)`** (#170) — `benchmarks/dijkstra-adj.mjs`,
+  the fair baseline: the oracle's lazy-heap Dijkstra reworked to consume a prebuilt
+  `Map<from, [to, weight][]>`, with distance-comparison counters
+  (`resetDijkstraComparisonCount` / `getDijkstraComparisonCount`). Bench-only — not part
+  of the package API.
+- **Comparison counter (#170)** — `resetComparisonCount()` / `getComparisonCount()` in
+  `src/tieBreak.mjs`: an unconditional per-call counter in `compareKeys`. Because the heap
+  and BlockList receive `compareKeys` as their comparator and the algorithm modules call
+  it directly, this one counter measures every BMSSP path-length comparison. Internal
+  (not re-exported from `index.mjs`).
 - **Comparison-count crossover** — head-to-head result in the paper's comparison-addition
   model: counting every comparison between two distance values (heap sifts, BlockList
   searches/sorts, relaxations), BMSSP does **fewer** comparisons than Dijkstra past
-  ~n = 1M on sparse graphs (0.91× at n = 2M) even though Dijkstra still wins wall-clock —
-  the sorting barrier measurably broken, with constant factors as the remaining gap.
+  ~n = 1M on sparse graphs (0.91× at n = 2M in the 1.0.0 record) even though Dijkstra
+  still wins wall-clock — the sorting barrier measurably broken, with constant factors as
+  the remaining gap. Since #170, `npm run bench:counts` reproduces it exactly
+  (`compare-counts.bench.mjs` `COUNT_CASES`: 1.20× at 50k → 1.03× at 200k → 0.98× at 1M).
 - **Performance cliffs (#182)** — two measured regimes where the head-to-head ratio breaks
-  from its ~1.6–2× pattern: star graphs (superlinear blowup, 67.8× at n = 500k) and the
-  `topLevel = ⌈log₂n / t⌉` 3→4 transition (5× at n = 4M on sparse). Milestone 1.2.0.
+  from its ~1.6–2× pattern: star graphs (superlinear blowup, 67.8× at n = 500k; already
+  8.7× at n = 50k in the harness) and the `topLevel = ⌈log₂n / t⌉` 3→4 transition (5× at
+  n = 4M on sparse; 3.11× at n = 300k via `sparse-random-l4`). Milestone 1.2.0. Both run
+  as regression sentinels in every `npm run bench` since #170.
 - **Docs page (#166)** — `docs/index.html`, the GitHub-Pages-published public-API reference
   (deployed by `static.yml` on `docs/**` changes). Documents exactly the three `index.mjs`
   exports — `BMSSP` (constructor contract, `calculateShortestPaths`, `reconstructPath`),

--- a/README.md
+++ b/README.md
@@ -34,15 +34,19 @@ with every building block shipped, tested, and released individually:
 | Shortest-path reconstruction ([#169](https://github.com/Sirivasv/bmssp-js/issues/169)) | `BMSSP.reconstructPath()` | ✅ done |
 | Constructor input validation ([#165](https://github.com/Sirivasv/bmssp-js/issues/165)) | `BMSSP` constructor | ✅ done |
 | Opt-in constant-degree transform, in/out-degree ≤ 2 ([#164](https://github.com/Sirivasv/bmssp-js/issues/164)) | `constantDegreeTransform()` | ✅ done |
+| BMSSP-vs-Dijkstra head-to-head in the benchmark harness ([#170](https://github.com/Sirivasv/bmssp-js/issues/170)) | `npm run bench` / `npm run bench:counts` | ✅ done |
 
 > **Honest note:** the paper's win is asymptotic, and this repo optimizes for correctness
 > and readability, not raw speed. Measured head-to-head (algorithm time only, graph
-> loading excluded — see [benchmarks/HEAD-TO-HEAD.md](benchmarks/HEAD-TO-HEAD.md)):
+> loading excluded — rerun it yourself with `npm run bench`; methodology and the deep
+> 1.0.0 record in [benchmarks/HEAD-TO-HEAD.md](benchmarks/HEAD-TO-HEAD.md)):
 > Dijkstra still wins on wall-clock at every practical size, though the gap narrows as
 > sparse graphs grow (2.5× at 50k nodes → 1.57× at 2M). But in the paper's own metric —
 > **comparisons between path lengths** — BMSSP does **fewer comparisons than Dijkstra
-> from about n = 1M on sparse graphs** (0.91× at n = 2M), and the advantage grows with
-> size: the "sorting barrier" is measurably broken; what remains is JS constant factors.
+> from about n = 1M on sparse graphs** (`npm run bench:counts` measures the ratio falling
+> 1.20× at 50k → 1.03× at 200k → 0.98× at 1M; 0.91× at 2M in the record), and the
+> advantage grows with size: the "sorting barrier" is measurably broken; what remains is
+> JS constant factors.
 > Where inputs violate the paper's distinct-path-lengths assumption (e.g. zero-weight
 > edges), a principled deterministic tie-break
 > ([#163](https://github.com/Sirivasv/bmssp-js/issues/163)) realizes that assumption in
@@ -145,14 +149,17 @@ Other image versions are on [Docker Hub](https://hub.docker.com/r/sirivasv/bmssp
 
 ```bash
 npm install
-npm test          # Jest suite — every graph seeded, every failure reproducible (~3 s)
-npm run lint      # Prettier + ESLint
-npm run bench     # seeded micro-benchmarks (see benchmarks/README.md)
+npm test              # Jest suite — every graph seeded, every failure reproducible (~7 s)
+npm run lint          # Prettier + ESLint
+npm run bench         # BMSSP-vs-Dijkstra head-to-head per graph shape, outputs verified
+npm run bench:counts  # …plus comparison-count tables (the paper's own cost metric)
 ```
 
-The measured BMSSP-vs-Dijkstra head-to-head — wall-clock and comparison counts, with
-methodology — lives in [benchmarks/HEAD-TO-HEAD.md](benchmarks/HEAD-TO-HEAD.md)
-([#170](https://github.com/Sirivasv/bmssp-js/issues/170) tracks harness integration).
+The benchmark harness runs the measured BMSSP-vs-Dijkstra head-to-head on every
+`npm run bench` ([#170](https://github.com/Sirivasv/bmssp-js/issues/170)); methodology,
+the deep 1.0.0 record (up to n = 4M) and the "when to use which" guidance live in
+[benchmarks/HEAD-TO-HEAD.md](benchmarks/HEAD-TO-HEAD.md) and
+[benchmarks/README.md](benchmarks/README.md).
 
 The test suite's core contract: for every node, BMSSP's distances must equal the Dijkstra
 oracle's. A seeded property/fuzz suite (`test/fuzz.test.mjs`) hammers that contract across

--- a/benchmarks/HEAD-TO-HEAD.md
+++ b/benchmarks/HEAD-TO-HEAD.md
@@ -12,6 +12,11 @@ node v26.5.0, darwin/arm64, with the seeded generators from
   with n. The "sorting barrier" is measurably broken; the wall-clock loss is JS constant
   factors (Map churn, allocation), not algorithmic work.
 
+> This document is the frozen 1.0.0 measurement record (sizes up to n = 4M). Since #170
+> the harness reruns the head-to-head on every `npm run bench` (both timing columns,
+> outputs verified) and `npm run bench:counts` reproduces the comparison-count crossover;
+> the latest capture lives in [`RESULTS.md`](./RESULTS.md).
+
 ## Methodology — algorithm time only
 
 Timing starts when the algorithm starts and stops when it finishes. Everything that is

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,22 +1,26 @@
 # bmssp-js benchmarks
 
 Deterministic, dependency-free micro-benchmarks for `bmssp-js`. They exist to
-(1) justify the adjacency map added in issue #45, and (2) stand up the harness
-that drives the **BMSSP vs. Dijkstra** comparison across graph shapes — the
-"when to use which" question. The measured 1.0.0 head-to-head (wall-clock *and*
-comparison counts) lives in [`HEAD-TO-HEAD.md`](./HEAD-TO-HEAD.md).
+(1) justify the adjacency map added in issue #45, and (2) run the **BMSSP vs.
+Dijkstra** head-to-head across graph shapes (#170) — the "when to use which"
+question, in both wall-clock time and the paper's own metric, comparison
+counts. The measured 1.0.0 baseline record lives in
+[`HEAD-TO-HEAD.md`](./HEAD-TO-HEAD.md); the latest captured harness report is
+[`RESULTS.md`](./RESULTS.md).
 
 ## Running
 
 ```bash
-node benchmarks/run.mjs            # print a markdown report
-node benchmarks/run.mjs > RESULTS.md
-npm run bench                      # same, via package script
+npm run bench                      # adjacency + head-to-head timings
+npm run bench:counts               # …plus the comparison-count tables (slower)
+node benchmarks/run.mjs [--counts] # same, direct
+node benchmarks/run.mjs --counts > benchmarks/RESULTS.md   # capture a report
 ```
 
 All graphs come from seeded generators (`generators.mjs`), so numbers are
 reproducible on a given machine. Timings use `process.hrtime.bigint()` with a
-warm-up run and the median of several iterations.
+warm-up run and the median of several iterations; comparison counts are exact
+and machine-independent (one run per side).
 
 ## What each file is
 
@@ -25,9 +29,12 @@ warm-up run and the median of several iterations.
 | `generators.mjs` | Seeded graph builders + the named `SCENARIOS` registry |
 | `bench-util.mjs` | Timing (`timeMany`) and markdown-table helpers |
 | `adjacency.bench.mjs` | Adjacency map (#45) vs. linear edge scan |
-| `scenarios.bench.mjs` | Construct + Dijkstra timings per graph shape |
-| `run.mjs` | Runs everything, prints the report |
+| `scenarios.bench.mjs` | Head-to-head per graph shape: construct, Dijkstra and BMSSP timings, verified outputs (#170) |
+| `dijkstra-adj.mjs` | Algorithm-only Dijkstra over a prebuilt adjacency map + comparison counter — the fair baseline (#170) |
+| `compare-counts.bench.mjs` | Comparison-count mode: the sorting barrier measured in the paper's cost metric (#170) |
+| `run.mjs` | Runs everything, prints the report (`--counts` adds the count tables) |
 | `HEAD-TO-HEAD.md` | Measured BMSSP-vs-Dijkstra results (1.0.0), methodology + tables |
+| `RESULTS.md` | Latest captured harness report (`npm run bench:counts` output) |
 
 ---
 
@@ -52,16 +59,16 @@ whole algorithm. #45 is a prerequisite, not an optimization.
 > Exact numbers vary by machine; run `npm run bench` for yours. The captured
 > report lives in [`RESULTS.md`](./RESULTS.md).
 
-## Result 2 — graph-shape scenarios (Dijkstra baseline)
+## Result 2 — graph-shape scenarios (BMSSP vs Dijkstra, #170)
 
-`scenarios.bench.mjs` times construction (which now includes building the #45
-map) and one single-source Dijkstra run per shape — the Dijkstra baseline
-column of the head-to-head. The real BMSSP recursion landed in `1.0.0` (#43);
-integrating an algorithm-only `bmssp` column (and an optional comparison-count
-mode) into this harness is tracked in #170. The measured results so far are in
-[`HEAD-TO-HEAD.md`](./HEAD-TO-HEAD.md).
+`scenarios.bench.mjs` runs the head-to-head per shape: construction (which
+includes building the #45 map), then **algorithm-only timings** for both
+sides — `dijkstra-adj.mjs`'s prebuilt-adjacency Dijkstra and
+`BMSSP.calculateShortestPaths()` consume the same adjacency Map, so neither
+timed window contains graph loading. Outputs are verified node-by-node every
+run; the `mismatches` column must read 0.
 
-The five shapes are chosen to stress the axes that separate the two algorithms:
+The shapes stress the axes that separate the two algorithms:
 
 | scenario | shape | why it's here |
 |----------|-------|---------------|
@@ -69,32 +76,50 @@ The five shapes are chosen to stress the axes that separate the two algorithms:
 | `dense-random` | avg degree 32 | edge-relaxation-bound; the `m` term dominates and sorting is cheap |
 | `grid-4nbr` | 200×200 lattice | large diameter, low uniform degree (spatial/mesh) |
 | `chain` | one long path | worst-case depth, minimal branching |
-| `star` | one hub, n−1 spokes | extreme degree skew |
+| `star` | one hub, n−1 spokes | extreme degree skew — the #182 blowup case |
+| `sparse-random-l4` | degree 3, n = 300k | just past the `topLevel` 3→4 step at n = 2^18 — the #182 level-transition case |
+
+## Result 3 — comparison counts (the sorting barrier, measured)
+
+`npm run bench:counts` adds the paper's own cost metric: **comparisons between
+path lengths**. Every BMSSP-side comparison funnels through
+`compareKeys` (`src/tieBreak.mjs` keeps an unconditional counter); the
+Dijkstra baseline counts its heap sifts, stale-pop checks and relaxations the
+same way. Counts are deterministic, so one run per side is exact. On sparse
+graphs the bmssp/dijkstra ratio falls as n grows and **crosses below 1.0
+between n = 200k and n = 1M** — the measured form of the paper's asymptotic
+claim (`1.0.0` record: 1.18× at 50k → 1.01× at 200k → 0.96× at 1M → 0.91× at
+2M).
 
 ---
 
-## When to use which (measured guidance, 1.0.0)
+## When to use which (measured guidance)
 
 BMSSP's advantage is **asymptotic and narrow**: `O(m · log^(2/3) n)` vs.
-Dijkstra's `O(m + n · log n)`. With the full algorithm now functional, the
-question is measured rather than asserted — see
-[`HEAD-TO-HEAD.md`](./HEAD-TO-HEAD.md) for methodology and tables:
+Dijkstra's `O(m + n · log n)`. The question is measured, not asserted — the
+harness reruns it on every `npm run bench` (fresh capture:
+[`RESULTS.md`](./RESULTS.md); the deeper 1.0.0 record up to n = 4M:
+[`HEAD-TO-HEAD.md`](./HEAD-TO-HEAD.md)):
 
 - **Use Dijkstra for wall-clock speed:** it wins on every shape and size
-  measured so far (algorithm-only timing, ~1.6–2× faster on large sparse
-  graphs, more on dense/chain/star). `bmssp-js` itself uses Dijkstra as the
-  oracle precisely because it is correct and fast.
-- **BMSSP's asymptotics are real and visible:** on sparse graphs the wall-clock
-  gap narrows steadily with n (2.5× at 50k nodes → 1.57× at 2M), and in the
-  paper's own metric — comparisons between path lengths — **BMSSP does fewer
-  comparisons than Dijkstra from about n = 1M**, improving with size. The
-  sorting barrier is measurably broken; the remaining loss is constant factors.
-- **Shapes that blunt BMSSP's edge:** `dense-random` (relaxation-bound, nothing
-  to save), `chain` (depth, not sorting, is the cost), and `star` (extreme
-  fanout — currently a real performance defect, tracked in #182).
+  measured (algorithm-only timing, ~1.6–3× on sparse graphs, more on
+  dense/chain/star). `bmssp-js` itself uses Dijkstra as the oracle precisely
+  because it is correct and fast.
+- **BMSSP's asymptotics are real and visible:** on sparse graphs the
+  wall-clock gap narrows with n (2.5× at 50k → 1.57× at 2M in the 1.0.0
+  record), and in the paper's own metric the harness's count mode shows the
+  ratio crossing below 1.0: 1.20× at 50k → 1.03× at 200k → **0.98× at 1M**
+  (0.91× at 2M in the record). The sorting barrier is measurably broken; the
+  remaining loss is constant factors.
+- **Shapes that blunt BMSSP's edge, per the harness:** `dense-random`
+  (relaxation-bound, ~4.8×), `chain` (depth, not sorting, is the cost —
+  ~8.9× against the prebuilt-adjacency baseline), `star` (extreme fanout,
+  ~8.7× already at 50k — the #182 defect), and the `topLevel` 3→4 window
+  (`sparse-random-l4`: 3.11× at 300k, against the narrowing trend on either
+  side — the #182 level-transition cliff, a regression sentinel).
 
 **Bottom line for this repo:** BMSSP is implemented here for **correctness and
 readability** — a faithful, tested rendering of the 2025 result. Pick Dijkstra
 for real workloads; reach for BMSSP to study the algorithm. The measured
-crossover in comparison counts (#170 tracks putting it in the harness) is the
+crossover in comparison counts — now one `npm run bench:counts` away — is the
 honest demonstration of the paper's claim.

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -1,6 +1,6 @@
 # bmssp-js benchmark run
 
-_Generated 2026-07-15T17:22:57.519Z · node v26.5.0 · darwin/arm64_
+_Generated 2026-07-21T07:44:53.485Z · node v26.5.0 · darwin/arm64_
 
 ## Adjacency map vs linear scan (#45)
 
@@ -8,17 +8,31 @@ Graph: 20000 nodes, 80000 edges · 5000 random per-node edge lookups.
 
 | method | median ms | per lookup µs |
 | --- | --- | --- |
-| linear scan (pre-#45) | 376.33 | 75.27 |
-| adjacency map (#45) | 0.12 | 0.02 |
+| linear scan (pre-#45) | 415.92 | 83.18 |
+| adjacency map (#45) | 0.13 | 0.03 |
 
-**Speedup: 3149.2x** faster per-node lookups with the map.
+**Speedup: 3295.5x** faster per-node lookups with the map.
 
-## Graph-shape scenarios (Dijkstra baseline)
+## Graph-shape scenarios — BMSSP vs Dijkstra (#170)
 
-| scenario | nodes | edges | construct ms | dijkstra ms | notes |
-| --- | --- | --- | --- | --- | --- |
-| sparse-random | 50000 | 150000 | 20.68 | 45.72 | m = O(n), degree 3 — the road-network regime |
-| dense-random | 8000 | 256000 | 18.53 | 14.89 | avg degree 32 — edge-relaxation-bound |
-| grid-4nbr | 40000 | 159200 | 13.84 | 26.18 | 200x200 lattice — large diameter, low degree |
-| chain | 50000 | 49999 | 8.65 | 8.96 | single long path — worst-case depth |
-| star | 50000 | 99998 | 14.46 | 38.45 | one hub, n-1 spokes — extreme degree skew |
+Algorithm time only: both sides consume the same prebuilt adjacency Map; `mismatches` must read 0 (outputs verified node-by-node every run).
+
+| scenario | nodes | edges | construct ms | dijkstra ms | bmssp ms | ratio | mismatches | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| sparse-random | 50000 | 150000 | 31.36 | 36.72 | 102.29 | 2.79x | 0 | m = O(n), degree 3 — the road-network regime |
+| dense-random | 8000 | 256000 | 19.15 | 14.02 | 67.88 | 4.84x | 0 | avg degree 32 — edge-relaxation-bound |
+| grid-4nbr | 40000 | 159200 | 14.44 | 18.70 | 76.75 | 4.10x | 0 | 200x200 lattice — large diameter, low degree |
+| chain | 50000 | 49999 | 8.26 | 5.14 | 45.56 | 8.87x | 0 | single long path — worst-case depth |
+| star | 50000 | 99998 | 10.55 | 35.21 | 307.51 | 8.73x | 0 | one hub, n-1 spokes — extreme degree skew (#182) |
+| sparse-random-l4 | 300000 | 900000 | 183.69 | 419.20 | 1305.50 | 3.11x | 0 | n just past the topLevel 3→4 step at n = 2^18 (#182) |
+
+## Comparison counts — the sorting barrier, measured (#170)
+
+Comparisons between path lengths (the paper's cost metric), one exact run per side. On sparse graphs the ratio falls with n and crosses below 1.0 between n = 200k and n = 1M.
+
+| case | nodes | edges | dijkstra cmps | bmssp cmps | ratio | mismatches |
+| --- | --- | --- | --- | --- | --- | --- |
+| sparse d3 n=50k | 50000 | 150000 | 1,653,644 | 1,976,506 | 1.20x | 0 |
+| sparse d3 n=200k | 200000 | 600000 | 7,509,518 | 7,720,650 | 1.03x | 0 |
+| sparse d3 n=1M | 1000000 | 3000000 | 42,809,732 | 42,123,299 | 0.98x | 0 |
+| grid 700x700 | 490000 | 1957200 | 15,269,647 | 19,330,072 | 1.27x | 0 |

--- a/benchmarks/compare-counts.bench.mjs
+++ b/benchmarks/compare-counts.bench.mjs
@@ -1,0 +1,101 @@
+// Benchmark: comparison counts — the sorting barrier, measured (#170).
+//
+// The paper's cost model counts comparisons between path lengths, not
+// wall-clock time. This mode runs each case once per algorithm and reports
+// how many distance comparisons each side performed:
+//   - bmssp: every compareKeys call (src/tieBreak.mjs counter) — the heap,
+//     the BlockList and the algorithm modules all funnel through it
+//   - dijkstra: every numeric distance comparison in the prebuilt-adjacency
+//     variant (benchmarks/dijkstra-adj.mjs counter)
+//
+// Counts are deterministic (seeded graphs), so a single run per side is
+// exact. On sparse graphs the bmssp/dijkstra ratio falls with n and crosses
+// below 1.0 between n = 200k and n = 1M — the measured form of the paper's
+// asymptotic claim (see benchmarks/HEAD-TO-HEAD.md for the 1.0.0 record).
+
+import { BMSSP } from "../src/bmssp.mjs";
+import { resetComparisonCount, getComparisonCount } from "../src/tieBreak.mjs";
+import {
+  dijkstraAdjacency,
+  resetDijkstraComparisonCount,
+  getDijkstraComparisonCount,
+} from "./dijkstra-adj.mjs";
+import { sparseRandom, grid } from "./generators.mjs";
+import { markdownTable } from "./bench-util.mjs";
+
+// Sized to reproduce the crossover table in a couple of tens of seconds:
+// sparse d3 at 50k / 200k / 1M brackets the crossover; the grid shows a
+// shape where BMSSP stays behind. (The 1.0.0 record also has sparse 2M at
+// 0.91x — left out here to keep the opt-in mode reasonably fast.)
+export const COUNT_CASES = [
+  {
+    name: "sparse d3 n=50k",
+    build: () => sparseRandom(50_000, 3, 11),
+  },
+  {
+    name: "sparse d3 n=200k",
+    build: () => sparseRandom(200_000, 3, 21),
+  },
+  {
+    name: "sparse d3 n=1M",
+    build: () => sparseRandom(1_000_000, 3, 22),
+  },
+  {
+    name: "grid 700x700",
+    build: () => grid(700, 23),
+  },
+];
+
+export function runComparisonCountBenchmark(cases = COUNT_CASES) {
+  const rows = [];
+  for (const testCase of cases) {
+    const graph = testCase.build();
+    const bmssp = new BMSSP(graph);
+    const source = [...bmssp.nodeIDs][0];
+
+    resetDijkstraComparisonCount();
+    const dijkstraDist = dijkstraAdjacency(
+      bmssp.adjacency,
+      bmssp.nodeIDs,
+      source,
+    );
+    const dijkstraComparisons = getDijkstraComparisonCount();
+
+    resetComparisonCount();
+    bmssp.calculateShortestPaths(source);
+    const bmsspComparisons = getComparisonCount();
+
+    let mismatches = 0;
+    for (const id of bmssp.nodeIDs) {
+      if (dijkstraDist.get(id) !== bmssp.shortestPaths.get(id)) {
+        mismatches += 1;
+      }
+    }
+
+    rows.push({
+      case: testCase.name,
+      nodes: bmssp.nodeIDs.size,
+      edges: graph.length,
+      "dijkstra cmps": dijkstraComparisons.toLocaleString("en-US"),
+      "bmssp cmps": bmsspComparisons.toLocaleString("en-US"),
+      ratio: `${(bmsspComparisons / dijkstraComparisons).toFixed(2)}x`,
+      mismatches,
+    });
+  }
+
+  return {
+    table: markdownTable(
+      [
+        "case",
+        "nodes",
+        "edges",
+        "dijkstra cmps",
+        "bmssp cmps",
+        "ratio",
+        "mismatches",
+      ],
+      rows,
+    ),
+    rows,
+  };
+}

--- a/benchmarks/dijkstra-adj.mjs
+++ b/benchmarks/dijkstra-adj.mjs
@@ -1,0 +1,103 @@
+// Algorithm-only Dijkstra over a prebuilt adjacency map — the fair baseline
+// for the BMSSP head-to-head (#170).
+//
+// The shipped `dijkstra()` builds its own adjacency list inside the call;
+// that is graph loading, not algorithm work. This variant consumes the same
+// `adjacency` Map a BMSSP instance already holds (`from -> [[to, weight]]`),
+// so the timed window contains only the heap traversal on both sides —
+// matching the methodology of benchmarks/HEAD-TO-HEAD.md.
+//
+// Every comparison between two distance values (heap sifts, the stale-pop
+// check, edge relaxations) bumps a module-level counter, mirroring the
+// unconditional compareKeys counter on the BMSSP side (src/tieBreak.mjs).
+
+let comparisonCount = 0;
+
+/** Reset the distance-comparison counter to zero. */
+export function resetDijkstraComparisonCount() {
+  comparisonCount = 0;
+}
+
+/**
+ * Number of distance comparisons since the last reset.
+ * @returns {number}
+ */
+export function getDijkstraComparisonCount() {
+  return comparisonCount;
+}
+
+/**
+ * Single-source shortest paths over a prebuilt adjacency map.
+ * @param {Map<number, Array<[number, number]>>} adjacency - from -> [[to, weight]]
+ * @param {Set<number>} nodeIDs - All node IDs (each gets a distance)
+ * @param {number} source - Source node ID (must be in nodeIDs)
+ * @returns {Map<number, number>} node ID -> shortest distance (Infinity if unreachable)
+ */
+export function dijkstraAdjacency(adjacency, nodeIDs, source) {
+  if (!nodeIDs.has(source)) {
+    throw new Error("Source node not found in nodeIDs");
+  }
+  const dist = new Map();
+  for (const id of nodeIDs) {
+    dist.set(id, Infinity);
+  }
+  dist.set(source, 0);
+
+  const heap = [[0, source]];
+
+  function heapPush(d, v) {
+    heap.push([d, v]);
+    let i = heap.length - 1;
+    while (i > 0) {
+      const p = (i - 1) >> 1;
+      comparisonCount += 1;
+      if (heap[p][0] <= heap[i][0]) break;
+      [heap[p], heap[i]] = [heap[i], heap[p]];
+      i = p;
+    }
+  }
+
+  function heapPop() {
+    const top = heap[0];
+    const last = heap.pop();
+    if (heap.length === 0) return top;
+    heap[0] = last;
+    let i = 0;
+    const n = heap.length;
+    while (true) {
+      let smallest = i;
+      const left = 2 * i + 1;
+      const right = 2 * i + 2;
+      if (left < n) {
+        comparisonCount += 1;
+        if (heap[left][0] < heap[smallest][0]) smallest = left;
+      }
+      if (right < n) {
+        comparisonCount += 1;
+        if (heap[right][0] < heap[smallest][0]) smallest = right;
+      }
+      if (smallest === i) break;
+      [heap[i], heap[smallest]] = [heap[smallest], heap[i]];
+      i = smallest;
+    }
+    return top;
+  }
+
+  while (heap.length > 0) {
+    const [d, u] = heapPop();
+    comparisonCount += 1;
+    if (d > dist.get(u)) continue;
+    const neighbors = adjacency.get(u);
+    if (!neighbors) continue;
+    for (const [to, weight] of neighbors) {
+      const alt = d + weight;
+      comparisonCount += 1;
+      if (alt < dist.get(to)) {
+        dist.set(to, alt);
+        heapPush(alt, to);
+      }
+    }
+  }
+
+  return dist;
+}

--- a/benchmarks/generators.mjs
+++ b/benchmarks/generators.mjs
@@ -125,7 +125,12 @@ export const SCENARIOS = [
   },
   {
     name: "star",
-    blurb: "one hub, n-1 spokes — extreme degree skew",
+    blurb: "one hub, n-1 spokes — extreme degree skew (#182)",
     build: () => star(50_000, 15),
+  },
+  {
+    name: "sparse-random-l4",
+    blurb: "n just past the topLevel 3→4 step at n = 2^18 (#182)",
+    build: () => sparseRandom(300_000, 3, 16),
   },
 ];

--- a/benchmarks/run.mjs
+++ b/benchmarks/run.mjs
@@ -1,13 +1,18 @@
 // Entry point: run every benchmark and print a markdown report to stdout.
 //
 //   node benchmarks/run.mjs            # human-readable report
+//   node benchmarks/run.mjs --counts   # also run the comparison-count mode
 //   node benchmarks/run.mjs > RESULTS.md
 //
 // All benchmarks are deterministic (seeded generators), so re-running on the
-// same machine yields stable numbers.
+// same machine yields stable numbers; the --counts tables are exact and
+// machine-independent.
 
 import { runAdjacencyBenchmark } from "./adjacency.bench.mjs";
 import { runScenarioBenchmark } from "./scenarios.bench.mjs";
+import { runComparisonCountBenchmark } from "./compare-counts.bench.mjs";
+
+const withCounts = process.argv.includes("--counts");
 
 function section(title) {
   return `\n## ${title}\n`;
@@ -30,8 +35,23 @@ out.push(
 );
 
 const scen = runScenarioBenchmark();
-out.push(section("Graph-shape scenarios (Dijkstra baseline)"));
+out.push(section("Graph-shape scenarios — BMSSP vs Dijkstra (#170)"));
+out.push(
+  "Algorithm time only: both sides consume the same prebuilt adjacency Map;" +
+    " `mismatches` must read 0 (outputs verified node-by-node every run).\n",
+);
 out.push(scen.table);
+
+if (withCounts) {
+  const counts = runComparisonCountBenchmark();
+  out.push(section("Comparison counts — the sorting barrier, measured (#170)"));
+  out.push(
+    "Comparisons between path lengths (the paper's cost metric), one exact" +
+      " run per side. On sparse graphs the ratio falls with n and crosses" +
+      " below 1.0 between n = 200k and n = 1M.\n",
+  );
+  out.push(counts.table);
+}
 
 const report = out.join("\n");
 console.log(report);

--- a/benchmarks/scenarios.bench.mjs
+++ b/benchmarks/scenarios.bench.mjs
@@ -1,32 +1,62 @@
-// Benchmark: graph-shape scenarios.
+// Benchmark: graph-shape scenarios — the BMSSP-vs-Dijkstra head-to-head (#170).
 //
-// For each scenario we measure:
+// For each scenario we measure, algorithm time only (graph generation and
+// adjacency construction sit outside every timed window):
 //   - construct: building the BMSSP instance (includes the #45 adjacency map)
-//   - dijkstra: one full single-source shortest-path run from node 0
+//   - dijkstra: one full run of the prebuilt-adjacency Dijkstra variant
+//     (benchmarks/dijkstra-adj.mjs) — the fair baseline
+//   - bmssp: one full BMSSP.calculateShortestPaths() run
 //
-// This is the Dijkstra baseline column of the head-to-head. The real BMSSP
-// recursion landed in 1.0.0 (#43); adding an algorithm-only bmssp column (and
-// an optional comparison-count mode) is tracked in #170. Measured results so
-// far: benchmarks/HEAD-TO-HEAD.md.
+// Both algorithms run from the same source over the same adjacency Map, and
+// their outputs are verified identical every run (the `mismatches` column
+// must read 0). Methodology and the measured 1.0.0 numbers:
+// benchmarks/HEAD-TO-HEAD.md.
 
 import { BMSSP } from "../src/bmssp.mjs";
-import { dijkstra } from "../src/dijkstra.mjs";
+import { dijkstraAdjacency } from "./dijkstra-adj.mjs";
 import { SCENARIOS } from "./generators.mjs";
 import { timeMany, markdownTable, fmt } from "./bench-util.mjs";
 
-export function runScenarioBenchmark() {
+// Count nodes whose distances differ between the two result maps.
+function countMismatches(dijkstraDist, bmsspDist, nodeIDs) {
+  let mismatches = 0;
+  for (const id of nodeIDs) {
+    if (dijkstraDist.get(id) !== bmsspDist.get(id)) mismatches += 1;
+  }
+  return mismatches;
+}
+
+export function runScenarioBenchmark(scenarios = SCENARIOS, iters = 3) {
   const rows = [];
-  for (const scenario of SCENARIOS) {
+  for (const scenario of scenarios) {
     const graph = scenario.build();
 
-    const construct = timeMany(() => new BMSSP(graph), { iters: 3, warmup: 1 });
+    const construct = timeMany(() => new BMSSP(graph), { iters, warmup: 1 });
 
     const bmssp = new BMSSP(graph);
     const source = [...bmssp.nodeIDs][0];
-    const dij = timeMany(() => dijkstra(graph, bmssp.nodeIDs, source), {
-      iters: 3,
+
+    const dij = timeMany(
+      () => dijkstraAdjacency(bmssp.adjacency, bmssp.nodeIDs, source),
+      { iters, warmup: 1 },
+    );
+    const alg = timeMany(() => bmssp.calculateShortestPaths(source), {
+      iters,
       warmup: 1,
     });
+
+    // Verify: fresh run on each side, distances must agree node-by-node.
+    const dijkstraDist = dijkstraAdjacency(
+      bmssp.adjacency,
+      bmssp.nodeIDs,
+      source,
+    );
+    bmssp.calculateShortestPaths(source);
+    const mismatches = countMismatches(
+      dijkstraDist,
+      bmssp.shortestPaths,
+      bmssp.nodeIDs,
+    );
 
     rows.push({
       scenario: scenario.name,
@@ -34,13 +64,26 @@ export function runScenarioBenchmark() {
       edges: graph.length,
       "construct ms": fmt(construct.median),
       "dijkstra ms": fmt(dij.median),
+      "bmssp ms": fmt(alg.median),
+      ratio: `${(alg.median / dij.median).toFixed(2)}x`,
+      mismatches,
       notes: scenario.blurb,
     });
   }
 
   return {
     table: markdownTable(
-      ["scenario", "nodes", "edges", "construct ms", "dijkstra ms", "notes"],
+      [
+        "scenario",
+        "nodes",
+        "edges",
+        "construct ms",
+        "dijkstra ms",
+        "bmssp ms",
+        "ratio",
+        "mismatches",
+        "notes",
+      ],
       rows,
     ),
     rows,

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "scripts": {
     "test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --coverage",
     "bench": "node benchmarks/run.mjs",
+    "bench:counts": "node benchmarks/run.mjs --counts",
     "lint": "npm run prettier && npm run eslint",
     "format": "npm run prettier:fix && npm run eslint:fix",
     "eslint": "eslint --max-warnings=0 .",

--- a/src/tieBreak.mjs
+++ b/src/tieBreak.mjs
@@ -42,6 +42,28 @@
 // source's own label never loses an equal-(length, hops) comparison.
 const NO_PRED = -Infinity;
 
+// Running count of compareKeys calls — the paper's cost metric ("comparisons
+// between path lengths"). Every BMSSP-side comparison funnels through
+// compareKeys (the heap and BlockList receive it as their comparator, and
+// baseCase/findPivots/bmssp call it directly), so this one counter covers the
+// whole algorithm. The benchmark harness (#170) reads it to measure the
+// sorting barrier; one unconditional increment keeps the hot path branch-free.
+let comparisonCount = 0;
+
+/** Reset the compareKeys call counter to zero (benchmark instrumentation). */
+function resetComparisonCount() {
+  comparisonCount = 0;
+}
+
+/**
+ * Number of compareKeys calls since the last reset (benchmark
+ * instrumentation).
+ * @returns {number}
+ */
+function getComparisonCount() {
+  return comparisonCount;
+}
+
 /**
  * Lexicographic comparison of two composite keys.
  * @param {[number, number, *]} a - [length, hops, id]
@@ -49,6 +71,7 @@ const NO_PRED = -Infinity;
  * @returns {number} Negative when a < b, positive when a > b, 0 when equal
  */
 function compareKeys(a, b) {
+  comparisonCount += 1;
   if (a[0] !== b[0]) return a[0] < b[0] ? -1 : 1;
   if (a[1] !== b[1]) return a[1] < b[1] ? -1 : 1;
   if (a[2] !== b[2]) return a[2] < b[2] ? -1 : 1;
@@ -139,4 +162,13 @@ function relaxEdge(u, v, weight, dHat, ties, bound) {
   return { key: [length, hopCount, v], improved: true };
 }
 
-export { compareKeys, toBound, makeTies, orderKey, relaxEdge, NO_PRED };
+export {
+  compareKeys,
+  toBound,
+  makeTies,
+  orderKey,
+  relaxEdge,
+  NO_PRED,
+  resetComparisonCount,
+  getComparisonCount,
+};

--- a/test/benchmarks.test.mjs
+++ b/test/benchmarks.test.mjs
@@ -1,0 +1,117 @@
+import { describe, test, expect } from "@jest/globals";
+import { BMSSP } from "../src/bmssp.mjs";
+import { dijkstra } from "../src/dijkstra.mjs";
+import {
+  dijkstraAdjacency,
+  resetDijkstraComparisonCount,
+  getDijkstraComparisonCount,
+} from "../benchmarks/dijkstra-adj.mjs";
+import { runScenarioBenchmark } from "../benchmarks/scenarios.bench.mjs";
+import { runComparisonCountBenchmark } from "../benchmarks/compare-counts.bench.mjs";
+import { sparseRandom, chain, star } from "../benchmarks/generators.mjs";
+
+describe("dijkstraAdjacency (#170): the fair prebuilt-adjacency baseline", () => {
+  test("matches the shipped dijkstra on seeded random graphs", () => {
+    for (const seed of [1, 2, 3]) {
+      const graph = sparseRandom(300, 3, seed);
+      const bmssp = new BMSSP(graph);
+      const source = [...bmssp.nodeIDs][0];
+      const expected = dijkstra(graph, bmssp.nodeIDs, source);
+      const actual = dijkstraAdjacency(bmssp.adjacency, bmssp.nodeIDs, source);
+      expect(actual.size).toBe(expected.size);
+      for (const [id, d] of expected) {
+        expect(actual.get(id)).toBe(d);
+      }
+    }
+  });
+
+  test("reports Infinity for unreachable nodes", () => {
+    // 0 -> 1 and an isolated pair 2 -> 3: from 0, nodes 2 and 3 are unreachable
+    const graph = [
+      [0, 1, 4],
+      [2, 3, 1],
+    ];
+    const bmssp = new BMSSP(graph);
+    const dist = dijkstraAdjacency(bmssp.adjacency, bmssp.nodeIDs, 0);
+    expect(dist.get(1)).toBe(4);
+    expect(dist.get(2)).toBe(Infinity);
+    expect(dist.get(3)).toBe(Infinity);
+  });
+
+  test("throws when the source is not in nodeIDs", () => {
+    const bmssp = new BMSSP([[0, 1, 1]]);
+    expect(() => dijkstraAdjacency(bmssp.adjacency, bmssp.nodeIDs, 99)).toThrow(
+      "Source node not found",
+    );
+  });
+
+  test("comparison counter counts and resets", () => {
+    const bmssp = new BMSSP(sparseRandom(100, 3, 7));
+    resetDijkstraComparisonCount();
+    expect(getDijkstraComparisonCount()).toBe(0);
+    dijkstraAdjacency(bmssp.adjacency, bmssp.nodeIDs, 0);
+    expect(getDijkstraComparisonCount()).toBeGreaterThan(0);
+    resetDijkstraComparisonCount();
+    expect(getDijkstraComparisonCount()).toBe(0);
+  });
+
+  test("counts are deterministic for a fixed graph and source", () => {
+    const bmssp = new BMSSP(sparseRandom(200, 3, 9));
+    resetDijkstraComparisonCount();
+    dijkstraAdjacency(bmssp.adjacency, bmssp.nodeIDs, 0);
+    const first = getDijkstraComparisonCount();
+    resetDijkstraComparisonCount();
+    dijkstraAdjacency(bmssp.adjacency, bmssp.nodeIDs, 0);
+    expect(getDijkstraComparisonCount()).toBe(first);
+  });
+});
+
+// Tiny scenarios keep the harness integration tests fast: the point is the
+// report shape and the zero-mismatch verification, not the timings.
+const TINY_SCENARIOS = [
+  {
+    name: "tiny-sparse",
+    blurb: "test scenario",
+    build: () => sparseRandom(200, 3, 41),
+  },
+  { name: "tiny-chain", blurb: "test scenario", build: () => chain(50, 42) },
+  { name: "tiny-star", blurb: "test scenario", build: () => star(60, 43) },
+];
+
+describe("runScenarioBenchmark (#170): head-to-head harness", () => {
+  test("reports both algorithm columns with zero mismatches", () => {
+    const { table, rows } = runScenarioBenchmark(TINY_SCENARIOS, 1);
+    expect(rows).toHaveLength(TINY_SCENARIOS.length);
+    for (const row of rows) {
+      expect(row.mismatches).toBe(0);
+      expect(Number(row["dijkstra ms"])).toBeGreaterThanOrEqual(0);
+      expect(Number(row["bmssp ms"])).toBeGreaterThanOrEqual(0);
+      expect(row.ratio).toMatch(/x$/);
+    }
+    for (const header of ["dijkstra ms", "bmssp ms", "ratio", "mismatches"]) {
+      expect(table).toContain(header);
+    }
+  });
+});
+
+describe("runComparisonCountBenchmark (#170): sorting-barrier counts", () => {
+  test("counts both sides exactly once with zero mismatches", () => {
+    const { table, rows } = runComparisonCountBenchmark([
+      {
+        name: "tiny-sparse",
+        build: () => sparseRandom(300, 3, 44),
+      },
+    ]);
+    expect(rows).toHaveLength(1);
+    const row = rows[0];
+    expect(row.mismatches).toBe(0);
+    // Counts are formatted with thousands separators; strip them to compare
+    const dijkstraComparisons = Number(
+      row["dijkstra cmps"].replaceAll(",", ""),
+    );
+    const bmsspComparisons = Number(row["bmssp cmps"].replaceAll(",", ""));
+    expect(dijkstraComparisons).toBeGreaterThan(0);
+    expect(bmsspComparisons).toBeGreaterThan(0);
+    expect(table).toContain("bmssp cmps");
+  });
+});

--- a/test/tieBreak.test.mjs
+++ b/test/tieBreak.test.mjs
@@ -5,6 +5,8 @@ import {
   makeTies,
   orderKey,
   relaxEdge,
+  resetComparisonCount,
+  getComparisonCount,
 } from "../src/tieBreak.mjs";
 import { BMSSP } from "../src/bmssp.mjs";
 import { dijkstra } from "../src/dijkstra.mjs";
@@ -404,5 +406,40 @@ describe("canonical labels (#163): hops and preds are the lexicographic optimum"
         }
       }
     }
+  });
+});
+
+describe("comparison counter (#170): benchmark instrumentation", () => {
+  test("resets to zero and counts each compareKeys call", () => {
+    resetComparisonCount();
+    expect(getComparisonCount()).toBe(0);
+    compareKeys([1, 0, 0], [2, 0, 0]);
+    compareKeys([1, 0, 0], [1, 0, 0]);
+    expect(getComparisonCount()).toBe(2);
+    resetComparisonCount();
+    expect(getComparisonCount()).toBe(0);
+  });
+
+  test("counts comparisons made inside relaxEdge", () => {
+    const dHat = new Map([
+      [0, 0],
+      [1, Infinity],
+    ]);
+    const ties = makeTies();
+    resetComparisonCount();
+    relaxEdge(0, 1, 5, dHat, ties);
+    expect(getComparisonCount()).toBeGreaterThan(0);
+  });
+
+  test("a full BMSSP run performs comparisons through the counter", () => {
+    const bmssp = new BMSSP([
+      [0, 1, 1],
+      [1, 2, 2],
+      [0, 2, 5],
+    ]);
+    resetComparisonCount();
+    bmssp.calculateShortestPaths(0);
+    expect(getComparisonCount()).toBeGreaterThan(0);
+    expect(bmssp.shortestPaths.get(2)).toBe(3);
   });
 });


### PR DESCRIPTION
Closes #170

## Summary

The benchmark harness now runs the BMSSP-vs-Dijkstra comparison itself, in both metrics, exactly as scoped on the issue:

- **Head-to-head timing columns** — `scenarios.bench.mjs` reports algorithm-only `dijkstra ms` / `bmssp ms` / `ratio` per graph shape. The new `benchmarks/dijkstra-adj.mjs` is the fair baseline: the oracle's lazy-heap Dijkstra reworked to consume the BMSSP instance's prebuilt `adjacency` Map, so neither timed window contains graph loading (HEAD-TO-HEAD methodology). Outputs are verified node-by-node every run — the `mismatches` column must read 0, and does, on every shape.
- **Opt-in comparison-count mode** — `npm run bench:counts` (or `node benchmarks/run.mjs --counts`). BMSSP side: an unconditional counter in `src/tieBreak.mjs`'s `compareKeys` — the heap and BlockList receive it as their comparator and the algorithm modules call it directly, so one counter covers every path-length comparison. Dijkstra side: matching counters in `dijkstra-adj.mjs` (heap sifts, stale-pop checks, relaxations). Counts are deterministic (one exact run per side) and reproduce the crossover: **sparse 1.20× at 50k → 1.03× at 200k → 0.98× at 1M** (record: 0.91× at 2M).
- **#182 regression sentinels** — new `sparse-random-l4` scenario: n = 300k sits inside the `topLevel` 3→4 window that starts at exactly n = 2^18 + 1 (and closes ~376k where t reaches 7). Fresh capture shows the transition cliff (3.11× vs 2.79× at 50k) and the star pathology already visible at 50k (8.73×). Both rerun on every `npm run bench`.
- Fresh `benchmarks/RESULTS.md` captured (2026-07-21); `HEAD-TO-HEAD.md` marked as the frozen 1.0.0 record; `benchmarks/README.md` rewritten around the integrated harness.

**No version bump** — issue-closing but not a bug fix, and #167/#168/#182 remain open in milestone 1.2.0.

Also carries the previous session's Phase E marker flips in knowledge `05`/`06` (1.1.0 released, milestone closed) per branch protection.

## Tests / lint

- `npm test`: 12 suites, **157 tests — 156 passed + 1 XL skipped** (10 new: 7 harness tests in `test/benchmarks.test.mjs`, 3 counter tests in `test/tieBreak.test.mjs`).
- `npm run lint`: clean.

## Roadmap proposals

1. **Comment on #182** with the harness's small-n reproductions so the investigation can iterate in seconds instead of minutes: star is already 8.7× at n = 50k, and the `topLevel` 3→4 transition is reachable at n = 300k via `sparse-random-l4` (window: n ∈ (2^18, ~376k]). Both are standing regression sentinels in `npm run bench`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)