### PR TITLE
test: cover the mismatch branch in the benchmark harness (100% coverage)

### DIFF
--- a/.claude/knowledge/05-codebase-map.md
+++ b/.claude/knowledge/05-codebase-map.md
@@ -1,16 +1,14 @@
 # 05 — Codebase Map (current state)
 
-<!-- BOOKMARK-COMMIT: d7d3080 -->
-<!-- PENDING-PR-BRANCH: feat/170-bmssp-dijkstra-benchmark -->
-<!-- Last validated: 2026-07-21 (Phase C of the #170 PR). Describes the tree as it will
-     exist once that PR merges: the benchmark harness runs the BMSSP-vs-Dijkstra
-     head-to-head itself (bmssp column + verified outputs in scenarios.bench.mjs, new
-     dijkstra-adj.mjs fair baseline, opt-in comparison-count mode via `npm run
-     bench:counts`), a comparison counter in src/tieBreak.mjs, a sparse-random-l4
-     level-transition scenario, and a fresh RESULTS.md. No bump (issue-closing, not a
-     bug fix, not 1.2.0's last issue). This file also carries the previous session's
-     Phase E marker flip (1.1.0 released 2026-07-21, milestone closed) that rides this
-     branch per branch protection. -->
+<!-- BOOKMARK-COMMIT: a1a9ef5 -->
+<!-- PENDING-PR-BRANCH: test/compare-counts-mismatch-coverage -->
+<!-- Last validated: 2026-07-21 (Phase C of the coverage PR, same session as the #170
+     PR/Phase E). Describes the tree as it will exist once that PR merges: the mismatch
+     counter extracted to bench-util.mjs countMismatches (shared by scenarios + counts
+     benchmarks) and unit-tested on both branches — compare-counts.bench.mjs and
+     scenarios.bench.mjs at 100% statement+branch coverage; suite 159. User-directed,
+     closes no issue, no bump. Also carries the #170 Phase E facts: PR #198 merged as
+     a1a9ef5, no release (1.1.0 == tag), #182 reproductions comment posted. -->
 
 Snapshot of what exists in `bmssp-js` today, so you know what to build on vs. what's missing.
 
@@ -81,11 +79,11 @@ test/
   heap.test.mjs           # #41: 16 MinHeap tests incl. a seeded stress test vs. a naive queue
   baseCase.test.mjs       # #40: 13 BaseCase tests incl. seeded oracle-comparison stress
   findPivots.test.mjs     # #44: 12 FindPivots tests incl. two seeded oracle stress tests
-  benchmarks.test.mjs     # #170: 7 harness tests — dijkstra-adj vs shipped oracle, counters, tiny-scenario report shape + zero mismatches
+  benchmarks.test.mjs     # #170: 9 harness tests — dijkstra-adj vs shipped oracle, counters, countMismatches both branches, tiny-scenario report shape + zero mismatches
   README.md               # test-suite principles (everything seeded, no data files) + file map
 benchmarks/               # dependency-free benchmark harness, `npm run bench` / `npm run bench:counts`
   generators.mjs          #   seeded graph builders + SCENARIOS registry (sparse/dense/grid/chain/star/sparse-l4)
-  bench-util.mjs          #   timing (timeMany) + markdown-table helpers
+  bench-util.mjs          #   timing (timeMany), markdown-table + countMismatches helpers
   adjacency.bench.mjs     #   adjacency map (#45) vs. linear edge scan
   scenarios.bench.mjs     #   #170: head-to-head per shape — construct + dijkstra + bmssp timings, verified outputs
   dijkstra-adj.mjs        #   #170: algorithm-only Dijkstra over prebuilt adjacency + comparison counter (fair baseline)
@@ -409,12 +407,14 @@ edge-order deterministic (copies allocated in edge order); ~2m copies, ~3m edges
   **opt-in `FUZZ_XL=1` sparse n = 2M round** (~33 s, `test.skip` otherwise). Every failure
   message carries the round's seed for reproduction. **`FUZZ_ROUNDS=<x>`** multiplies all
   round counts (default 1 ≈ 0.5 s; 25 ≈ 10 s, several thousand graphs).
-- `test/benchmarks.test.mjs` (7, #170): the harness itself. `dijkstraAdjacency` equals the
+- `test/benchmarks.test.mjs` (9, #170): the harness itself. `dijkstraAdjacency` equals the
   shipped `dijkstra` on seeded graphs, reports Infinity for unreachable nodes, rejects an
   unknown source; both comparison counters count, reset, and are deterministic for a fixed
-  graph; `runScenarioBenchmark` and `runComparisonCountBenchmark` on tiny injected
-  scenarios return the expected columns with **zero mismatches**.
-- Current suite: **157 tests — 156 passing + 1 XL skipped by default**, ~100% statement
+  graph; `countMismatches` (shared via `bench-util.mjs`) unit-tested on both branches
+  (identical maps incl. Infinity → 0; wrong/missing entries counted); `runScenarioBenchmark`
+  and `runComparisonCountBenchmark` on tiny injected scenarios return the expected columns
+  with **zero mismatches**.
+- Current suite: **159 tests — 158 passing + 1 XL skipped by default**, ~100% statement
   coverage, ~7.5 s wall-clock (the #164 distance-preservation sweeps run BMSSP/Dijkstra
   from every source). No graph data files: every generated test graph comes from a
   seed; the #162 fixtures are hand-built and fully deterministic.
@@ -457,9 +457,10 @@ BMSSP-vs-Dijkstra head-to-head itself:
 | Constructor input validation | `BMSSP` constructor + `test/main.test.mjs` | #165 | ✅ merged (PR #191, no bump) |
 | Optional constant-degree transform (in/out-degree ≤ 2) | `src/constantDegree.mjs` + `test/constantDegree.test.mjs` | #164 | ✅ merged (PR #195, no bump) |
 | JSDoc on `index.mjs` exports + public-API docs page | `index.mjs` + `docs/index.html` | #166 | ✅ merged (PR #196, **minor → 1.1.0**, released 2026-07-21) |
-| BMSSP-vs-Dijkstra head-to-head in the harness | `benchmarks/` + `src/tieBreak.mjs` counter | #170 | ✅ done-pending-merge (this PR, no bump) |
+| BMSSP-vs-Dijkstra head-to-head in the harness | `benchmarks/` + `src/tieBreak.mjs` counter | #170 | ✅ merged (PR #198, no bump) |
 
 Milestone `1.1.0` (correctness hardening) is **closed** — released 2026-07-21 (npm +
-Docker Hub). Milestone `1.2.0` is the current focus: after #170 merges, #182
-(performance-cliff investigation, now armed with the harness's small-n reproductions)
-is next, then #167/#168; see [06-milestones-roadmap.md](06-milestones-roadmap.md).
+Docker Hub). Milestone `1.2.0` is the current focus: **#182 is next** (performance-cliff
+investigation, armed with the harness's small-n reproductions — see the 2026-07-21
+comment on the issue), then #167/#168; see
+[06-milestones-roadmap.md](06-milestones-roadmap.md).

--- a/.claude/knowledge/06-milestones-roadmap.md
+++ b/.claude/knowledge/06-milestones-roadmap.md
@@ -1,8 +1,8 @@
 # 06 — Milestones Roadmap
 
-<!-- SYNCED-FROM-GITHUB: 2026-07-21 Phase C of the #170 PR (verified live: milestone 1.1.0
-     CLOSED 6/6; 1.2.0 open with 4 open issues #167/#168/#170/#182; 2.0.0 open with 3
-     open issues #171/#172/#173; #170 is done-pending-merge in this PR) -->
+<!-- SYNCED-FROM-GITHUB: 2026-07-21 Phase E of the #170 PR (#170 closed by merged PR #198,
+     commit a1a9ef5; 1.2.0 open with 3 open issues #167/#168/#182; 2.0.0 open with 3
+     open issues #171/#172/#173; no release — no bump, package.json 1.1.0 == tag) -->
 <!-- Current package version: 1.1.0 — released 2026-07-21 (tag + GitHub Release with
      Announcements discussion #197 → npm + Docker Hub via publish.yml); tag matches -->
 <!-- Release-discussion convention (user-directed 2026-07-21): every GitHub Release also
@@ -43,15 +43,11 @@ it runs the same Phase C reconciliation directly on `main`.
 
 ## 📋 Roadmap proposals (pending user approval)
 
-From the #170 PR (Phase C, 2026-07-21):
+_None pending._
 
-1. **Comment on #182** with the harness's small-n reproductions so the investigation can
-   iterate in seconds instead of minutes: the star pathology is already 8.7× at n = 50k
-   (`star` scenario), and the `topLevel` 3→4 transition is reachable at n = 300k
-   (`sparse-random-l4`: 3.11× vs 2.79× at 50k — the window is exactly n ∈ (2^18, ~376k],
-   where t is still 6; t reaches 7 at ~n = 376k and topLevel drops back to 3). Both are
-   now standing regression sentinels in `npm run bench`.
-
+_(The #170-PR proposal — comment on **#182** with the harness's small-n reproductions —
+was approved and executed 2026-07-21: star 8.7× at n = 50k, `sparse-random-l4` 3.11× at
+n = 300k inside the topLevel 3→4 window n ∈ (2^18, ~376k].)_
 _(The #166-PR proposal — close milestone `1.1.0` — was approved and executed 2026-07-21:
 milestone #2 is closed on GitHub with 6/6 issues done.)_
 
@@ -110,17 +106,24 @@ executed 2026-07-17.)_
 - **Milestone `1.2.0` — performance & ergonomics** (in progress). **#169 merged**
   (PR #189): public `BMSSP.reconstructPath(target)` walks the existing canonical
   predecessor map, with independent path-oracle coverage and public usage docs.
-- **#170 done-pending-merge (this PR, 2026-07-21):** the harness runs the head-to-head
-  itself. `scenarios.bench.mjs` gains algorithm-only `dijkstra ms`/`bmssp ms`/`ratio`
-  columns (both sides on the instance's prebuilt adjacency via the new
-  `benchmarks/dijkstra-adj.mjs`; outputs verified, `mismatches` column must be 0) plus a
-  `sparse-random-l4` scenario (n = 300k — inside the `topLevel` 3→4 window that starts at
-  n = 2^18 + 1). Opt-in `npm run bench:counts` (`compare-counts.bench.mjs`) reproduces
-  the comparison-count crossover exactly (sparse 1.20× at 50k → 1.03× at 200k → **0.98×
-  at 1M**) via an unconditional `compareKeys` counter in `src/tieBreak.mjs` and matching
-  counters in the bench Dijkstra. 7 new harness tests + 3 counter tests (suite 157).
-  Fresh `RESULTS.md` captured; `HEAD-TO-HEAD.md` marked as the frozen 1.0.0 record.
-  No bump (not a bug fix; #167/#168/#182 still open in 1.2.0).
+- **#170 merged (PR #198, 2026-07-21, commit a1a9ef5):** the harness runs the
+  head-to-head itself. `scenarios.bench.mjs` gained algorithm-only
+  `dijkstra ms`/`bmssp ms`/`ratio` columns (both sides on the instance's prebuilt
+  adjacency via the new `benchmarks/dijkstra-adj.mjs`; outputs verified, `mismatches`
+  column must be 0) plus a `sparse-random-l4` scenario (n = 300k — inside the `topLevel`
+  3→4 window that starts at n = 2^18 + 1). Opt-in `npm run bench:counts`
+  (`compare-counts.bench.mjs`) reproduces the comparison-count crossover exactly (sparse
+  1.20× at 50k → 1.03× at 200k → **0.98× at 1M**) via an unconditional `compareKeys`
+  counter in `src/tieBreak.mjs` and matching counters in the bench Dijkstra. 7 new
+  harness tests + 3 counter tests (suite 157). Fresh `RESULTS.md` captured;
+  `HEAD-TO-HEAD.md` marked as the frozen 1.0.0 record. No bump, no release. The Phase E
+  proposal (comment on #182 with the small-n reproductions) was approved and posted the
+  same day.
+- **Coverage follow-up (user-directed, 2026-07-21, no issue, no bump):** the harness's
+  mismatch counter extracted to `bench-util.mjs` `countMismatches` (shared by
+  `scenarios.bench.mjs` and `compare-counts.bench.mjs`) and unit-tested on both branches,
+  closing the uncovered defensive lines in `compare-counts.bench.mjs` — both benchmark
+  modules now at 100% statement+branch coverage (suite 159).
 - **Semver release convention (user-directed 2026-07-17, PR #186):** bumps only on bug
   fix (patch) or milestone-closing PR (minor/major) — see "Release mechanics" below.
 - **2026-07-16 reflection session (post-release):** measured the BMSSP-vs-Dijkstra
@@ -167,16 +170,16 @@ All six issues done (build order as executed — cheapest protection first, then
 
 ## Milestone `1.2.0` (milestone #3) — performance & ergonomics — CURRENT
 
-Build order: ~~#170~~ (done-pending-merge), then **#182** (use the harness's small-n
-reproductions to investigate the two measured cliffs), then **#167 / #168** (the
-optimizations the investigation informs).
+Build order: ~~#170~~ (merged, PR #198), then **#182** (use the harness's small-n
+reproductions — see the 2026-07-21 issue comment — to investigate the two measured
+cliffs), then **#167 / #168** (the optimizations the investigation informs).
 
 | # | Issue | Labels | Notes |
 |---|---|---|---|
 | 167 | Restore Lemma 3.3's exact asymptotics in BlockList (balanced-BST bound index + linear-time selection) | enhancement · help wanted | — |
 | 168 | Adjacency and relaxation micro-optimizations | enhancement · help wanted | — |
 | 169 | Optional shortest-path reconstruction (`Pred[]` → paths) | enhancement · help wanted | ✅ merged (PR #189, no bump): public API + independent path oracle |
-| 170 | BMSSP-vs-Dijkstra benchmark comparison | enhancement · help wanted | ✅ done-pending-merge (this PR, no bump): head-to-head + count mode in the harness, verified outputs |
+| 170 | BMSSP-vs-Dijkstra benchmark comparison | enhancement · help wanted | ✅ merged (PR #198, no bump): head-to-head + count mode in the harness, verified outputs |
 | 182 | Investigate BMSSP performance cliffs: high-fanout (star) graphs and recursion-level transitions | enhancement · help wanted | — |
 
 _Note:_ #182 carries the two measured pathologies (star blowup: 67.8× at n = 500k in the

--- a/benchmarks/bench-util.mjs
+++ b/benchmarks/bench-util.mjs
@@ -26,6 +26,17 @@ export function timeMany(fn, { iters = 5, warmup = 1 } = {}) {
   };
 }
 
+// Count nodes whose distances differ between two result maps — the
+// head-to-head's per-run output verification (#170). Any nonzero count in a
+// benchmark report means the two algorithms disagreed on that graph.
+export function countMismatches(expectedDist, actualDist, nodeIDs) {
+  let mismatches = 0;
+  for (const id of nodeIDs) {
+    if (expectedDist.get(id) !== actualDist.get(id)) mismatches += 1;
+  }
+  return mismatches;
+}
+
 // Render an array of row objects as a GitHub-flavored markdown table.
 export function markdownTable(headers, rows) {
   const head = `| ${headers.join(" | ")} |`;

--- a/benchmarks/compare-counts.bench.mjs
+++ b/benchmarks/compare-counts.bench.mjs
@@ -21,7 +21,7 @@ import {
   getDijkstraComparisonCount,
 } from "./dijkstra-adj.mjs";
 import { sparseRandom, grid } from "./generators.mjs";
-import { markdownTable } from "./bench-util.mjs";
+import { markdownTable, countMismatches } from "./bench-util.mjs";
 
 // Sized to reproduce the crossover table in a couple of tens of seconds:
 // sparse d3 at 50k / 200k / 1M brackets the crossover; the grid shows a
@@ -65,12 +65,11 @@ export function runComparisonCountBenchmark(cases = COUNT_CASES) {
     bmssp.calculateShortestPaths(source);
     const bmsspComparisons = getComparisonCount();
 
-    let mismatches = 0;
-    for (const id of bmssp.nodeIDs) {
-      if (dijkstraDist.get(id) !== bmssp.shortestPaths.get(id)) {
-        mismatches += 1;
-      }
-    }
+    const mismatches = countMismatches(
+      dijkstraDist,
+      bmssp.shortestPaths,
+      bmssp.nodeIDs,
+    );
 
     rows.push({
       case: testCase.name,

--- a/benchmarks/scenarios.bench.mjs
+++ b/benchmarks/scenarios.bench.mjs
@@ -15,16 +15,12 @@
 import { BMSSP } from "../src/bmssp.mjs";
 import { dijkstraAdjacency } from "./dijkstra-adj.mjs";
 import { SCENARIOS } from "./generators.mjs";
-import { timeMany, markdownTable, fmt } from "./bench-util.mjs";
-
-// Count nodes whose distances differ between the two result maps.
-function countMismatches(dijkstraDist, bmsspDist, nodeIDs) {
-  let mismatches = 0;
-  for (const id of nodeIDs) {
-    if (dijkstraDist.get(id) !== bmsspDist.get(id)) mismatches += 1;
-  }
-  return mismatches;
-}
+import {
+  timeMany,
+  markdownTable,
+  fmt,
+  countMismatches,
+} from "./bench-util.mjs";
 
 export function runScenarioBenchmark(scenarios = SCENARIOS, iters = 3) {
   const rows = [];

--- a/test/benchmarks.test.mjs
+++ b/test/benchmarks.test.mjs
@@ -8,7 +8,38 @@ import {
 } from "../benchmarks/dijkstra-adj.mjs";
 import { runScenarioBenchmark } from "../benchmarks/scenarios.bench.mjs";
 import { runComparisonCountBenchmark } from "../benchmarks/compare-counts.bench.mjs";
+import { countMismatches } from "../benchmarks/bench-util.mjs";
 import { sparseRandom, chain, star } from "../benchmarks/generators.mjs";
+
+describe("countMismatches (#170): per-run output verification", () => {
+  test("identical maps count zero, including Infinity entries", () => {
+    const nodeIDs = new Set([0, 1, 2]);
+    const a = new Map([
+      [0, 0],
+      [1, 5],
+      [2, Infinity],
+    ]);
+    const b = new Map(a);
+    expect(countMismatches(a, b, nodeIDs)).toBe(0);
+  });
+
+  test("counts every differing node, missing entries included", () => {
+    const nodeIDs = new Set([0, 1, 2, 3]);
+    const expected = new Map([
+      [0, 0],
+      [1, 5],
+      [2, 7],
+      [3, Infinity],
+    ]);
+    const actual = new Map([
+      [0, 0],
+      [1, 6], // wrong distance
+      [2, 7],
+      // 3 missing entirely -> undefined !== Infinity
+    ]);
+    expect(countMismatches(expected, actual, nodeIDs)).toBe(2);
+  });
+});
 
 describe("dijkstraAdjacency (#170): the fair prebuilt-adjacency baseline", () => {
   test("matches the shipped dijkstra on seeded random graphs", () => {


### PR DESCRIPTION
No linked issue — user-directed coverage follow-up to #170 (PR #198). No version bump.

## Summary

`benchmarks/compare-counts.bench.mjs` lines 70–72 (the `mismatches += 1` defensive branch) were uncovered: the branch never fires in tests because BMSSP always agrees with the Dijkstra baseline. Rather than rigging a fake disagreement through the full benchmark, the counter is now directly testable:

- Extracted the duplicated mismatch loop into **`bench-util.mjs` `countMismatches(expected, actual, nodeIDs)`**, shared by `scenarios.bench.mjs` (which had its own private copy with the same uncovered branch) and `compare-counts.bench.mjs`.
- Two new unit tests in `test/benchmarks.test.mjs` exercise both branches: identical maps (including `Infinity` entries) count 0; wrong and missing entries are each counted.

Coverage: `compare-counts.bench.mjs` and `scenarios.bench.mjs` both now read **100% statements + 100% branches**.

Also carries the #170 Phase E bookkeeping in knowledge `05`/`06` (PR #198 merged as `a1a9ef5`, markers flipped, the approved #182 reproductions comment posted) per branch protection.

## Tests / lint

- `npm test`: 12 suites, **159 tests — 158 passed + 1 XL skipped** (2 new).
- `npm run lint`: clean.

## Roadmap proposals

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)