### PR TITLE
fix(#182): quadratic BatchPrepend prepend — star cliff fixed; level cliff measured

### DIFF
--- a/.claude/knowledge/05-codebase-map.md
+++ b/.claude/knowledge/05-codebase-map.md
@@ -1,14 +1,14 @@
 # 05 — Codebase Map (current state)
 
-<!-- BOOKMARK-COMMIT: a1a9ef5 -->
-<!-- PENDING-PR-BRANCH: test/compare-counts-mismatch-coverage -->
-<!-- Last validated: 2026-07-21 (Phase C of the coverage PR, same session as the #170
-     PR/Phase E). Describes the tree as it will exist once that PR merges: the mismatch
-     counter extracted to bench-util.mjs countMismatches (shared by scenarios + counts
-     benchmarks) and unit-tested on both branches — compare-counts.bench.mjs and
-     scenarios.bench.mjs at 100% statement+branch coverage; suite 159. User-directed,
-     closes no issue, no bump. Also carries the #170 Phase E facts: PR #198 merged as
-     a1a9ef5, no release (1.1.0 == tag), #182 reproductions comment posted. -->
+<!-- BOOKMARK-COMMIT: 4891318 -->
+<!-- PENDING-PR-BRANCH: fix/182-performance-cliffs -->
+<!-- Last validated: 2026-07-21 (Phase C of the #182 PR). Describes the tree as it will
+     exist once that PR merges: the #182 cliff investigation. Star cliff root-caused to
+     quadratic per-chunk d0.unshift in BlockList.batchPrepend and FIXED (one concat;
+     star 500k 61s -> ~3.1s, 67.8x -> ~5.5x, superlinearity gone); topLevel 3->4 cliff
+     measured at the exact straddle n = 2^18 -> 2^18+1 as an inherent ~+24% step (one
+     extra full relax pass per level), documented in HEAD-TO-HEAD's #182 addendum.
+     Bug fix -> patch bump 1.1.1 (release in Phase E after merge). -->
 
 Snapshot of what exists in `bmssp-js` today, so you know what to build on vs. what's missing.
 
@@ -75,7 +75,7 @@ test/
   tieBreak.test.mjs       # #163: 16 tests — key order, canonical relaxEdge, edge-order determinism, strict Lemma 3.1, lex-oracle hops/preds
   constantDegree.test.mjs # #164: 11 tests — degree ≤ 2 on hand + seeded shapes (incl. star hub), distance preservation via oracle, BMSSP-on-transform, determinism, empty/validation
   pathReconstruction.test.mjs # #169: 3 public-API tests — Dijkstra path oracle, unreachable/pre-run/source switching, target validation
-  blockList.test.mjs      # #42: 18 BlockList tests incl. a seeded random stress test
+  blockList.test.mjs      # #42: 20 BlockList tests incl. seeded random stress + #182 many-chunk/M=1 batchPrepend regression tests
   heap.test.mjs           # #41: 16 MinHeap tests incl. a seeded stress test vs. a naive queue
   baseCase.test.mjs       # #40: 13 BaseCase tests incl. seeded oracle-comparison stress
   findPivots.test.mjs     # #44: 12 FindPivots tests incl. two seeded oracle stress tests
@@ -171,17 +171,21 @@ make every frontier comparison strict. Consequences, replacing the pre-#163 guar
 4. **Full determinism:** distances, hops, preds, and even partial-call `U`/`boundKey` are
    invariant under edge-list permutation (`test/tieBreak.test.mjs` asserts this).
 
-**Performance (measured 2026-07-16, Apple Silicon, node v26.5.0 — full data + methodology
-in `benchmarks/HEAD-TO-HEAD.md`):** algorithm-only wall-clock (construction excluded,
-Dijkstra fed the same prebuilt adjacency): Dijkstra wins every shape/size; sparse-graph
-ratio narrows with n (2.54× at 50k → **1.57× at 2M**). **Comparison
-counts (the paper's metric) cross over:** BMSSP does fewer distance comparisons than
-Dijkstra past ~n = 1M sparse (0.96× at 1M, **0.91× at 2M**). Two measured pathologies,
-tracked in **#182**: star graphs blow up superlinearly (67.8× at n = 500k) and the ratio
-cliffs to 5× at n = 4M where `topLevel` steps 3→4. Note `topLevel` is **3 from n = 10k
-all the way to 2M** — scale tests buy volume/memory pressure, not recursion depth. The
-default suite runs in ~3 s; the opt-in `FUZZ_XL=1` 2M-node round takes ~33 s (#163's
-composite keys added ~10% over the ~30 s scalar baseline — candidate for #168).
+**Performance (measured 2026-07-16, addendum 2026-07-21; Apple Silicon, node v26.5.0 —
+full data + methodology in `benchmarks/HEAD-TO-HEAD.md`):** algorithm-only wall-clock
+(construction excluded, Dijkstra fed the same prebuilt adjacency): Dijkstra wins every
+shape/size; sparse-graph ratio narrows with n (2.54× at 50k → **1.57× at 2M**).
+**Comparison counts (the paper's metric) cross over:** BMSSP does fewer distance
+comparisons than Dijkstra past ~n = 1M sparse (0.96× at 1M, **0.91× at 2M**). The two
+#182 pathologies were profiled 2026-07-21 (HEAD-TO-HEAD addendum): the **star blowup was
+quadratic `batchPrepend` bookkeeping — fixed in 1.1.1** (500k: 61 s → ~3.1 s, ratio now
+falls with n); the **`topLevel` 3→4 step is an inherent ~+24%** (one extra full relax
+pass per level, measured at the exact n = 2^18 straddle) — the recorded 5× at 4M is that
+step plus GC/memory amplification at 12M edges. Note `topLevel` is **3 from n = 10k to
+2M** (4 only in n ∈ (2^18, ~376k]) — scale tests buy volume/memory pressure, not
+recursion depth. The default suite runs in ~7.5 s; the opt-in `FUZZ_XL=1` 2M-node round
+takes ~33 s (#163's composite keys added ~10% over the ~30 s scalar baseline — candidate
+for #168).
 
 ## `src/blockList.mjs` — Lemma 3.3 structure `D` (#42)
 
@@ -203,7 +207,10 @@ Implementation notes (matches §03-B including its documented shortcuts):
   Blocks are `{ bound, entries: Map }`; a `locator` Map (key → block) gives O(1) duplicate handling.
 - Bound index = plain array + binary search instead of a balanced BST (upgrade tracked as #167).
 - Overfull `d1` block splits around the median via sort (O(M log M), not linear-time selection).
-- Big `batchPrepend` batches are sorted and chunked into blocks of ≤ ⌈M/2⌉, prepended to `d0`.
+- Big `batchPrepend` batches are sorted and chunked into blocks of ≤ ⌈M/2⌉, prepended to `d0`
+  **in one concat** (#182 fix, 1.1.1): the earlier per-chunk `unshift` re-shifted the whole
+  `d0` array per chunk — O(n²) when M is small and the chunk count approaches |L|, which was
+  the star-graph blowup (67.8× at 500k; now ~5.5× and falling with n).
 - Last `d1` block (bound `B`) is kept even when empty so every `insert` finds a home.
 - The pulled set is always the exact M smallest values regardless of block layout, so pulls
   are insertion-order independent. Under #163's composite keys (all values distinct) the
@@ -414,7 +421,7 @@ edge-order deterministic (copies allocated in edge order); ~2m copies, ~3m edges
   (identical maps incl. Infinity → 0; wrong/missing entries counted); `runScenarioBenchmark`
   and `runComparisonCountBenchmark` on tiny injected scenarios return the expected columns
   with **zero mismatches**.
-- Current suite: **159 tests — 158 passing + 1 XL skipped by default**, ~100% statement
+- Current suite: **161 tests — 160 passing + 1 XL skipped by default**, ~100% statement
   coverage, ~7.5 s wall-clock (the #164 distance-preservation sweeps run BMSSP/Dijkstra
   from every source). No graph data files: every generated test graph comes from a
   seed; the #162 fixtures are hand-built and fully deterministic.
@@ -430,7 +437,9 @@ BMSSP-vs-Dijkstra head-to-head itself:
   is the fair baseline) and outputs are verified node-by-node (`mismatches` must be 0).
   Scenario registry adds `sparse-random-l4` (n = 300k, degree 3): `topLevel` steps 3→4 at
   exactly n = 2^18 + 1 and stays 4 until t reaches 7 (~n = 376k), so 300k sits inside the
-  #182 level-transition window (3.11× vs 2.79× at 50k on 2026-07-21 capture).
+  #182 level-transition window (~3× vs ~2.2× at 50k on the 2026-07-21 post-fix capture;
+  the step itself measures ~+24% at the exact straddle). Star post-#182-fix: 3.82× at
+  50k (was 8.73×).
 - `compare-counts.bench.mjs` (opt-in, `npm run bench:counts` or `--counts`): comparisons
   between path lengths — BMSSP counted via `tieBreak`'s unconditional `compareKeys`
   counter, Dijkstra via matching counters in `dijkstra-adj.mjs`. One exact run per side
@@ -458,9 +467,9 @@ BMSSP-vs-Dijkstra head-to-head itself:
 | Optional constant-degree transform (in/out-degree ≤ 2) | `src/constantDegree.mjs` + `test/constantDegree.test.mjs` | #164 | ✅ merged (PR #195, no bump) |
 | JSDoc on `index.mjs` exports + public-API docs page | `index.mjs` + `docs/index.html` | #166 | ✅ merged (PR #196, **minor → 1.1.0**, released 2026-07-21) |
 | BMSSP-vs-Dijkstra head-to-head in the harness | `benchmarks/` + `src/tieBreak.mjs` counter | #170 | ✅ merged (PR #198, no bump) |
+| Performance-cliff investigation + quadratic batchPrepend fix | `src/blockList.mjs` + HEAD-TO-HEAD addendum | #182 | ✅ done-pending-merge (this PR, **patch → 1.1.1**) |
 
 Milestone `1.1.0` (correctness hardening) is **closed** — released 2026-07-21 (npm +
-Docker Hub). Milestone `1.2.0` is the current focus: **#182 is next** (performance-cliff
-investigation, armed with the harness's small-n reproductions — see the 2026-07-21
-comment on the issue), then #167/#168; see
+Docker Hub). Milestone `1.2.0` is the current focus: after #182 merges, **#167 / #168**
+remain (the structural/constant-factor work the investigation informs); see
 [06-milestones-roadmap.md](06-milestones-roadmap.md).

--- a/.claude/knowledge/06-milestones-roadmap.md
+++ b/.claude/knowledge/06-milestones-roadmap.md
@@ -1,10 +1,11 @@
 # 06 — Milestones Roadmap
 
-<!-- SYNCED-FROM-GITHUB: 2026-07-21 Phase E of the #170 PR (#170 closed by merged PR #198,
-     commit a1a9ef5; 1.2.0 open with 3 open issues #167/#168/#182; 2.0.0 open with 3
-     open issues #171/#172/#173; no release — no bump, package.json 1.1.0 == tag) -->
-<!-- Current package version: 1.1.0 — released 2026-07-21 (tag + GitHub Release with
-     Announcements discussion #197 → npm + Docker Hub via publish.yml); tag matches -->
+<!-- SYNCED-FROM-GITHUB: 2026-07-21 Phase C of the #182 PR (verified live at RKB same day:
+     1.2.0 open with 3 open issues #167/#168/#182 — #182 done-pending-merge in this PR;
+     2.0.0 open with 3 open issues #171/#172/#173) -->
+<!-- Current package version: 1.1.1 (bumped in the #182 PR — bug-fix patch for the
+     quadratic batchPrepend; release fires in Phase E after the user confirms the merge.
+     Last released: 1.1.0, 2026-07-21, Announcements discussion #197) -->
 <!-- Release-discussion convention (user-directed 2026-07-21): every GitHub Release also
      creates a linked discussion — pass --discussion-category "Announcements" to
      gh release create (the UI's "Create a discussion for this release" checkbox) -->
@@ -43,7 +44,21 @@ it runs the same Phase C reconciliation directly on `main`.
 
 ## 📋 Roadmap proposals (pending user approval)
 
-_None pending._
+From the #182 PR (Phase C, 2026-07-21):
+
+1. **Comment on #167** with the investigation's BlockList findings: the quadratic
+   per-chunk `unshift` in `batchPrepend` is fixed in the #182 PR (1.1.1), so #167's
+   remaining scope is exactly its title — the balanced-BST bound index (replacing the
+   plain-array binary search + `splice` in `insert`/`splitBlock`) and linear-time median
+   selection (replacing sort-based splits/chunking). Profiles show these are now ordinary
+   constant factors (~3–5% self-time each on sparse shapes), not cliffs.
+2. **Comment on #168** with the level/relaxation findings: the dominant recursion
+   overhead is the per-level O(m + n) pass — every completed `Ui`'s edges are re-relaxed
+   at each ancestor level with composite-key `relaxEdge` (~8.5% self-time at 300k) plus
+   `U`/`W` Set churn in `bmssp()` itself (~57% self-time at topLevel 4). The `topLevel`
+   3→4 step measures **+24%** at the exact n = 2^18 straddle; the recorded 5× at 4M is
+   that step plus GC pressure. Cheapest wins likely: reduce per-edge allocation in
+   `relaxEdge`, avoid re-scanning completed vertices' edges at upper levels.
 
 _(The #170-PR proposal — comment on **#182** with the harness's small-n reproductions —
 was approved and executed 2026-07-21: star 8.7× at n = 50k, `sparse-random-l4` 3.11× at
@@ -119,11 +134,22 @@ executed 2026-07-17.)_
   `HEAD-TO-HEAD.md` marked as the frozen 1.0.0 record. No bump, no release. The Phase E
   proposal (comment on #182 with the small-n reproductions) was approved and posted the
   same day.
-- **Coverage follow-up (user-directed, 2026-07-21, no issue, no bump):** the harness's
-  mismatch counter extracted to `bench-util.mjs` `countMismatches` (shared by
-  `scenarios.bench.mjs` and `compare-counts.bench.mjs`) and unit-tested on both branches,
-  closing the uncovered defensive lines in `compare-counts.bench.mjs` — both benchmark
-  modules now at 100% statement+branch coverage (suite 159).
+- **Coverage follow-up merged (PR #199, 2026-07-21, commit 4891318; no issue, no bump):**
+  the harness's mismatch counter extracted to `bench-util.mjs` `countMismatches` (shared
+  by `scenarios.bench.mjs` and `compare-counts.bench.mjs`) and unit-tested on both
+  branches, closing the uncovered defensive lines in `compare-counts.bench.mjs` — both
+  benchmark modules now at 100% statement+branch coverage (suite 159).
+- **#182 done-pending-merge (this PR, 2026-07-21):** cliff investigation complete. CPU
+  profiles + prototype-level instrumentation localized the **star blowup** to quadratic
+  per-chunk `d0.unshift` in `BlockList.batchPrepend` (~1.25e9 element moves at n = 50k;
+  64% of self-time) — **fixed** with a single-concat prepend (star 500k: 61 s → ~3.1 s,
+  67.8× → ~5.5×, ratio now falls with n; 2 regression tests added, suite 161). The
+  **`topLevel` 3→4 cliff** was measured at the exact straddle (n = 2^18 → 2^18 + 1, same
+  seed): an inherent **+24% step** (one extra full relax pass + Set churn per level) —
+  documented as known behavior in `HEAD-TO-HEAD.md`'s #182 addendum; the 1.0.0 record's
+  5× at 4M is that step plus GC/memory amplification. **Bug fix → patch bump 1.1.1**
+  (batchPrepend violated its documented Lemma 3.3 amortized bound); release fires in
+  Phase E. Findings feed #167/#168 (Roadmap proposals 1–2).
 - **Semver release convention (user-directed 2026-07-17, PR #186):** bumps only on bug
   fix (patch) or milestone-closing PR (minor/major) — see "Release mechanics" below.
 - **2026-07-16 reflection session (post-release):** measured the BMSSP-vs-Dijkstra
@@ -170,23 +196,20 @@ All six issues done (build order as executed — cheapest protection first, then
 
 ## Milestone `1.2.0` (milestone #3) — performance & ergonomics — CURRENT
 
-Build order: ~~#170~~ (merged, PR #198), then **#182** (use the harness's small-n
-reproductions — see the 2026-07-21 issue comment — to investigate the two measured
-cliffs), then **#167 / #168** (the optimizations the investigation informs).
+Build order: ~~#170~~ (merged, PR #198), ~~#182~~ (done-pending-merge, this PR), then
+**#167 / #168** (the structural/constant-factor work the investigation informs — see
+Roadmap proposals 1–2 for the findings each inherits).
 
 | # | Issue | Labels | Notes |
 |---|---|---|---|
-| 167 | Restore Lemma 3.3's exact asymptotics in BlockList (balanced-BST bound index + linear-time selection) | enhancement · help wanted | — |
-| 168 | Adjacency and relaxation micro-optimizations | enhancement · help wanted | — |
+| 167 | Restore Lemma 3.3's exact asymptotics in BlockList (balanced-BST bound index + linear-time selection) | enhancement · help wanted | remaining scope = bound index + median selection; the batchPrepend quadratic was fixed by #182 (1.1.1) |
+| 168 | Adjacency and relaxation micro-optimizations | enhancement · help wanted | #182 findings: per-level O(m+n) relax pass dominates; relaxEdge allocation + Set churn are the targets |
 | 169 | Optional shortest-path reconstruction (`Pred[]` → paths) | enhancement · help wanted | ✅ merged (PR #189, no bump): public API + independent path oracle |
 | 170 | BMSSP-vs-Dijkstra benchmark comparison | enhancement · help wanted | ✅ merged (PR #198, no bump): head-to-head + count mode in the harness, verified outputs |
-| 182 | Investigate BMSSP performance cliffs: high-fanout (star) graphs and recursion-level transitions | enhancement · help wanted | — |
+| 182 | Investigate BMSSP performance cliffs: high-fanout (star) graphs and recursion-level transitions | enhancement · help wanted | ✅ done-pending-merge (this PR, **patch → 1.1.1**): star = quadratic batchPrepend, fixed (61 s → ~3.1 s at 500k); level step = inherent +24%, documented (HEAD-TO-HEAD addendum) |
 
-_Note:_ #182 carries the two measured pathologies (star blowup: 67.8× at n = 500k in the
-1.0.0 record, already 8.7× at n = 50k in the harness; the `topLevel` 3→4 transition: 5× at
-n = 4M in the record, 3.11× at n = 300k via `sparse-random-l4`); likely overlaps
-#167/#168. Since #170 the harness reruns both as regression sentinels on every
-`npm run bench`, and `npm run bench:counts` reproduces the comparison-count crossover
+_Note:_ both #182 shapes stay as regression sentinels in every `npm run bench` (`star`,
+`sparse-random-l4`), and `npm run bench:counts` reproduces the comparison-count crossover
 (below 1.0 between n = 200k and n = 1M).
 
 ## Milestone `2.0.0` (milestone #4) — API-breaking generalization

--- a/.claude/knowledge/07-glossary.md
+++ b/.claude/knowledge/07-glossary.md
@@ -248,11 +248,17 @@ Quick lookup for the symbols and terms used across the paper, the notes, and the
   still wins wall-clock — the sorting barrier measurably broken, with constant factors as
   the remaining gap. Since #170, `npm run bench:counts` reproduces it exactly
   (`compare-counts.bench.mjs` `COUNT_CASES`: 1.20× at 50k → 1.03× at 200k → 0.98× at 1M).
-- **Performance cliffs (#182)** — two measured regimes where the head-to-head ratio breaks
-  from its ~1.6–2× pattern: star graphs (superlinear blowup, 67.8× at n = 500k; already
-  8.7× at n = 50k in the harness) and the `topLevel = ⌈log₂n / t⌉` 3→4 transition (5× at
-  n = 4M on sparse; 3.11× at n = 300k via `sparse-random-l4`). Milestone 1.2.0. Both run
-  as regression sentinels in every `npm run bench` since #170.
+- **Performance cliffs (#182, resolved 2026-07-21)** — two measured regimes where the
+  head-to-head ratio broke from its ~1.6–2× pattern; profiled and dispatched in the #182
+  investigation (full write-up: `benchmarks/HEAD-TO-HEAD.md` addendum). (1) **Star
+  blowup**: quadratic per-chunk `d0.unshift` in `BlockList.batchPrepend` (M = 1 at level
+  1 → ~n single-entry chunks) — **fixed in 1.1.1** with a single-concat prepend; star
+  500k went 61 s → ~3.1 s (67.8× → ~5.5×) and the ratio now falls with n. (2)
+  **`topLevel = ⌈log₂n / t⌉` 3→4 transition**: an inherent **~+24% step** (one extra
+  full relax pass + Set churn per level), measured at the exact n = 2^18 → 2^18 + 1
+  straddle; the 1.0.0 record's 5× at n = 4M is that step plus GC/memory amplification —
+  known behavior, constant-factor work tracked in #168. Both shapes stay as regression
+  sentinels in every `npm run bench` (`star`, `sparse-random-l4`).
 - **Docs page (#166)** — `docs/index.html`, the GitHub-Pages-published public-API reference
   (deployed by `static.yml` on `docs/**` changes). Documents exactly the three `index.mjs`
   exports — `BMSSP` (constructor contract, `calculateShortestPaths`, `reconstructPath`),

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ with every building block shipped, tested, and released individually:
 | Constructor input validation ([#165](https://github.com/Sirivasv/bmssp-js/issues/165)) | `BMSSP` constructor | ✅ done |
 | Opt-in constant-degree transform, in/out-degree ≤ 2 ([#164](https://github.com/Sirivasv/bmssp-js/issues/164)) | `constantDegreeTransform()` | ✅ done |
 | BMSSP-vs-Dijkstra head-to-head in the benchmark harness ([#170](https://github.com/Sirivasv/bmssp-js/issues/170)) | `npm run bench` / `npm run bench:counts` | ✅ done |
+| Performance-cliff investigation; quadratic `BatchPrepend` fixed ([#182](https://github.com/Sirivasv/bmssp-js/issues/182)) | `src/blockList.mjs` | ✅ done — **1.1.1** |
 
 > **Honest note:** the paper's win is asymptotic, and this repo optimizes for correctness
 > and readability, not raw speed. Measured head-to-head (algorithm time only, graph
@@ -46,7 +47,12 @@ with every building block shipped, tested, and released individually:
 > from about n = 1M on sparse graphs** (`npm run bench:counts` measures the ratio falling
 > 1.20× at 50k → 1.03× at 200k → 0.98× at 1M; 0.91× at 2M in the record), and the
 > advantage grows with size: the "sorting barrier" is measurably broken; what remains is
-> JS constant factors.
+> JS constant factors. The two performance cliffs found in the 1.0.0 measurements were
+> run down in [#182](https://github.com/Sirivasv/bmssp-js/issues/182): the star-graph
+> blowup was a quadratic in `BatchPrepend`'s bookkeeping — fixed in `1.1.1` (500k-node
+> star: 61 s → ~3 s) — and the recursion-level step is an inherent, measured ~+24% per
+> extra level (see the addendum in
+> [benchmarks/HEAD-TO-HEAD.md](benchmarks/HEAD-TO-HEAD.md)).
 > Where inputs violate the paper's distinct-path-lengths assumption (e.g. zero-weight
 > edges), a principled deterministic tie-break
 > ([#163](https://github.com/Sirivasv/bmssp-js/issues/163)) realizes that assumption in

--- a/benchmarks/HEAD-TO-HEAD.md
+++ b/benchmarks/HEAD-TO-HEAD.md
@@ -108,11 +108,40 @@ less ordering work per vertex.
 
 ## Reproducing
 
-[#170](https://github.com/Sirivasv/bmssp-js/issues/170) tracks integrating both
-measurements into the `npm run bench` harness (an algorithm-only `bmssp` column in
-`scenarios.bench.mjs` plus an optional comparison-count mode). Until then, the recipe:
-build the `BMSSP` instance untimed; time `calculateShortestPaths(source)` against a
-Dijkstra traversal fed the instance's own `adjacency` Map; for comparison counts, add a
-shared counter to every distance-comparison site in `src/*.mjs` and the Dijkstra variant.
-The raw numbers above are also recorded on
+Both measurements are integrated into the harness since
+[#170](https://github.com/Sirivasv/bmssp-js/issues/170): `npm run bench` reruns the
+algorithm-only head-to-head per shape (outputs verified node-by-node), and
+`npm run bench:counts` reproduces the comparison-count tables. The latest capture lives
+in [`RESULTS.md`](./RESULTS.md); the raw 1.0.0 numbers above are also recorded on
 [#170](https://github.com/Sirivasv/bmssp-js/issues/170#issuecomment-4991749542).
+
+## Addendum — the #182 cliff investigation (2026-07-21)
+
+The two pathologies in the 1.0.0 tables above were profiled
+([#182](https://github.com/Sirivasv/bmssp-js/issues/182)); one was a fixable defect, the
+other is inherent recursion cost. Both are permanent regression sentinels in
+`npm run bench` (`star`, `sparse-random-l4`).
+
+**1. The star blowup was quadratic `BatchPrepend` bookkeeping — fixed.** CPU profiles put
+64% of star-graph self-time in `BlockList.batchPrepend`: it prepended each chunk with
+`d0.unshift`, re-shifting the whole block array per chunk. At recursion level 1 the block
+size is `M = 1`, so a hub fanning out to ~n neighbors staged ~n single-entry chunks —
+~1.25 **billion** element moves at n = 50k, and O(n²) overall, matching the superlinear
+ratios above (67.8× at 500k). The fix (all chunk blocks prepended in one concat) restores
+the documented amortized bound. Measured after: star 500k **61,090 ms → ~3,100 ms
+(67.8× → ~5.5×)**, and the ratio now *falls* with n (6.6× at 50k → 5.5× at 500k) — the
+superlinearity is gone. The residual ~5× is ordinary constant-factor overhead on a shape
+where BMSSP's frontier machinery buys nothing (one hub completes and everything else is
+distance-2). Further constant-factor work: #167 (block-index structure), #168.
+
+**2. The `topLevel` 3→4 cliff is one extra full relax pass — inherent, and much smaller
+than the 4M row suggests.** A clean straddle at the exact step (n = 262,144 → 262,145,
+one vertex apart, same seed) measures 2.71× → 3.37×: a **~+24% step**, not 3×. Per-level
+instrumentation shows BlockList work is virtually identical on both sides; the extra
+level adds one more full pass of edge relaxations out of the children's returned `U` sets
+plus another round of `U`/`W` set bookkeeping — O(m + n) of Map/Set/composite-key work
+per level, which is the recursion's designed cost model. The remaining gap up to the
+recorded 5.00× at n = 4M is memory/GC amplification at 12M edges (visible as GC time in
+profiles), not an algorithmic discontinuity. Known behavior; the per-level constant is
+#168's target. The `topLevel = 4` window at practical sizes is exactly
+n ∈ (2^18, ~376k] — `sparse-random-l4` (n = 300k) sits inside it.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -112,11 +112,14 @@ harness reruns it on every `npm run bench` (fresh capture:
   (0.91× at 2M in the record). The sorting barrier is measurably broken; the
   remaining loss is constant factors.
 - **Shapes that blunt BMSSP's edge, per the harness:** `dense-random`
-  (relaxation-bound, ~4.8×), `chain` (depth, not sorting, is the cost —
-  ~8.9× against the prebuilt-adjacency baseline), `star` (extreme fanout,
-  ~8.7× already at 50k — the #182 defect), and the `topLevel` 3→4 window
-  (`sparse-random-l4`: 3.11× at 300k, against the narrowing trend on either
-  side — the #182 level-transition cliff, a regression sentinel).
+  (relaxation-bound, ~4.7×), `chain` (depth, not sorting, is the cost —
+  ~7.4× against the prebuilt-adjacency baseline), `star` (extreme fanout,
+  ~3.8× at 50k — the #182 quadratic-`batchPrepend` blowup is **fixed**, 500k
+  went 61 s → ~3 s and the ratio now falls with n), and the `topLevel` 3→4
+  window (`sparse-random-l4`: ~3× at 300k — a measured **~+24% step** at the
+  exact transition n = 2^18 → 2^18 + 1, inherent one-extra-relax-pass cost;
+  both stay as regression sentinels; see the #182 addendum in
+  [`HEAD-TO-HEAD.md`](./HEAD-TO-HEAD.md)).
 
 **Bottom line for this repo:** BMSSP is implemented here for **correctness and
 readability** — a faithful, tested rendering of the 2025 result. Pick Dijkstra

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -1,6 +1,6 @@
 # bmssp-js benchmark run
 
-_Generated 2026-07-21T07:44:53.485Z · node v26.5.0 · darwin/arm64_
+_Generated 2026-07-21T08:24:31.434Z · node v26.5.0 · darwin/arm64_
 
 ## Adjacency map vs linear scan (#45)
 
@@ -8,10 +8,10 @@ Graph: 20000 nodes, 80000 edges · 5000 random per-node edge lookups.
 
 | method | median ms | per lookup µs |
 | --- | --- | --- |
-| linear scan (pre-#45) | 415.92 | 83.18 |
-| adjacency map (#45) | 0.13 | 0.03 |
+| linear scan (pre-#45) | 417.98 | 83.60 |
+| adjacency map (#45) | 0.12 | 0.02 |
 
-**Speedup: 3295.5x** faster per-node lookups with the map.
+**Speedup: 3471.1x** faster per-node lookups with the map.
 
 ## Graph-shape scenarios — BMSSP vs Dijkstra (#170)
 
@@ -19,12 +19,12 @@ Algorithm time only: both sides consume the same prebuilt adjacency Map; `mismat
 
 | scenario | nodes | edges | construct ms | dijkstra ms | bmssp ms | ratio | mismatches | notes |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| sparse-random | 50000 | 150000 | 31.36 | 36.72 | 102.29 | 2.79x | 0 | m = O(n), degree 3 — the road-network regime |
-| dense-random | 8000 | 256000 | 19.15 | 14.02 | 67.88 | 4.84x | 0 | avg degree 32 — edge-relaxation-bound |
-| grid-4nbr | 40000 | 159200 | 14.44 | 18.70 | 76.75 | 4.10x | 0 | 200x200 lattice — large diameter, low degree |
-| chain | 50000 | 49999 | 8.26 | 5.14 | 45.56 | 8.87x | 0 | single long path — worst-case depth |
-| star | 50000 | 99998 | 10.55 | 35.21 | 307.51 | 8.73x | 0 | one hub, n-1 spokes — extreme degree skew (#182) |
-| sparse-random-l4 | 300000 | 900000 | 183.69 | 419.20 | 1305.50 | 3.11x | 0 | n just past the topLevel 3→4 step at n = 2^18 (#182) |
+| sparse-random | 50000 | 150000 | 30.04 | 42.90 | 95.82 | 2.23x | 0 | m = O(n), degree 3 — the road-network regime |
+| dense-random | 8000 | 256000 | 16.88 | 14.83 | 69.64 | 4.70x | 0 | avg degree 32 — edge-relaxation-bound |
+| grid-4nbr | 40000 | 159200 | 13.26 | 16.00 | 67.33 | 4.21x | 0 | 200x200 lattice — large diameter, low degree |
+| chain | 50000 | 49999 | 8.04 | 6.08 | 44.65 | 7.35x | 0 | single long path — worst-case depth |
+| star | 50000 | 99998 | 11.67 | 37.70 | 144.11 | 3.82x | 0 | one hub, n-1 spokes — extreme degree skew (#182) |
+| sparse-random-l4 | 300000 | 900000 | 184.34 | 419.21 | 1246.14 | 2.97x | 0 | n just past the topLevel 3→4 step at n = 2^18 (#182) |
 
 ## Comparison counts — the sorting barrier, measured (#170)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bmssp",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bmssp",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MPL-2.0",
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bmssp",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Javascript package implementation of the bmssp algorithm.",
   "main": "index.mjs",
   "keywords": [

--- a/src/blockList.mjs
+++ b/src/blockList.mjs
@@ -156,9 +156,13 @@ class BlockList {
         chunks.push(fresh.slice(i, i + chunkSize));
       }
     }
-    // Prepend in reverse chunk order so the smallest chunk lands at the front
-    for (let c = chunks.length - 1; c >= 0; c -= 1) {
-      const chunk = chunks[c];
+    // Materialize the chunks as blocks (ascending, so chunk 0 — the smallest
+    // values — ends up frontmost) and prepend them all in one concat. A
+    // per-chunk unshift here re-shifts the whole d0 array every time: with a
+    // small M the chunk count approaches |L| and the loop turns quadratic —
+    // the #182 star-graph blowup (~n single-entry chunks at M = 1).
+    const blocks = [];
+    for (const chunk of chunks) {
       // Seed the block bound with the first value, then max-update — avoids
       // needing a -Infinity sentinel that a custom comparator can't order
       const block = this.makeBlock(chunk[0][1]);
@@ -168,8 +172,9 @@ class BlockList {
         if (this.compare(value, block.bound) > 0) block.bound = value;
         this.count += 1;
       }
-      this.d0.unshift(block);
+      blocks.push(block);
     }
+    this.d0 = blocks.concat(this.d0);
   }
 
   /**

--- a/test/blockList.test.mjs
+++ b/test/blockList.test.mjs
@@ -204,6 +204,67 @@ describe("BlockList batchPrepend", () => {
     expect(order).toEqual([...valueOf.values()].sort((a, b) => a - b));
   });
 
+  test("a many-chunk batch at M = 1 pulls in order — the #182 star shape", () => {
+    // M = 1 makes every chunk a single-entry block: the regime where the
+    // pre-#182 per-chunk unshift turned quadratic. Behavior must be
+    // unchanged: pulls come out in ascending value order, one at a time.
+    const list = new BlockList(1, Infinity);
+    list.insert("far", 10_000);
+    const batch = [];
+    for (let i = 0; i < 500; i += 1) {
+      batch.push([`v${i}`, 1 + ((i * 271) % 500)]); // distinct values 1..500
+    }
+    list.batchPrepend(batch);
+    expect(list.size).toBe(501);
+    const values = new Map([...batch, ["far", 10_000]]);
+    let previous = -Infinity;
+    for (const { keys } of drain(list)) {
+      expect(keys.size).toBe(1);
+      const value = values.get([...keys][0]);
+      expect(value).toBeGreaterThan(previous);
+      previous = value;
+    }
+    expect(previous).toBe(10_000); // the pre-existing entry drained last
+  });
+
+  test("successive prepended batches stay ordered in front of each other", () => {
+    const M = 2;
+    const list = new BlockList(M, 1000);
+    list.insert("stored", 500);
+    list.batchPrepend([
+      ["a", 40],
+      ["b", 43],
+      ["c", 41],
+      ["d", 44],
+      ["e", 42],
+    ]); // > M -> chunked
+    list.batchPrepend([
+      ["f", 4],
+      ["g", 3],
+      ["h", 1],
+      ["i", 2],
+      ["j", 5],
+    ]); // all smaller than everything above -> must drain first
+    const values = new Map([
+      ["a", 40],
+      ["b", 43],
+      ["c", 41],
+      ["d", 44],
+      ["e", 42],
+      ["f", 4],
+      ["g", 3],
+      ["h", 1],
+      ["i", 2],
+      ["j", 5],
+      ["stored", 500],
+    ]);
+    const order = [];
+    for (const { keys } of drain(list)) {
+      order.push(...[...keys].map((k) => values.get(k)).sort((a, b) => a - b));
+    }
+    expect(order).toEqual([...values.values()].sort((a, b) => a - b));
+  });
+
   test("duplicate keys keep the smallest value, within the batch and vs stored", () => {
     const list = new BlockList(2, 100);
     list.insert("x", 50);


### PR DESCRIPTION
Closes #182

## Summary

Both performance cliffs from the 1.0.0 head-to-head are now explained; one is fixed, the other measured and documented (full write-up: new **#182 addendum in `benchmarks/HEAD-TO-HEAD.md`**).

### 1. Star blowup — a real defect, fixed (the one-line-diagnosis: `d0.unshift` in a loop)

CPU profiles put **64% of star-graph self-time in `BlockList.batchPrepend`**: it prepended each chunk with `d0.unshift`, re-shifting the entire block array per chunk. At recursion level 1 the block size is `M = 1`, so a hub fanning out to ~n neighbors staged **~n single-entry chunks** — instrumentation counted **~1.25 billion element moves at n = 50k** — O(n²) overall, violating `batchPrepend`'s documented Lemma 3.3 amortized bound. The fix materializes the chunk blocks and prepends them in **one concat** (same block order, same contract).

Measured after the fix, outputs verified (0 mismatches):

| case | before | after |
|---|---|---|
| star 500k (the issue's headline) | 61,090 ms / **67.8×** | **~3,100 ms / ~5.5×** |
| star 50k (in-harness) | 8.73× | **3.82×** |

The ratio now **falls** with n (6.6× at 50k → 5.5× at 500k) — the superlinearity is gone; the residual is ordinary constant factors (#167/#168 territory).

### 2. `topLevel` 3→4 cliff — inherent, and much smaller than the 4M row suggested

Measured at the exact straddle (n = 2^18 = 262,144 vs 262,145 — one vertex apart, same seed): **2.71× → 3.37×, a ~+24% step**. Per-level instrumentation shows BlockList work identical on both sides; the extra level costs one more full relax pass over the children's returned `U` sets plus another round of `U`/`W` Set bookkeeping — the recursion's designed O(m + n)-per-level cost. The 1.0.0 record's 5.00× at n = 4M is this step **plus GC/memory amplification** at 12M edges. Documented as known behavior; the per-level constant is #168's target. (`topLevel = 4` at practical sizes is exactly n ∈ (2^18, ~376k] — `sparse-random-l4` sits inside it.)

### Version

**Patch bump → 1.1.1** (bug fix in shipped behavior: `batchPrepend` broke its documented amortized complexity). Release fires in Phase E after merge confirmation.

## Tests / lint

- `npm test`: 12 suites, **161 tests — 160 passed + 1 XL skipped** (2 new BlockList regression tests: many-chunk `M = 1` batch ordering — the star shape — and successive-batch front ordering). BlockList at 100% statement+branch coverage.
- `npm run lint`: clean.
- Fresh `benchmarks/RESULTS.md` captured; comparison counts unchanged (the fix performs zero comparisons).

## Roadmap proposals

1. **Comment on #167**: the batchPrepend quadratic is fixed here, so #167's remaining scope is exactly its title — balanced-BST bound index (replacing array binary-search + `splice`) and linear-time median selection (replacing sort-based splits). Profiles show these are now ordinary constant factors (~3–5% self-time each), not cliffs.
2. **Comment on #168**: the dominant recursion overhead is the per-level O(m + n) relax pass (composite-key `relaxEdge` ~8.5% self-time at 300k; `bmssp()` Set churn ~57% at topLevel 4); the level step is +24% at the exact straddle, with GC amplification beyond ~4M. Cheapest wins: reduce per-edge allocation in `relaxEdge`, avoid re-scanning completed vertices' edges at upper levels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)