### PR TITLE
feat(#167): exact Lemma 3.3 asymptotics — balanced-BST bound index + linear-time selection

### DIFF
--- a/.claude/knowledge/05-codebase-map.md
+++ b/.claude/knowledge/05-codebase-map.md
@@ -64,7 +64,10 @@ src/
   dijkstra.mjs            # reference Dijkstra (array binary-heap) — DONE, used as oracle
   constantDegree.mjs      # #164: opt-in constant-degree transform (in/out-degree ≤ 2); public, re-exported
   tieBreak.mjs            # #163: composite [length, hops, id] keys — Assumption 2.1 realized (compareKeys/toBound/relaxEdge)
-  blockList.mjs           # #42: Lemma 3.3 block-based partial-sort structure D (comparator-aware since #163)
+  blockList.mjs           # #42: Lemma 3.3 block-based partial-sort structure D (comparator-aware since #163;
+                          #      exact Lemma 3.3 asymptotics since #167 via boundIndex + select)
+  boundIndex.mjs          # #167: AVL ordered block sequence — the paper's balanced-BST bound index (BoundIndex)
+  select.mjs              # #167: deterministic worst-case-linear selection (partitionByRank, median of medians)
   heap.mjs                # #41: indexed binary min-heap (MinHeap) for BaseCase (comparator-aware since #163)
   baseCase.mjs            # #40: BaseCase(B, S) — Algorithm 2 bounded mini-Dijkstra on composite keys
   findPivots.mjs          # #44: FindPivots(B, S) — Algorithm 1 frontier shrink, canonical-pred forest
@@ -76,7 +79,9 @@ test/
   tieBreak.test.mjs       # #163: 16 tests — key order, canonical relaxEdge, edge-order determinism, strict Lemma 3.1, lex-oracle hops/preds
   constantDegree.test.mjs # #164: 11 tests — degree ≤ 2 on hand + seeded shapes (incl. star hub), distance preservation via oracle, BMSSP-on-transform, determinism, empty/validation
   pathReconstruction.test.mjs # #169: 3 public-API tests — Dijkstra path oracle, unreachable/pre-run/source switching, target validation
-  blockList.test.mjs      # #42: 20 BlockList tests incl. seeded random stress + #182 many-chunk/M=1 batchPrepend regression tests
+  blockList.test.mjs      # #42: 25 BlockList tests incl. seeded random stress, #182 many-chunk/M=1 regression tests + #167 machinery tests
+  boundIndex.test.mjs     # #167: 8 BoundIndex tests — sequence ops, monotone findFirst, AVL invariants under seeded churn
+  select.test.mjs         # #167: 9 partitionByRank tests — every-rank contract, worst-case orderings, duplicates, determinism
   heap.test.mjs           # #41: 16 MinHeap tests incl. a seeded stress test vs. a naive queue
   baseCase.test.mjs       # #40: 13 BaseCase tests incl. seeded oracle-comparison stress
   findPivots.test.mjs     # #44: 12 FindPivots tests incl. two seeded oracle stress tests
@@ -172,21 +177,24 @@ make every frontier comparison strict. Consequences, replacing the pre-#163 guar
 4. **Full determinism:** distances, hops, preds, and even partial-call `U`/`boundKey` are
    invariant under edge-list permutation (`test/tieBreak.test.mjs` asserts this).
 
-**Performance (measured 2026-07-16, addendum 2026-07-21; Apple Silicon, node v26.5.0 —
-full data + methodology in `benchmarks/HEAD-TO-HEAD.md`):** algorithm-only wall-clock
-(construction excluded, Dijkstra fed the same prebuilt adjacency): Dijkstra wins every
-shape/size; sparse-graph ratio narrows with n (2.54× at 50k → **1.57× at 2M**).
-**Comparison counts (the paper's metric) cross over:** BMSSP does fewer distance
-comparisons than Dijkstra past ~n = 1M sparse (0.96× at 1M, **0.91× at 2M**). The two
-#182 pathologies were profiled 2026-07-21 (HEAD-TO-HEAD addendum): the **star blowup was
-quadratic `batchPrepend` bookkeeping — fixed in 1.1.1** (500k: 61 s → ~3.1 s, ratio now
-falls with n); the **`topLevel` 3→4 step is an inherent ~+24%** (one extra full relax
-pass per level, measured at the exact n = 2^18 straddle) — the recorded 5× at 4M is that
-step plus GC/memory amplification at 12M edges. Note `topLevel` is **3 from n = 10k to
-2M** (4 only in n ∈ (2^18, ~376k]) — scale tests buy volume/memory pressure, not
-recursion depth. The default suite runs in ~7.5 s; the opt-in `FUZZ_XL=1` 2M-node round
-takes ~33 s (#163's composite keys added ~10% over the ~30 s scalar baseline — candidate
-for #168).
+**Performance (measured 2026-07-16, addenda 2026-07-21; Apple Silicon, node v26.5.0 —
+full data + methodology in `benchmarks/HEAD-TO-HEAD.md`, latest capture in
+`benchmarks/RESULTS.md`):** algorithm-only wall-clock (construction excluded, Dijkstra fed
+the same prebuilt adjacency): Dijkstra wins every shape/size; sparse-graph ratio narrows
+with n (1.0.0 record: 2.54× at 50k → **1.57× at 2M**). **Comparison counts (the paper's
+metric) crossed over at ~n = 1M sparse in the 1.0.0/1.1.1 records; after #167's
+selection-based BlockList they cross before n = 50k** — 0.97× at 50k, 0.77× at 200k,
+**0.66× at 1M** (grid 700×700 down to 1.12×): replacing the sort-based splits/pulls
+removed a major comparison cost, and #167's wall-clock is also at-or-better than 1.1.1
+on every shape (star ~134 ms vs ~144 ms at 50k, sparse ~100 ms vs ~96 ms — within noise).
+The two #182 pathologies were profiled 2026-07-21 (HEAD-TO-HEAD addendum): the **star
+blowup was quadratic `batchPrepend` bookkeeping — fixed in 1.1.1** (500k: 61 s → ~3.1 s);
+the **`topLevel` 3→4 step is an inherent ~+24%** (one extra full relax pass per level,
+measured at the exact n = 2^18 straddle) — the recorded 5× at 4M is that step plus
+GC/memory amplification at 12M edges. Note `topLevel` is **3 from n = 10k to 2M** (4 only
+in n ∈ (2^18, ~376k]) — scale tests buy volume/memory pressure, not recursion depth. The
+default suite runs in ~7.5 s; the opt-in `FUZZ_XL=1` 2M-node round takes ~33 s (#163's
+composite keys added ~10% over the ~30 s scalar baseline — candidate for #168).
 
 ## `src/blockList.mjs` — Lemma 3.3 structure `D` (#42)
 
@@ -203,20 +211,80 @@ class BlockList {
 export { BlockList };      // NOT re-exported from index.mjs — internal to the algorithm
 ```
 
-Implementation notes (matches §03-B including its documented shortcuts):
+Implementation notes (matches §03-B; since #167 both of its documented shortcuts are gone
+and the structure meets Lemma 3.3's exact per-operation bounds):
 - `d1` (insert blocks) + `d0` (prepend blocks); values ordered between blocks, unsorted within.
-  Blocks are `{ bound, entries: Map }`; a `locator` Map (key → block) gives O(1) duplicate handling.
-- Bound index = plain array + binary search instead of a balanced BST (upgrade tracked as #167).
-- Overfull `d1` block splits around the median via sort (O(M log M), not linear-time selection).
-- Big `batchPrepend` batches are sorted and chunked into blocks of ≤ ⌈M/2⌉, prepended to `d0`
-  **in one concat** (#182 fix, 1.1.1): the earlier per-chunk `unshift` re-shifted the whole
-  `d0` array per chunk — O(n²) when M is small and the chunk count approaches |L|, which was
-  the star-graph blowup (67.8× at 500k; now ~5.5× and falling with n).
-- Last `d1` block (bound `B`) is kept even when empty so every `insert` finds a home.
+  Blocks are `{ bound, entries: Map, node, prev, next }`; a `locator` Map (key → block) gives
+  O(1) duplicate handling.
+- **Bound index = `BoundIndex` AVL sequence tree (#167)**, replacing the plain sorted array:
+  `insert` finds its block via a monotone-predicate descent (`findFirst`, O(log #blocks)),
+  splits insert the lower half via `insertBefore`, emptied blocks leave via `remove` — no
+  O(#blocks) `splice`/`indexOf` anywhere. Each `d1` block keeps its tree-node handle in
+  `block.node` (`null` marks a `d0` block; `d0` is a doubly-linked list via `prev`/`next`
+  with O(1) unlink).
+- **Splits, chunking and pulls use `partitionByRank` (#167)** — deterministic worst-case-
+  linear selection — instead of an O(M log M) sort: an overfull `d1` block partitions around
+  its median rank; `pull` selects the exact M smallest candidates in O(M).
+- Big `batchPrepend` batches become value-ordered chunks of ≤ ⌈M/2⌉ prepended to `d0` in one
+  linked-list splice (#182 fix preserved). Chunking is a two-branch hybrid, both inside the
+  Lemma bound O(|L|·max{1, log(|L|/M)}): with many chunks (|L| ≥ ⌈M/2⌉², e.g. the M = 1 star
+  regime) one sort is within 2× of the target and far faster than log(|L|/M) median rounds;
+  with few chunks (|L| < ⌈M/2⌉²) recursive median splitting (≤ log₂⌈M/2⌉ levels) avoids the
+  sort's O(|L| log |L|) overshoot.
+- The shared `compareBySecond` pair comparator is hoisted onto the instance so hot paths
+  don't allocate a closure per call.
+- Last `d1` block (bound `B`, `this.lastD1Block`) is kept even when empty so every `insert`
+  finds a home.
 - The pulled set is always the exact M smallest values regardless of block layout, so pulls
   are insertion-order independent. Under #163's composite keys (all values distinct) the
   separator is strictly above every pulled value — the pre-#163 tie caveat (bound tying a
   pulled key, `d̂ == Bi` batch members) is gone.
+
+## `src/boundIndex.mjs` — AVL ordered block sequence (#167)
+
+```js
+class BoundIndex {
+  constructor()            // empty sequence
+  get size
+  clear()
+  first() / last()         // sequence ends (node handles), null when empty
+  next(node)               // in-order successor, null at the end
+  findFirst(predicate)     // leftmost node whose ITEM satisfies predicate — predicate must
+                           // be monotone along the sequence (false…false, true…true);
+                           // O(log size). BlockList passes bound >= value.
+  append(item)             // → node handle; insert at the end
+  insertBefore(node, item) // → node handle; insert immediately before an existing node
+  remove(node)             // remove by handle
+}
+export { BoundIndex };     // NOT re-exported from index.mjs — internal to the algorithm
+```
+
+The paper's "balanced BST over block upper bounds", realized as a POSITIONAL AVL tree: the
+tree never compares items — a node's in-order position is its sequence position, and because
+`d1` bounds are monotone along the sequence, `findFirst` with a monotone predicate is a
+binary search. Nodes are plain `{ item, parent, left, right, height }` objects handed back
+as handles (blocks store theirs in `block.node`). Insert/remove rebalance with standard AVL
+rotations walking to the root.
+
+## `src/select.mjs` — deterministic linear-time selection (#167)
+
+```js
+partitionByRank(items, rank, compare?, cheapBudget?)  // → items[rank]
+// Reorders items IN PLACE: items[0..rank] become the rank+1 smallest and
+// items[rank] the rank-th smallest (their max); order within the sides is
+// unspecified. compare defaults to numeric. cheapBudget (default 6·|items|)
+// is the introselect knob: elements the median-of-3 phase may visit before
+// pivots switch to median-of-medians; 0 forces the fallback (tests).
+export { partitionByRank };   // NOT re-exported from index.mjs — internal to the algorithm
+```
+
+Introselect: deterministic median-of-3 quickselect (three-way partition, ~2–3n comparisons
+on typical inputs — below a sort's n log n, which keeps the #170 comparison counts honest)
+with a work budget; exhausting it switches pivots to median-of-medians (groups of 5), whose
+guaranteed middle-40% split makes the remainder — and thus the worst case — linear. Pure
+median-of-medians was measured at ~10–20n comparisons, worse than sorting at practical
+sizes; the budgeted hybrid keeps both the bound and the constant. No randomness: fully
+reproducible.
 
 ## `src/heap.mjs` — indexed binary min-heap (#41)
 
@@ -365,10 +433,22 @@ edge-order deterministic (copies allocated in edge order); ~2m copies, ~3m edges
   recursion contract (bounded call: complete-below-boundary, exact membership, d̂ never
   underestimates; unbounded call: successful execution returning exactly the reachable set),
   and seeded full-map-vs-oracle stress across sizes (up to n = 2000).
-- `test/blockList.test.mjs` (18), `test/heap.test.mjs` (16), `test/baseCase.test.mjs` (13),
+- `test/blockList.test.mjs` (25), `test/heap.test.mjs` (16), `test/baseCase.test.mjs` (13),
   `test/findPivots.test.mjs` (12): per-module contracts incl. seeded stress — see the
   module sections above. (Since #163 the baseCase partial-run tests assert the composite
-  contract: strictly below `boundKey`, `≤` the scalar bound.)
+  contract: strictly below `boundKey`, `≤` the scalar bound. #167 added five BlockList
+  tests: hundreds-of-splits drain at M = 2, interior-block drops via duplicate-key
+  replacement, both chunking branches of `batchPrepend` — sort and median-recursion —
+  and a middle-`d0`-block unlink.)
+- `test/select.test.mjs` (11, #167): `partitionByRank` — validation, the every-rank
+  contract on shuffled/sorted/reverse/duplicate-heavy/organ-pipe inputs, custom
+  comparators, the forced median-of-medians fallback (`cheapBudget: 0`), seeded stress
+  across sizes, and determinism of the final arrangement.
+- `test/boundIndex.test.mjs` (8, #167): `BoundIndex` — sequence semantics of
+  append/insertBefore/remove/first/last/next, leftmost-match `findFirst` on duplicate
+  bound runs, and AVL invariants (parent pointers, stored heights, |balance| ≤ 1)
+  verified recursively under append-only growth (height ≤ 17 at n = 2048) and two
+  seeded random-churn stresses against a reference array.
 - `test/tieBreak.test.mjs` (19, #163 + 3 counter tests from #170): unit tests for
   `compareKeys`/`toBound`/`relaxEdge`
   (lexicographic order, scalar-bound infimum, canonical pred choice, zero-weight-cycle
@@ -422,7 +502,7 @@ edge-order deterministic (copies allocated in edge order); ~2m copies, ~3m edges
   (identical maps incl. Infinity → 0; wrong/missing entries counted); `runScenarioBenchmark`
   and `runComparisonCountBenchmark` on tiny injected scenarios return the expected columns
   with **zero mismatches**.
-- Current suite: **161 tests — 160 passing + 1 XL skipped by default**, ~100% statement
+- Current suite: **185 tests — 184 passing + 1 XL skipped by default**, ~100% statement
   coverage, ~7.5 s wall-clock (the #164 distance-preservation sweeps run BMSSP/Dijkstra
   from every source). No graph data files: every generated test graph comes from a
   seed; the #162 fixtures are hand-built and fully deterministic.
@@ -438,17 +518,19 @@ BMSSP-vs-Dijkstra head-to-head itself:
   is the fair baseline) and outputs are verified node-by-node (`mismatches` must be 0).
   Scenario registry adds `sparse-random-l4` (n = 300k, degree 3): `topLevel` steps 3→4 at
   exactly n = 2^18 + 1 and stays 4 until t reaches 7 (~n = 376k), so 300k sits inside the
-  #182 level-transition window (~3× vs ~2.2× at 50k on the 2026-07-21 post-fix capture;
-  the step itself measures ~+24% at the exact straddle). Star post-#182-fix: 3.82× at
-  50k (was 8.73×).
+  #182 level-transition window (the step itself measures ~+24% at the exact straddle).
+  Post-#167 capture (2026-07-21): sparse 2.46×, star 4.53× (~131 ms; pre-#182 8.73×),
+  l4 2.96× — ratios are noisy run-to-run (the Dijkstra denominator swings ±20%); compare
+  `bmssp ms` across captures for regressions.
 - `compare-counts.bench.mjs` (opt-in, `npm run bench:counts` or `--counts`): comparisons
   between path lengths — BMSSP counted via `tieBreak`'s unconditional `compareKeys`
   counter, Dijkstra via matching counters in `dijkstra-adj.mjs`. One exact run per side
-  (counts are deterministic). 2026-07-21 capture reproduces the crossover: sparse 1.20× at
-  50k → 1.03× at 200k → **0.98× at 1M**; grid 700×700 stays 1.27×.
+  (counts are deterministic). 2026-07-21 post-#167 capture: crossover before n = 50k —
+  sparse **0.97× at 50k → 0.77× at 200k → 0.66× at 1M**; grid 700×700 down to 1.12×
+  (pre-#167: 1.20× / 1.03× / 0.98× / 1.27× — sort-based splits/pulls were the cost).
 - **`HEAD-TO-HEAD.md` is the frozen 1.0.0 measurement record** (2026-07-16, sizes to
-  n = 4M incl. star-500k 67.8× and the 4M cliff); `RESULTS.md` is the latest captured
-  harness report.
+  n = 4M incl. star-500k 67.8× and the 4M cliff) plus dated addenda (#182 cliffs,
+  #167 crossover shift); `RESULTS.md` is the latest captured harness report.
 
 ## Gaps to fill (the actual work)
 
@@ -469,8 +551,9 @@ BMSSP-vs-Dijkstra head-to-head itself:
 | JSDoc on `index.mjs` exports + public-API docs page | `index.mjs` + `docs/index.html` | #166 | ✅ merged (PR #196, **minor → 1.1.0**, released 2026-07-21) |
 | BMSSP-vs-Dijkstra head-to-head in the harness | `benchmarks/` + `src/tieBreak.mjs` counter | #170 | ✅ merged (PR #198, no bump) |
 | Performance-cliff investigation + quadratic batchPrepend fix | `src/blockList.mjs` + HEAD-TO-HEAD addendum | #182 | ✅ merged (PR #200, **patch → 1.1.1**, released 2026-07-21) |
+| Exact Lemma 3.3 asymptotics (BST bound index + linear selection) | `src/boundIndex.mjs` + `src/select.mjs` + `src/blockList.mjs` | #167 | ✅ done-pending-merge (this PR, no bump) |
 
 Milestone `1.1.0` (correctness hardening) is **closed** — released 2026-07-21 (npm +
-Docker Hub). Milestone `1.2.0` is the current focus: **#167 / #168** remain (the
-structural/constant-factor work the #182 investigation informs — findings posted on both
-issues 2026-07-21); see [06-milestones-roadmap.md](06-milestones-roadmap.md).
+Docker Hub). Milestone `1.2.0` is the current focus: after #167 merges, **#168** is its
+last open issue (adjacency/relaxation micro-optimizations; the PR closing it takes the
+**minor → 1.2.0** bump); see [06-milestones-roadmap.md](06-milestones-roadmap.md).

--- a/.claude/knowledge/05-codebase-map.md
+++ b/.claude/knowledge/05-codebase-map.md
@@ -1,14 +1,15 @@
 # 05 — Codebase Map (current state)
 
-<!-- BOOKMARK-COMMIT: 4891318 -->
-<!-- PENDING-PR-BRANCH: fix/182-performance-cliffs -->
-<!-- Last validated: 2026-07-21 (Phase C of the #182 PR). Describes the tree as it will
-     exist once that PR merges: the #182 cliff investigation. Star cliff root-caused to
-     quadratic per-chunk d0.unshift in BlockList.batchPrepend and FIXED (one concat;
-     star 500k 61s -> ~3.1s, 67.8x -> ~5.5x, superlinearity gone); topLevel 3->4 cliff
-     measured at the exact straddle n = 2^18 -> 2^18+1 as an inherent ~+24% step (one
-     extra full relax pass per level), documented in HEAD-TO-HEAD's #182 addendum.
-     Bug fix -> patch bump 1.1.1 (release in Phase E after merge). -->
+<!-- BOOKMARK-COMMIT: 16e53f2 -->
+<!-- PENDING-PR-BRANCH: feat/167-exact-lemma33-asymptotics -->
+<!-- Last validated: 2026-07-21 (Phase C of the #167 PR). Describes the tree as it will
+     exist once that PR merges: BlockList's two documented shortcuts replaced to meet
+     Lemma 3.3's exact bounds — the plain-array bound index by an AVL sequence tree
+     (src/boundIndex.mjs) and the sort-based splits/chunking/pulls by deterministic
+     linear-time selection (src/select.mjs, median of medians). Behavior-preserving:
+     all pre-existing tests unchanged. No version bump (not a bug fix; #168 still open
+     in milestone 1.2.0). -->
+
 
 Snapshot of what exists in `bmssp-js` today, so you know what to build on vs. what's missing.
 
@@ -467,9 +468,9 @@ BMSSP-vs-Dijkstra head-to-head itself:
 | Optional constant-degree transform (in/out-degree ≤ 2) | `src/constantDegree.mjs` + `test/constantDegree.test.mjs` | #164 | ✅ merged (PR #195, no bump) |
 | JSDoc on `index.mjs` exports + public-API docs page | `index.mjs` + `docs/index.html` | #166 | ✅ merged (PR #196, **minor → 1.1.0**, released 2026-07-21) |
 | BMSSP-vs-Dijkstra head-to-head in the harness | `benchmarks/` + `src/tieBreak.mjs` counter | #170 | ✅ merged (PR #198, no bump) |
-| Performance-cliff investigation + quadratic batchPrepend fix | `src/blockList.mjs` + HEAD-TO-HEAD addendum | #182 | ✅ done-pending-merge (this PR, **patch → 1.1.1**) |
+| Performance-cliff investigation + quadratic batchPrepend fix | `src/blockList.mjs` + HEAD-TO-HEAD addendum | #182 | ✅ merged (PR #200, **patch → 1.1.1**, released 2026-07-21) |
 
 Milestone `1.1.0` (correctness hardening) is **closed** — released 2026-07-21 (npm +
-Docker Hub). Milestone `1.2.0` is the current focus: after #182 merges, **#167 / #168**
-remain (the structural/constant-factor work the investigation informs); see
-[06-milestones-roadmap.md](06-milestones-roadmap.md).
+Docker Hub). Milestone `1.2.0` is the current focus: **#167 / #168** remain (the
+structural/constant-factor work the #182 investigation informs — findings posted on both
+issues 2026-07-21); see [06-milestones-roadmap.md](06-milestones-roadmap.md).

--- a/.claude/knowledge/06-milestones-roadmap.md
+++ b/.claude/knowledge/06-milestones-roadmap.md
@@ -1,8 +1,8 @@
 # 06 — Milestones Roadmap
 
-<!-- SYNCED-FROM-GITHUB: 2026-07-21 Phase A (post-#182 session; verified live):
-     1.2.0 open with 2 open issues #167/#168 (3 closed incl. #182, merged PR #200);
-     2.0.0 open with 3 open issues #171/#172/#173 -->
+<!-- SYNCED-FROM-GITHUB: 2026-07-21 Phase C of the #167 PR (verified live at Phase A the
+     same day: 1.2.0 open with 2 open issues #167/#168 — #167 done-pending-merge in this
+     PR; 2.0.0 open with 3 open issues #171/#172/#173) -->
 <!-- Current package version: 1.1.1 — released 2026-07-21 (tag + GitHub Release with
      Announcements discussion → npm + Docker Hub via publish.yml); tag matches -->
 <!-- Release-discussion convention (user-directed 2026-07-21): every GitHub Release also
@@ -43,7 +43,15 @@ it runs the same Phase C reconciliation directly on `main`.
 
 ## 📋 Roadmap proposals (pending user approval)
 
-_None pending._
+From the #167 PR (Phase C, 2026-07-21):
+
+1. **Comment on #168** with the post-#167 baseline its work should start from: the
+   BlockList is no longer a comparison-count factor at all (introselect does ~2–3n
+   comparisons where sorts did n log n — the count crossover moved from ~n = 1M to
+   before n = 50k: 0.97× at 50k, 0.66× at 1M), and wall-clock profiles now put the
+   dominant costs squarely in #168's stated targets — `relaxEdge` allocation, `U`/`W`
+   Set churn, and the per-level O(m + n) relax pass. Also note #168 is now 1.2.0's
+   last open issue, so its PR takes the **minor → 1.2.0** bump and release.
 
 _(The #182-PR proposals — findings comments on **#167** (remaining scope = BST bound
 index + linear-time selection; batchPrepend quadratic fixed) and **#168** (per-level
@@ -140,6 +148,24 @@ executed 2026-07-17.)_
   5× at 4M is that step plus GC/memory amplification. **Bug fix → patch bump 1.1.1**
   (batchPrepend violated its documented Lemma 3.3 amortized bound); **1.1.1 released
   2026-07-21**. Findings posted on #167/#168 (approved proposals, executed same day).
+- **#167 done-pending-merge (this PR, 2026-07-21):** BlockList's two documented
+  shortcuts replaced to meet Lemma 3.3's exact per-operation bounds — the plain-array
+  bound index by `src/boundIndex.mjs` (`BoundIndex`, a positional AVL tree searched
+  through the monotone block bounds; O(log #blocks) search/split/drop) and the
+  sort-based splits/chunking/pulls by `src/select.mjs` (`partitionByRank`, budgeted
+  introselect: deterministic median-of-3 quickselect with a median-of-medians fallback —
+  worst-case linear, ~2–3n comparisons typical). First cut used pure median-of-medians
+  (~10–20n comparisons) and REGRESSED both wall-clock (star +68%) and counts (1M
+  crossover lost) — caught by the harness, fixed with the introselect budget and a
+  two-branch batchPrepend chunker (sort when |L| ≥ ⌈M/2⌉², median recursion below).
+  Net result: **comparison-count crossover moved from ~n = 1M to before n = 50k**
+  (0.97×/0.77×/0.66× at 50k/200k/1M; grid 1.27× → 1.12×), wall-clock at-or-better than
+  1.1.1 everywhere. +22 tests (suite 185: `select` 11, `boundIndex` 8, BlockList +5,
+  incl. a forced-fallback path via the `cheapBudget: 0` knob). Behavior-preserving:
+  all pre-existing tests unchanged; extended FUZZ_ROUNDS=25 and FUZZ_XL runs green.
+  No bump (not a bug fix; #168 still open in 1.2.0). Addendum added to
+  `HEAD-TO-HEAD.md`; `RESULTS.md` recaptured; stale crossover blurbs updated in the
+  harness and `benchmarks/README.md`.
 - **Semver release convention (user-directed 2026-07-17, PR #186):** bumps only on bug
   fix (patch) or milestone-closing PR (minor/major) — see "Release mechanics" below.
 - **2026-07-16 reflection session (post-release):** measured the BMSSP-vs-Dijkstra
@@ -186,21 +212,21 @@ All six issues done (build order as executed — cheapest protection first, then
 
 ## Milestone `1.2.0` (milestone #3) — performance & ergonomics — CURRENT
 
-Build order: ~~#170~~ (merged, PR #198), ~~#182~~ (merged, PR #200, 1.1.1), then
-**#167 / #168** (the structural/constant-factor work the investigation informs — the
-findings each inherits are posted as 2026-07-21 comments on the issues).
+Build order: ~~#170~~ (merged, PR #198), ~~#182~~ (merged, PR #200, 1.1.1), ~~#167~~
+(done-pending-merge, this PR), then **#168** — 1.2.0's last open issue, whose PR takes
+the **minor → 1.2.0** bump and release.
 
 | # | Issue | Labels | Notes |
 |---|---|---|---|
-| 167 | Restore Lemma 3.3's exact asymptotics in BlockList (balanced-BST bound index + linear-time selection) | enhancement · help wanted | remaining scope = bound index + median selection; the batchPrepend quadratic was fixed by #182 (1.1.1) |
-| 168 | Adjacency and relaxation micro-optimizations | enhancement · help wanted | #182 findings: per-level O(m+n) relax pass dominates; relaxEdge allocation + Set churn are the targets |
+| 167 | Restore Lemma 3.3's exact asymptotics in BlockList (balanced-BST bound index + linear-time selection) | enhancement · help wanted | ✅ done-pending-merge (this PR, no bump): `BoundIndex` AVL sequence + `partitionByRank` introselect; count crossover moved ~1M → <50k (0.66× at 1M); wall-clock at-or-better |
+| 168 | Adjacency and relaxation micro-optimizations | enhancement · help wanted | #182 findings: per-level O(m+n) relax pass dominates; relaxEdge allocation + Set churn are the targets. **Milestone-closing → minor 1.2.0** |
 | 169 | Optional shortest-path reconstruction (`Pred[]` → paths) | enhancement · help wanted | ✅ merged (PR #189, no bump): public API + independent path oracle |
 | 170 | BMSSP-vs-Dijkstra benchmark comparison | enhancement · help wanted | ✅ merged (PR #198, no bump): head-to-head + count mode in the harness, verified outputs |
 | 182 | Investigate BMSSP performance cliffs: high-fanout (star) graphs and recursion-level transitions | enhancement · help wanted | ✅ merged (PR #200, **patch → 1.1.1**, released 2026-07-21): star = quadratic batchPrepend, fixed (61 s → ~3.1 s at 500k); level step = inherent +24%, documented (HEAD-TO-HEAD addendum) |
 
 _Note:_ both #182 shapes stay as regression sentinels in every `npm run bench` (`star`,
 `sparse-random-l4`), and `npm run bench:counts` reproduces the comparison-count crossover
-(below 1.0 between n = 200k and n = 1M).
+(below 1.0 before n = 50k since #167; ~n = 1M in the 1.0.0/1.1.1 records).
 
 ## Milestone `2.0.0` (milestone #4) — API-breaking generalization
 

--- a/.claude/knowledge/06-milestones-roadmap.md
+++ b/.claude/knowledge/06-milestones-roadmap.md
@@ -1,11 +1,10 @@
 # 06 — Milestones Roadmap
 
-<!-- SYNCED-FROM-GITHUB: 2026-07-21 Phase C of the #182 PR (verified live at RKB same day:
-     1.2.0 open with 3 open issues #167/#168/#182 — #182 done-pending-merge in this PR;
-     2.0.0 open with 3 open issues #171/#172/#173) -->
-<!-- Current package version: 1.1.1 (bumped in the #182 PR — bug-fix patch for the
-     quadratic batchPrepend; release fires in Phase E after the user confirms the merge.
-     Last released: 1.1.0, 2026-07-21, Announcements discussion #197) -->
+<!-- SYNCED-FROM-GITHUB: 2026-07-21 Phase A (post-#182 session; verified live):
+     1.2.0 open with 2 open issues #167/#168 (3 closed incl. #182, merged PR #200);
+     2.0.0 open with 3 open issues #171/#172/#173 -->
+<!-- Current package version: 1.1.1 — released 2026-07-21 (tag + GitHub Release with
+     Announcements discussion → npm + Docker Hub via publish.yml); tag matches -->
 <!-- Release-discussion convention (user-directed 2026-07-21): every GitHub Release also
      creates a linked discussion — pass --discussion-category "Announcements" to
      gh release create (the UI's "Create a discussion for this release" checkbox) -->
@@ -44,22 +43,12 @@ it runs the same Phase C reconciliation directly on `main`.
 
 ## 📋 Roadmap proposals (pending user approval)
 
-From the #182 PR (Phase C, 2026-07-21):
+_None pending._
 
-1. **Comment on #167** with the investigation's BlockList findings: the quadratic
-   per-chunk `unshift` in `batchPrepend` is fixed in the #182 PR (1.1.1), so #167's
-   remaining scope is exactly its title — the balanced-BST bound index (replacing the
-   plain-array binary search + `splice` in `insert`/`splitBlock`) and linear-time median
-   selection (replacing sort-based splits/chunking). Profiles show these are now ordinary
-   constant factors (~3–5% self-time each on sparse shapes), not cliffs.
-2. **Comment on #168** with the level/relaxation findings: the dominant recursion
-   overhead is the per-level O(m + n) pass — every completed `Ui`'s edges are re-relaxed
-   at each ancestor level with composite-key `relaxEdge` (~8.5% self-time at 300k) plus
-   `U`/`W` Set churn in `bmssp()` itself (~57% self-time at topLevel 4). The `topLevel`
-   3→4 step measures **+24%** at the exact n = 2^18 straddle; the recorded 5× at 4M is
-   that step plus GC pressure. Cheapest wins likely: reduce per-edge allocation in
-   `relaxEdge`, avoid re-scanning completed vertices' edges at upper levels.
-
+_(The #182-PR proposals — findings comments on **#167** (remaining scope = BST bound
+index + linear-time selection; batchPrepend quadratic fixed) and **#168** (per-level
+O(m + n) relax pass dominates; relaxEdge allocation + Set churn targets; +24% level
+step) — were approved and executed 2026-07-21.)_
 _(The #170-PR proposal — comment on **#182** with the harness's small-n reproductions —
 was approved and executed 2026-07-21: star 8.7× at n = 50k, `sparse-random-l4` 3.11× at
 n = 300k inside the topLevel 3→4 window n ∈ (2^18, ~376k].)_
@@ -139,7 +128,8 @@ executed 2026-07-17.)_
   by `scenarios.bench.mjs` and `compare-counts.bench.mjs`) and unit-tested on both
   branches, closing the uncovered defensive lines in `compare-counts.bench.mjs` — both
   benchmark modules now at 100% statement+branch coverage (suite 159).
-- **#182 done-pending-merge (this PR, 2026-07-21):** cliff investigation complete. CPU
+- **#182 merged (PR #200, 2026-07-21, commit 16e53f2; 1.1.1 released same day):** cliff
+  investigation complete. CPU
   profiles + prototype-level instrumentation localized the **star blowup** to quadratic
   per-chunk `d0.unshift` in `BlockList.batchPrepend` (~1.25e9 element moves at n = 50k;
   64% of self-time) — **fixed** with a single-concat prepend (star 500k: 61 s → ~3.1 s,
@@ -148,8 +138,8 @@ executed 2026-07-17.)_
   seed): an inherent **+24% step** (one extra full relax pass + Set churn per level) —
   documented as known behavior in `HEAD-TO-HEAD.md`'s #182 addendum; the 1.0.0 record's
   5× at 4M is that step plus GC/memory amplification. **Bug fix → patch bump 1.1.1**
-  (batchPrepend violated its documented Lemma 3.3 amortized bound); release fires in
-  Phase E. Findings feed #167/#168 (Roadmap proposals 1–2).
+  (batchPrepend violated its documented Lemma 3.3 amortized bound); **1.1.1 released
+  2026-07-21**. Findings posted on #167/#168 (approved proposals, executed same day).
 - **Semver release convention (user-directed 2026-07-17, PR #186):** bumps only on bug
   fix (patch) or milestone-closing PR (minor/major) — see "Release mechanics" below.
 - **2026-07-16 reflection session (post-release):** measured the BMSSP-vs-Dijkstra
@@ -196,9 +186,9 @@ All six issues done (build order as executed — cheapest protection first, then
 
 ## Milestone `1.2.0` (milestone #3) — performance & ergonomics — CURRENT
 
-Build order: ~~#170~~ (merged, PR #198), ~~#182~~ (done-pending-merge, this PR), then
-**#167 / #168** (the structural/constant-factor work the investigation informs — see
-Roadmap proposals 1–2 for the findings each inherits).
+Build order: ~~#170~~ (merged, PR #198), ~~#182~~ (merged, PR #200, 1.1.1), then
+**#167 / #168** (the structural/constant-factor work the investigation informs — the
+findings each inherits are posted as 2026-07-21 comments on the issues).
 
 | # | Issue | Labels | Notes |
 |---|---|---|---|
@@ -206,7 +196,7 @@ Roadmap proposals 1–2 for the findings each inherits).
 | 168 | Adjacency and relaxation micro-optimizations | enhancement · help wanted | #182 findings: per-level O(m+n) relax pass dominates; relaxEdge allocation + Set churn are the targets |
 | 169 | Optional shortest-path reconstruction (`Pred[]` → paths) | enhancement · help wanted | ✅ merged (PR #189, no bump): public API + independent path oracle |
 | 170 | BMSSP-vs-Dijkstra benchmark comparison | enhancement · help wanted | ✅ merged (PR #198, no bump): head-to-head + count mode in the harness, verified outputs |
-| 182 | Investigate BMSSP performance cliffs: high-fanout (star) graphs and recursion-level transitions | enhancement · help wanted | ✅ done-pending-merge (this PR, **patch → 1.1.1**): star = quadratic batchPrepend, fixed (61 s → ~3.1 s at 500k); level step = inherent +24%, documented (HEAD-TO-HEAD addendum) |
+| 182 | Investigate BMSSP performance cliffs: high-fanout (star) graphs and recursion-level transitions | enhancement · help wanted | ✅ merged (PR #200, **patch → 1.1.1**, released 2026-07-21): star = quadratic batchPrepend, fixed (61 s → ~3.1 s at 500k); level step = inherent +24%, documented (HEAD-TO-HEAD addendum) |
 
 _Note:_ both #182 shapes stay as regression sentinels in every `npm run bench` (`star`,
 `sparse-random-l4`), and `npm run bench:counts` reproduces the comparison-count crossover

--- a/.claude/knowledge/07-glossary.md
+++ b/.claude/knowledge/07-glossary.md
@@ -1,9 +1,9 @@
 # 07 — Glossary
 
-<!-- Updated on: 2026-07-21 (#166 PR: no new symbols — the PR adds JSDoc to index.mjs and
-     rewrites docs/index.html; added the "Docs page" repo term. Terms last extended in the
-     #164 PR: the constant-degree transform — port copies, zero-weight cycle,
-     constantDegreeTransform and its sourceCopy/collapse/copiesOf/originalOf surface) -->
+<!-- Updated on: 2026-07-21 (#167 PR: BoundIndex, partitionByRank, introselect; the
+     "Bound index shortcut" entry rewritten as resolved; comparison-count crossover
+     entry updated to the post-#167 <50k figure. Previous update the same day: #166 PR
+     added the "Docs page" repo term) -->
 
 > **Lifecycle: dynamic — updated in Phase C of every PR.** When a PR introduces new symbols
 > or terms (module names, data-structure fields, paper notation newly used in code), add
@@ -108,10 +108,30 @@ Quick lookup for the symbols and terms used across the paper, the notes, and the
   is `B`), `d0` receives `batchPrepend` blocks and conceptually sits in front of `d1`.
 - **`locator`** (#42) — the `BlockList`'s `Map<key, block>` giving O(1) duplicate handling
   (find/replace an existing key without scanning blocks).
-- **Bound index shortcut** (#42) — `d1`'s block bounds are binary-searched in a plain array
-  instead of the paper's balanced BST, and block **splits**/batch chunking use a sort
-  (O(M log M)) instead of linear-time median selection — same correctness, worse constants.
-  Both upgrades are tracked together in issue #167.
+- **Bound index shortcut (historical, resolved by #167)** — until #167, `d1`'s block
+  bounds were binary-searched in a plain array (O(#blocks) `splice` maintenance) and
+  splits/chunking used a sort (O(M log M)) instead of linear-time selection. Both
+  shortcuts are gone: see `BoundIndex` and `partitionByRank` below.
+- **`BoundIndex`** (#167) — `src/boundIndex.mjs`, the paper's "balanced BST over block
+  upper bounds": a POSITIONAL AVL tree holding `d1`'s block sequence (a node's in-order
+  position is its sequence position; the tree itself never compares items). API:
+  `append` / `insertBefore(node, item)` / `remove(node)` / `first` / `last` /
+  `next(node)` / `findFirst(predicate)` / `size` / `clear`, all O(log size); nodes are
+  handles (`{ item, parent, left, right, height }`), stored by BlockList in
+  `block.node`. `findFirst` requires a predicate monotone along the sequence — with
+  monotone bounds, `bound >= value` binary-searches in O(log #blocks). Internal (not
+  re-exported from `index.mjs`).
+- **`partitionByRank(items, rank, compare?, cheapBudget?)`** (#167) — `src/select.mjs`,
+  deterministic worst-case-linear selection: reorders `items` in place so
+  `items[0..rank]` are the rank+1 smallest and `items[rank]` the rank-th smallest.
+  Used by BlockList for block splits, batchPrepend chunking and pulls. Internal (not
+  re-exported from `index.mjs`).
+- **Introselect (budgeted)** (#167) — `partitionByRank`'s strategy: median-of-3
+  quickselect (deterministic, ~2–3n comparisons — below a sort's n log n) with a work
+  budget (`cheapBudget`, default 6·|items|); exhausting it switches pivots to
+  median-of-medians (groups of 5, guaranteed middle-40% split), keeping the worst case
+  linear. Pure median-of-medians costs ~10–20n comparisons — measured worse than the
+  sorts it replaced — hence the hybrid. `cheapBudget: 0` forces the fallback (tests).
 - **`MinHeap`** (#41) — `src/heap.mjs`, the *indexed* binary min-heap for BaseCase (Alg 2):
   `insert` / `extractMin()` / `peekMin() → { key, value }` / `decreaseKey` / `has` /
   `getValue` / `size` / `isEmpty()`. `has` is Algorithm 2's "is `v` in `H`?" branch;
@@ -243,11 +263,12 @@ Quick lookup for the symbols and terms used across the paper, the notes, and the
   (not re-exported from `index.mjs`).
 - **Comparison-count crossover** — head-to-head result in the paper's comparison-addition
   model: counting every comparison between two distance values (heap sifts, BlockList
-  searches/sorts, relaxations), BMSSP does **fewer** comparisons than Dijkstra past
-  ~n = 1M on sparse graphs (0.91× at n = 2M in the 1.0.0 record) even though Dijkstra
-  still wins wall-clock — the sorting barrier measurably broken, with constant factors as
-  the remaining gap. Since #170, `npm run bench:counts` reproduces it exactly
-  (`compare-counts.bench.mjs` `COUNT_CASES`: 1.20× at 50k → 1.03× at 200k → 0.98× at 1M).
+  searches/selections, relaxations), BMSSP does **fewer** comparisons than Dijkstra on
+  sparse graphs — since #167, from **before n = 50k** (0.97× at 50k → 0.77× at 200k →
+  0.66× at 1M; grid 700×700 at 1.12×), where the sort-based 1.0.0/1.1.1 records crossed
+  only at ~n = 1M (0.91× at 2M). Dijkstra still wins wall-clock — the sorting barrier is
+  measurably broken, with constant factors as the remaining gap. Since #170,
+  `npm run bench:counts` reproduces it exactly (`compare-counts.bench.mjs` `COUNT_CASES`).
 - **Performance cliffs (#182, resolved 2026-07-21)** — two measured regimes where the
   head-to-head ratio broke from its ~1.6–2× pattern; profiled and dispatched in the #182
   investigation (full write-up: `benchmarks/HEAD-TO-HEAD.md` addendum). (1) **Star

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ with every building block shipped, tested, and released individually:
 | Opt-in constant-degree transform, in/out-degree ≤ 2 ([#164](https://github.com/Sirivasv/bmssp-js/issues/164)) | `constantDegreeTransform()` | ✅ done |
 | BMSSP-vs-Dijkstra head-to-head in the benchmark harness ([#170](https://github.com/Sirivasv/bmssp-js/issues/170)) | `npm run bench` / `npm run bench:counts` | ✅ done |
 | Performance-cliff investigation; quadratic `BatchPrepend` fixed ([#182](https://github.com/Sirivasv/bmssp-js/issues/182)) | `src/blockList.mjs` | ✅ done — **1.1.1** |
+| Exact Lemma 3.3 asymptotics: balanced-BST bound index + linear-time selection ([#167](https://github.com/Sirivasv/bmssp-js/issues/167)) | `src/boundIndex.mjs` + `src/select.mjs` | ✅ done |
 
 > **Honest note:** the paper's win is asymptotic, and this repo optimizes for correctness
 > and readability, not raw speed. Measured head-to-head (algorithm time only, graph
@@ -44,10 +45,13 @@ with every building block shipped, tested, and released individually:
 > Dijkstra still wins on wall-clock at every practical size, though the gap narrows as
 > sparse graphs grow (2.5× at 50k nodes → 1.57× at 2M). But in the paper's own metric —
 > **comparisons between path lengths** — BMSSP does **fewer comparisons than Dijkstra
-> from about n = 1M on sparse graphs** (`npm run bench:counts` measures the ratio falling
-> 1.20× at 50k → 1.03× at 200k → 0.98× at 1M; 0.91× at 2M in the record), and the
-> advantage grows with size: the "sorting barrier" is measurably broken; what remains is
-> JS constant factors. The two performance cliffs found in the 1.0.0 measurements were
+> from under n = 50k on sparse graphs** (`npm run bench:counts` measures 0.97× at 50k →
+> 0.77× at 200k → **0.66× at 1M**), and the advantage grows with size: the "sorting
+> barrier" is measurably broken; what remains is JS constant factors. That crossover
+> used to sit at ~n = 1M until [#167](https://github.com/Sirivasv/bmssp-js/issues/167)
+> replaced the block structure's sort-based internals with the paper's exact machinery
+> (balanced-BST bound index + deterministic linear-time selection).
+> The two performance cliffs found in the 1.0.0 measurements were
 > run down in [#182](https://github.com/Sirivasv/bmssp-js/issues/182): the star-graph
 > blowup was a quadratic in `BatchPrepend`'s bookkeeping — fixed in `1.1.1` (500k-node
 > star: 61 s → ~3 s) — and the recursion-level step is an inherent, measured ~+24% per
@@ -70,8 +74,9 @@ with every building block shipped, tested, and released individually:
    closest batch without paying the Θ(log n)-per-vertex "sorting barrier."
 
 The wall-clock crossover point is astronomically large, but the asymptotics are real: in
-measured comparison counts this implementation already beats Dijkstra past ~1M nodes on
-sparse graphs ([benchmarks/HEAD-TO-HEAD.md](benchmarks/HEAD-TO-HEAD.md)). This repo
+measured comparison counts this implementation already beats Dijkstra from under 50k
+nodes on sparse graphs, by a third at 1M
+([benchmarks/HEAD-TO-HEAD.md](benchmarks/HEAD-TO-HEAD.md)). This repo
 optimizes for a **correct, readable, well-tested** implementation, validated line-by-line
 against a Dijkstra oracle — not for raw speed.
 

--- a/benchmarks/HEAD-TO-HEAD.md
+++ b/benchmarks/HEAD-TO-HEAD.md
@@ -145,3 +145,28 @@ recorded 5.00× at n = 4M is memory/GC amplification at 12M edges (visible as GC
 profiles), not an algorithmic discontinuity. Known behavior; the per-level constant is
 #168's target. The `topLevel = 4` window at practical sizes is exactly
 n ∈ (2^18, ~376k] — `sparse-random-l4` (n = 300k) sits inside it.
+
+## Addendum — #167 moves the comparison-count crossover to n < 50k (2026-07-21)
+
+Restoring Lemma 3.3's exact asymptotics in the BlockList
+([#167](https://github.com/Sirivasv/bmssp-js/issues/167): balanced-BST bound index +
+deterministic linear-time selection replacing the array `splice`s and the O(M log M)
+sort-based splits/chunks/pulls) turned out to be worth far more in the paper's own metric
+than the "ordinary constant factors" the #182 profiles suggested. Selection via budgeted
+introselect (median-of-3 quickselect, ~2–3n comparisons, with a median-of-medians
+fallback keeping the worst case linear) does strictly less comparison work than the sorts
+it replaced, at every M:
+
+| case | 1.1.1 (sort-based) | post-#167 | change |
+| --- | --- | --- | --- |
+| sparse d3 n=50k | 1.20× | **0.97×** | crossover reached at 50k |
+| sparse d3 n=200k | 1.03× | **0.77×** | |
+| sparse d3 n=1M | 0.98× | **0.66×** | |
+| grid 700x700 | 1.27× | 1.12× | |
+
+The sparse crossover that previously required ~n = 1M now happens **before n = 50k**, and
+the separation widens with n exactly as O(m·log^(2/3) n) vs. O(m + n·log n) predicts.
+Wall-clock stayed at-or-better than 1.1.1 on every shape (star 50k ~144 ms → ~131 ms;
+sparse 50k within noise; `sparse-random-l4` ~1,246 ms → ~1,083 ms) — the AVL bound index
+and selection cost about what the array + native sort did, while doing asymptotically
+honest work. Current capture: [`RESULTS.md`](./RESULTS.md).

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -86,10 +86,12 @@ path lengths**. Every BMSSP-side comparison funnels through
 `compareKeys` (`src/tieBreak.mjs` keeps an unconditional counter); the
 Dijkstra baseline counts its heap sifts, stale-pop checks and relaxations the
 same way. Counts are deterministic, so one run per side is exact. On sparse
-graphs the bmssp/dijkstra ratio falls as n grows and **crosses below 1.0
-between n = 200k and n = 1M** — the measured form of the paper's asymptotic
-claim (`1.0.0` record: 1.18× at 50k → 1.01× at 200k → 0.96× at 1M → 0.91× at
-2M).
+graphs the bmssp/dijkstra ratio falls as n grows and — since #167's
+selection-based BlockList — is **already below 1.0 at n = 50k** (2026-07-21
+capture: 0.97× at 50k → 0.77× at 200k → 0.66× at 1M), the measured form of
+the paper's asymptotic claim. Before #167, sort-based splits/pulls pushed the
+crossover out to ~n = 1M (`1.0.0` record: 1.18× at 50k → 1.01× at 200k →
+0.96× at 1M → 0.91× at 2M).
 
 ---
 
@@ -108,9 +110,9 @@ harness reruns it on every `npm run bench` (fresh capture:
 - **BMSSP's asymptotics are real and visible:** on sparse graphs the
   wall-clock gap narrows with n (2.5× at 50k → 1.57× at 2M in the 1.0.0
   record), and in the paper's own metric the harness's count mode shows the
-  ratio crossing below 1.0: 1.20× at 50k → 1.03× at 200k → **0.98× at 1M**
-  (0.91× at 2M in the record). The sorting barrier is measurably broken; the
-  remaining loss is constant factors.
+  ratio below 1.0 from n = 50k on: **0.97× at 50k → 0.77× at 200k → 0.66×
+  at 1M** (since #167; ~1M crossover before it). The sorting barrier is
+  measurably broken; the remaining loss is constant factors.
 - **Shapes that blunt BMSSP's edge, per the harness:** `dense-random`
   (relaxation-bound, ~4.7×), `chain` (depth, not sorting, is the cost —
   ~7.4× against the prebuilt-adjacency baseline), `star` (extreme fanout,

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -1,6 +1,6 @@
 # bmssp-js benchmark run
 
-_Generated 2026-07-21T08:24:31.434Z · node v26.5.0 · darwin/arm64_
+_Generated 2026-07-21T10:18:01.877Z · node v26.5.0 · darwin/arm64_
 
 ## Adjacency map vs linear scan (#45)
 
@@ -8,10 +8,10 @@ Graph: 20000 nodes, 80000 edges · 5000 random per-node edge lookups.
 
 | method | median ms | per lookup µs |
 | --- | --- | --- |
-| linear scan (pre-#45) | 417.98 | 83.60 |
-| adjacency map (#45) | 0.12 | 0.02 |
+| linear scan (pre-#45) | 372.80 | 74.56 |
+| adjacency map (#45) | 0.09 | 0.02 |
 
-**Speedup: 3471.1x** faster per-node lookups with the map.
+**Speedup: 4003.2x** faster per-node lookups with the map.
 
 ## Graph-shape scenarios — BMSSP vs Dijkstra (#170)
 
@@ -19,20 +19,20 @@ Algorithm time only: both sides consume the same prebuilt adjacency Map; `mismat
 
 | scenario | nodes | edges | construct ms | dijkstra ms | bmssp ms | ratio | mismatches | notes |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| sparse-random | 50000 | 150000 | 30.04 | 42.90 | 95.82 | 2.23x | 0 | m = O(n), degree 3 — the road-network regime |
-| dense-random | 8000 | 256000 | 16.88 | 14.83 | 69.64 | 4.70x | 0 | avg degree 32 — edge-relaxation-bound |
-| grid-4nbr | 40000 | 159200 | 13.26 | 16.00 | 67.33 | 4.21x | 0 | 200x200 lattice — large diameter, low degree |
-| chain | 50000 | 49999 | 8.04 | 6.08 | 44.65 | 7.35x | 0 | single long path — worst-case depth |
-| star | 50000 | 99998 | 11.67 | 37.70 | 144.11 | 3.82x | 0 | one hub, n-1 spokes — extreme degree skew (#182) |
-| sparse-random-l4 | 300000 | 900000 | 184.34 | 419.21 | 1246.14 | 2.97x | 0 | n just past the topLevel 3→4 step at n = 2^18 (#182) |
+| sparse-random | 50000 | 150000 | 28.68 | 35.03 | 86.20 | 2.46x | 0 | m = O(n), degree 3 — the road-network regime |
+| dense-random | 8000 | 256000 | 17.55 | 13.48 | 60.66 | 4.50x | 0 | avg degree 32 — edge-relaxation-bound |
+| grid-4nbr | 40000 | 159200 | 12.18 | 17.68 | 69.64 | 3.94x | 0 | 200x200 lattice — large diameter, low degree |
+| chain | 50000 | 49999 | 7.81 | 5.03 | 37.39 | 7.43x | 0 | single long path — worst-case depth |
+| star | 50000 | 99998 | 9.09 | 28.82 | 130.66 | 4.53x | 0 | one hub, n-1 spokes — extreme degree skew (#182) |
+| sparse-random-l4 | 300000 | 900000 | 166.84 | 365.42 | 1082.77 | 2.96x | 0 | n just past the topLevel 3→4 step at n = 2^18 (#182) |
 
 ## Comparison counts — the sorting barrier, measured (#170)
 
-Comparisons between path lengths (the paper's cost metric), one exact run per side. On sparse graphs the ratio falls with n and crosses below 1.0 between n = 200k and n = 1M.
+Comparisons between path lengths (the paper's cost metric), one exact run per side. On sparse graphs the ratio falls with n and is already below 1.0 at n = 50k (since #167's selection-based BlockList; it was ~n = 1M before).
 
 | case | nodes | edges | dijkstra cmps | bmssp cmps | ratio | mismatches |
 | --- | --- | --- | --- | --- | --- | --- |
-| sparse d3 n=50k | 50000 | 150000 | 1,653,644 | 1,976,506 | 1.20x | 0 |
-| sparse d3 n=200k | 200000 | 600000 | 7,509,518 | 7,720,650 | 1.03x | 0 |
-| sparse d3 n=1M | 1000000 | 3000000 | 42,809,732 | 42,123,299 | 0.98x | 0 |
-| grid 700x700 | 490000 | 1957200 | 15,269,647 | 19,330,072 | 1.27x | 0 |
+| sparse d3 n=50k | 50000 | 150000 | 1,653,644 | 1,607,005 | 0.97x | 0 |
+| sparse d3 n=200k | 200000 | 600000 | 7,509,518 | 5,763,228 | 0.77x | 0 |
+| sparse d3 n=1M | 1000000 | 3000000 | 42,809,732 | 28,321,521 | 0.66x | 0 |
+| grid 700x700 | 490000 | 1957200 | 15,269,647 | 17,061,608 | 1.12x | 0 |

--- a/benchmarks/compare-counts.bench.mjs
+++ b/benchmarks/compare-counts.bench.mjs
@@ -10,8 +10,9 @@
 //
 // Counts are deterministic (seeded graphs), so a single run per side is
 // exact. On sparse graphs the bmssp/dijkstra ratio falls with n and crosses
-// below 1.0 between n = 200k and n = 1M — the measured form of the paper's
-// asymptotic claim (see benchmarks/HEAD-TO-HEAD.md for the 1.0.0 record).
+// below 1.0 — before n = 50k since #167's selection-based BlockList
+// (~n = 1M in the 1.0.0/1.1.1 records) — the measured form of the paper's
+// asymptotic claim (see benchmarks/HEAD-TO-HEAD.md for the records).
 
 import { BMSSP } from "../src/bmssp.mjs";
 import { resetComparisonCount, getComparisonCount } from "../src/tieBreak.mjs";

--- a/benchmarks/run.mjs
+++ b/benchmarks/run.mjs
@@ -47,8 +47,9 @@ if (withCounts) {
   out.push(section("Comparison counts — the sorting barrier, measured (#170)"));
   out.push(
     "Comparisons between path lengths (the paper's cost metric), one exact" +
-      " run per side. On sparse graphs the ratio falls with n and crosses" +
-      " below 1.0 between n = 200k and n = 1M.\n",
+      " run per side. On sparse graphs the ratio falls with n and is" +
+      " already below 1.0 at n = 50k (since #167's selection-based" +
+      " BlockList; it was ~n = 1M before).\n",
   );
   out.push(counts.table);
 }

--- a/src/blockList.mjs
+++ b/src/blockList.mjs
@@ -42,6 +42,9 @@ class BlockList {
     this.M = Math.floor(M);
     this.B = B;
     this.compare = compare ?? ((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+    // Shared [key, value]-pair comparator for splits/chunking/pulls, hoisted
+    // so the hot paths don't allocate a closure per call
+    this.compareBySecond = (a, b) => this.compare(a[1], b[1]);
     // d1 starts as a single empty block with upper bound B; that block is
     // kept as the sequence's last forever so every value < B has a home
     this.d1 = new BoundIndex();
@@ -108,7 +111,7 @@ class BlockList {
   splitBlock(block) {
     const pairs = [...block.entries];
     const half = pairs.length >> 1;
-    partitionByRank(pairs, half - 1, (a, b) => this.compare(a[1], b[1]));
+    partitionByRank(pairs, half - 1, this.compareBySecond);
     const lower = this.makeBlock(pairs[half - 1][1]);
     for (let i = 0; i < half; i += 1) {
       const [key, value] = pairs[i];
@@ -151,15 +154,32 @@ class BlockList {
       fresh.push([key, value]);
     }
     if (fresh.length === 0) return;
-    // One block if the batch fits; otherwise recursive median splitting into
-    // value-ordered chunks of <= ceil(M/2) — O(|L|/M) blocks built with
-    // O(|L|·max{1, log(|L|/M)}) comparisons, the Lemma 3.3 bound
+    // One block if the batch fits; otherwise value-ordered chunks of
+    // <= ceil(M/2) — O(|L|/M) blocks built with O(|L|·max{1, log(|L|/M)})
+    // comparisons, the Lemma 3.3 bound
     let chunks;
     if (fresh.length <= this.M) {
       chunks = [fresh];
     } else {
+      const chunkSize = Math.ceil(this.M / 2);
       chunks = [];
-      this.chunkByMedian(fresh, Math.ceil(this.M / 2), chunks);
+      if (fresh.length >= chunkSize * chunkSize) {
+        // Many chunks (|L| >= chunkSize², e.g. the M = 1 star regime, where
+        // |L|/M ~ |L|): sorting's O(|L| log |L|) is within 2x of the
+        // O(|L| log(|L|/chunkSize)) target — |L| >= c² gives
+        // log |L| <= 2 log(|L|/c) — and a single sort is much faster than
+        // log(|L|/M) rounds of median selection
+        fresh.sort(this.compareBySecond);
+        for (let i = 0; i < fresh.length; i += chunkSize) {
+          chunks.push(fresh.slice(i, i + chunkSize));
+        }
+      } else {
+        // Few chunks (|L| < chunkSize²): repeated median splitting — here
+        // the recursion is at most log2(chunkSize) levels deep, and a sort
+        // would overshoot the Lemma bound (up to O(|L| log |L|) for
+        // O(|L| log(|L|/M)) with |L| close to M)
+        this.chunkByMedian(fresh, chunkSize, chunks);
+      }
     }
     // Materialize the chunks as blocks (ascending order)...
     const blocks = [];
@@ -194,7 +214,7 @@ class BlockList {
       return;
     }
     const half = pairs.length >> 1;
-    partitionByRank(pairs, half - 1, (a, b) => this.compare(a[1], b[1]));
+    partitionByRank(pairs, half - 1, this.compareBySecond);
     this.chunkByMedian(pairs.slice(0, half), maxSize, out);
     this.chunkByMedian(pairs.slice(half), maxSize, out);
   }
@@ -246,7 +266,7 @@ class BlockList {
     }
     // Move the M smallest candidates to the front (linear-time selection,
     // the Lemma 3.3 O(M) pull) and take them out of the structure
-    partitionByRank(candidates, this.M - 1, (a, b) => this.compare(a[1], b[1]));
+    partitionByRank(candidates, this.M - 1, this.compareBySecond);
     const keys = new Set();
     for (let i = 0; i < this.M; i += 1) {
       const [key, , block] = candidates[i];

--- a/src/blockList.mjs
+++ b/src/blockList.mjs
@@ -1,3 +1,6 @@
+import { BoundIndex } from "./boundIndex.mjs";
+import { partitionByRank } from "./select.mjs";
+
 /**
  * Block-based "partial-sort" structure D from Lemma 3.3 of the BMSSP paper
  * ("Breaking the Sorting Barrier for Directed Single-Source Shortest Paths").
@@ -11,12 +14,16 @@
  * Internal layout:
  * - d1: blocks filled by insert(). Each block carries an upper bound on its
  *   values; bounds are non-decreasing across blocks, and the last block
- *   always has bound B so every value < B has a home.
- * - d0: blocks filled by batchPrepend() only; they conceptually sit in front
- *   of d1 (their values are smaller than everything inserted so far).
+ *   always has bound B so every value < B has a home. The sequence lives in
+ *   a self-balancing BST (BoundIndex) searched through the monotone bounds.
+ * - d0: blocks filled by batchPrepend() only, kept as a doubly-linked list;
+ *   they conceptually sit in front of d1 (their values are smaller than
+ *   everything inserted so far).
  *
- * The block-bound index is a plain array searched with binary search instead
- * of the paper's balanced BST — same behavior, worse constants (issue #167).
+ * Since #167 the structure meets Lemma 3.3's exact bounds: the bound index
+ * is a balanced BST (O(log #blocks) search/split/drop instead of O(#blocks)
+ * array splices) and splits/chunking/pulls use deterministic linear-time
+ * selection (partitionByRank) instead of an O(M log M) sort.
  */
 class BlockList {
   /**
@@ -35,17 +42,23 @@ class BlockList {
     this.M = Math.floor(M);
     this.B = B;
     this.compare = compare ?? ((a, b) => (a < b ? -1 : a > b ? 1 : 0));
-    // d1 starts as a single empty block with upper bound B
-    this.d1 = [this.makeBlock(B)];
-    this.d0 = [];
+    // d1 starts as a single empty block with upper bound B; that block is
+    // kept as the sequence's last forever so every value < B has a home
+    this.d1 = new BoundIndex();
+    this.lastD1Block = this.makeBlock(this.B);
+    this.lastD1Block.node = this.d1.append(this.lastD1Block);
+    // d0 is a doubly-linked list of blocks; the head holds the smallest values
+    this.d0Head = null;
     // key -> block currently holding that key, for O(1) duplicate handling
     this.locator = new Map();
     this.count = 0;
   }
 
-  // Internal: create an empty block with the given value upper bound
+  // Internal: create an empty block with the given value upper bound.
+  // node is the handle in the d1 BoundIndex (null for d0 blocks);
+  // prev/next thread the d0 linked list (null for d1 blocks).
   makeBlock(bound) {
-    return { bound, entries: new Map() };
+    return { bound, entries: new Map(), node: null, prev: null, next: null };
   }
 
   // Number of pairs currently stored
@@ -73,43 +86,37 @@ class BlockList {
       if (this.compare(holder.entries.get(key), value) <= 0) return;
       this.removeKey(key, holder);
     }
-    // Binary-search d1 for the first block whose bound covers the value
-    let lo = 0;
-    let hi = this.d1.length - 1;
-    while (lo < hi) {
-      const mid = (lo + hi) >> 1;
-      if (this.compare(this.d1[mid].bound, value) >= 0) {
-        hi = mid;
-      } else {
-        lo = mid + 1;
-      }
-    }
-    const block = this.d1[lo];
+    // First d1 block whose bound covers the value: bounds are monotone along
+    // the sequence, so this predicate search is the paper's O(log #blocks)
+    // BST lookup. It always succeeds — the last block's bound is B > value.
+    const node = this.d1.findFirst(
+      (candidate) => this.compare(candidate.bound, value) >= 0,
+    );
+    const block = node.item;
     block.entries.set(key, value);
     this.locator.set(key, block);
     this.count += 1;
     if (block.entries.size > this.M) {
-      this.splitBlock(lo);
+      this.splitBlock(block);
     }
   }
 
   // Internal: split an overfull d1 block into two halves around its median
-  // value. The lower half gets bound = its own max value; the upper half
-  // keeps the original bound, so inter-block ordering is preserved.
-  // (The paper uses linear-time median selection; sorting is O(M log M) but
-  // simpler — acceptable for this correctness-first implementation.)
-  splitBlock(index) {
-    const block = this.d1[index];
-    const sorted = [...block.entries].sort((a, b) => this.compare(a[1], b[1]));
-    const half = sorted.length >> 1;
-    const lower = this.makeBlock(sorted[half - 1][1]);
+  // value (deterministic linear-time selection, as Lemma 3.3 prescribes).
+  // The lower half gets bound = the median (its own max value); the upper
+  // half keeps the original bound, so inter-block ordering is preserved.
+  splitBlock(block) {
+    const pairs = [...block.entries];
+    const half = pairs.length >> 1;
+    partitionByRank(pairs, half - 1, (a, b) => this.compare(a[1], b[1]));
+    const lower = this.makeBlock(pairs[half - 1][1]);
     for (let i = 0; i < half; i += 1) {
-      const [key, value] = sorted[i];
+      const [key, value] = pairs[i];
       block.entries.delete(key);
       lower.entries.set(key, value);
       this.locator.set(key, lower);
     }
-    this.d1.splice(index, 0, lower);
+    lower.node = this.d1.insertBefore(block.node, lower);
   }
 
   /**
@@ -144,23 +151,17 @@ class BlockList {
       fresh.push([key, value]);
     }
     if (fresh.length === 0) return;
-    // One block if the batch fits, otherwise sorted chunks of <= ceil(M/2)
+    // One block if the batch fits; otherwise recursive median splitting into
+    // value-ordered chunks of <= ceil(M/2) — O(|L|/M) blocks built with
+    // O(|L|·max{1, log(|L|/M)}) comparisons, the Lemma 3.3 bound
     let chunks;
     if (fresh.length <= this.M) {
       chunks = [fresh];
     } else {
-      fresh.sort((a, b) => this.compare(a[1], b[1]));
-      const chunkSize = Math.ceil(this.M / 2);
       chunks = [];
-      for (let i = 0; i < fresh.length; i += chunkSize) {
-        chunks.push(fresh.slice(i, i + chunkSize));
-      }
+      this.chunkByMedian(fresh, Math.ceil(this.M / 2), chunks);
     }
-    // Materialize the chunks as blocks (ascending, so chunk 0 — the smallest
-    // values — ends up frontmost) and prepend them all in one concat. A
-    // per-chunk unshift here re-shifts the whole d0 array every time: with a
-    // small M the chunk count approaches |L| and the loop turns quadratic —
-    // the #182 star-graph blowup (~n single-entry chunks at M = 1).
+    // Materialize the chunks as blocks (ascending order)...
     const blocks = [];
     for (const chunk of chunks) {
       // Seed the block bound with the first value, then max-update — avoids
@@ -174,7 +175,28 @@ class BlockList {
       }
       blocks.push(block);
     }
-    this.d0 = blocks.concat(this.d0);
+    // ...and link them in front of d0, smallest chunk becoming the new head
+    let head = this.d0Head;
+    for (let i = blocks.length - 1; i >= 0; i -= 1) {
+      const block = blocks[i];
+      block.next = head;
+      if (head !== null) head.prev = block;
+      head = block;
+    }
+    this.d0Head = head;
+  }
+
+  // Internal: recursively median-split pairs (in place / via slices) into
+  // value-ordered chunks of at most maxSize, appended to out ascending
+  chunkByMedian(pairs, maxSize, out) {
+    if (pairs.length <= maxSize) {
+      out.push(pairs);
+      return;
+    }
+    const half = pairs.length >> 1;
+    partitionByRank(pairs, half - 1, (a, b) => this.compare(a[1], b[1]));
+    this.chunkByMedian(pairs.slice(0, half), maxSize, out);
+    this.chunkByMedian(pairs.slice(half), maxSize, out);
   }
 
   /**
@@ -189,8 +211,10 @@ class BlockList {
     if (this.count <= this.M) {
       // Everything fits in one batch: drain the structure and reset it
       const keys = new Set(this.locator.keys());
-      this.d0 = [];
-      this.d1 = [this.makeBlock(this.B)];
+      this.d0Head = null;
+      this.d1.clear();
+      this.lastD1Block = this.makeBlock(this.B);
+      this.lastD1Block.node = this.d1.append(this.lastD1Block);
       this.locator.clear();
       this.count = 0;
       return { keys, bound: this.B };
@@ -198,18 +222,31 @@ class BlockList {
     // Collect prefix blocks from each sequence until that side holds >= M
     // candidate elements (or runs out). The M smallest overall are in there.
     const candidates = [];
-    for (const seq of [this.d0, this.d1]) {
-      let collected = 0;
-      for (const block of seq) {
-        if (collected >= this.M) break;
-        for (const [key, value] of block.entries) {
-          candidates.push([key, value, block]);
-        }
-        collected += block.entries.size;
+    let collected = 0;
+    for (
+      let block = this.d0Head;
+      block !== null && collected < this.M;
+      block = block.next
+    ) {
+      for (const [key, value] of block.entries) {
+        candidates.push([key, value, block]);
       }
+      collected += block.entries.size;
     }
-    // Take the M smallest candidates out of the structure
-    candidates.sort((a, b) => this.compare(a[1], b[1]));
+    collected = 0;
+    for (
+      let node = this.d1.first();
+      node !== null && collected < this.M;
+      node = this.d1.next(node)
+    ) {
+      for (const [key, value] of node.item.entries) {
+        candidates.push([key, value, node.item]);
+      }
+      collected += node.item.entries.size;
+    }
+    // Move the M smallest candidates to the front (linear-time selection,
+    // the Lemma 3.3 O(M) pull) and take them out of the structure
+    partitionByRank(candidates, this.M - 1, (a, b) => this.compare(a[1], b[1]));
     const keys = new Set();
     for (let i = 0; i < this.M; i += 1) {
       const [key, , block] = candidates[i];
@@ -222,12 +259,20 @@ class BlockList {
     // Under a strict total order (#163's composite keys) this separator is
     // strictly above every pulled value — no boundary ties.
     let bound = null;
-    for (const seq of [this.d0, this.d1]) {
-      const block = seq.find((b) => b.entries.size > 0);
-      if (block) {
+    for (let block = this.d0Head; block !== null; block = block.next) {
+      if (block.entries.size > 0) {
         for (const value of block.entries.values()) {
           if (bound === null || this.compare(value, bound) < 0) bound = value;
         }
+        break;
+      }
+    }
+    for (let node = this.d1.first(); node !== null; node = this.d1.next(node)) {
+      if (node.item.entries.size > 0) {
+        for (const value of node.item.entries.values()) {
+          if (bound === null || this.compare(value, bound) < 0) bound = value;
+        }
+        break;
       }
     }
     return { keys, bound };
@@ -244,18 +289,18 @@ class BlockList {
     }
   }
 
-  // Internal: physically remove an emptied block. The last d1 block (bound B)
-  // is kept even when empty so insert always finds a home for any value < B.
+  // Internal: physically remove an emptied block from its sequence — an
+  // O(log #blocks) BST removal for d1, an O(1) unlink for d0. The last d1
+  // block (bound B) is kept even when empty so insert always finds a home.
   dropIfEmpty(block) {
-    const i0 = this.d0.indexOf(block);
-    if (i0 !== -1) {
-      this.d0.splice(i0, 1);
+    if (block.node !== null) {
+      if (block === this.lastD1Block) return;
+      this.d1.remove(block.node);
       return;
     }
-    const i1 = this.d1.indexOf(block);
-    if (i1 !== -1 && i1 < this.d1.length - 1) {
-      this.d1.splice(i1, 1);
-    }
+    if (block.prev !== null) block.prev.next = block.next;
+    else this.d0Head = block.next;
+    if (block.next !== null) block.next.prev = block.prev;
   }
 }
 

--- a/src/boundIndex.mjs
+++ b/src/boundIndex.mjs
@@ -1,0 +1,243 @@
+/**
+ * Self-balancing (AVL) ordered sequence — the "balanced BST over block upper
+ * bounds" of Lemma 3.3 (issue #167; replaces BlockList's plain-array bound
+ * index, whose splice-based maintenance paid O(#blocks) per split/drop).
+ *
+ * BlockList keeps its d1 blocks with non-decreasing value bounds. This tree
+ * stores that block sequence POSITIONALLY: a node's in-order position is its
+ * sequence position, and the tree itself never compares items. Because the
+ * bounds are monotone along the sequence, findFirst with a monotone
+ * predicate binary-searches the sequence in O(log size) — the paper's bound
+ * lookup — while insertBefore / append / remove stay O(log size) via AVL
+ * rebalancing.
+ *
+ * Nodes are plain objects { item, parent, left, right, height } returned as
+ * handles; callers keep the handle to later remove or iterate from it.
+ */
+class BoundIndex {
+  constructor() {
+    this.root = null;
+    this.count = 0;
+  }
+
+  // Number of items currently stored
+  get size() {
+    return this.count;
+  }
+
+  // Drop every item
+  clear() {
+    this.root = null;
+    this.count = 0;
+  }
+
+  // First node in sequence order, or null when empty
+  first() {
+    let node = this.root;
+    if (node === null) return null;
+    while (node.left !== null) node = node.left;
+    return node;
+  }
+
+  // Last node in sequence order, or null when empty
+  last() {
+    let node = this.root;
+    if (node === null) return null;
+    while (node.right !== null) node = node.right;
+    return node;
+  }
+
+  // In-order successor of a node, or null at the end of the sequence
+  next(node) {
+    if (node.right !== null) {
+      let succ = node.right;
+      while (succ.left !== null) succ = succ.left;
+      return succ;
+    }
+    let child = node;
+    let parent = child.parent;
+    while (parent !== null && parent.right === child) {
+      child = parent;
+      parent = parent.parent;
+    }
+    return parent;
+  }
+
+  /**
+   * Leftmost node whose item satisfies the predicate, or null when none
+   * does. The predicate must be monotone along the sequence (a prefix of
+   * false followed by a suffix of true) — with BlockList's non-decreasing
+   * bounds, `(block) => compare(block.bound, value) >= 0` is exactly that.
+   * O(log size).
+   * @param {(item: *) => boolean} predicate
+   * @returns {*} The matching node handle, or null
+   */
+  findFirst(predicate) {
+    let node = this.root;
+    let found = null;
+    while (node !== null) {
+      if (predicate(node.item)) {
+        found = node;
+        node = node.left;
+      } else {
+        node = node.right;
+      }
+    }
+    return found;
+  }
+
+  /**
+   * Insert an item at the end of the sequence. O(log size).
+   * @returns {*} The new node handle
+   */
+  append(item) {
+    const node = this.makeNode(item);
+    if (this.root === null) {
+      this.root = node;
+    } else {
+      const tail = this.last();
+      tail.right = node;
+      node.parent = tail;
+      this.rebalance(tail);
+    }
+    this.count += 1;
+    return node;
+  }
+
+  /**
+   * Insert an item immediately before an existing node. O(log size).
+   * @param {*} reference - Node handle the new item goes in front of
+   * @returns {*} The new node handle
+   */
+  insertBefore(reference, item) {
+    const node = this.makeNode(item);
+    if (reference.left === null) {
+      reference.left = node;
+      node.parent = reference;
+    } else {
+      let pred = reference.left;
+      while (pred.right !== null) pred = pred.right;
+      pred.right = node;
+      node.parent = pred;
+    }
+    this.count += 1;
+    this.rebalance(node.parent);
+    return node;
+  }
+
+  /**
+   * Remove a node from the sequence. O(log size).
+   * @param {*} node - Node handle previously returned by append/insertBefore
+   */
+  remove(node) {
+    let start; // deepest structurally-changed node, where rebalancing begins
+    if (node.left === null) {
+      start = node.parent;
+      this.replaceInParent(node, node.right);
+    } else if (node.right === null) {
+      start = node.parent;
+      this.replaceInParent(node, node.left);
+    } else {
+      // Two children: splice out the in-order successor (which has no left
+      // child) and put it in the removed node's place
+      let succ = node.right;
+      while (succ.left !== null) succ = succ.left;
+      if (succ.parent === node) {
+        start = succ;
+      } else {
+        start = succ.parent;
+        this.replaceInParent(succ, succ.right);
+        succ.right = node.right;
+        succ.right.parent = succ;
+      }
+      this.replaceInParent(node, succ);
+      succ.left = node.left;
+      succ.left.parent = succ;
+      succ.height = node.height;
+    }
+    node.parent = node.left = node.right = null;
+    this.count -= 1;
+    this.rebalance(start);
+  }
+
+  // Internal: fresh leaf node
+  makeNode(item) {
+    return { item, parent: null, left: null, right: null, height: 1 };
+  }
+
+  // Internal: make replacement take node's place under node's parent
+  // (replacement may be null)
+  replaceInParent(node, replacement) {
+    const parent = node.parent;
+    if (parent === null) {
+      this.root = replacement;
+    } else if (parent.left === node) {
+      parent.left = replacement;
+    } else {
+      parent.right = replacement;
+    }
+    if (replacement !== null) replacement.parent = parent;
+  }
+
+  // Internal: height of a possibly-null subtree
+  heightOf(node) {
+    return node === null ? 0 : node.height;
+  }
+
+  // Internal: recompute a node's height from its children
+  updateHeight(node) {
+    node.height =
+      1 + Math.max(this.heightOf(node.left), this.heightOf(node.right));
+  }
+
+  // Internal: left-minus-right height difference
+  balanceOf(node) {
+    return this.heightOf(node.left) - this.heightOf(node.right);
+  }
+
+  // Internal: walk from node to the root, updating heights and rotating
+  // wherever the AVL invariant |balance| <= 1 broke (deletion can require a
+  // rotation at every level; insertion at most one — the loop covers both)
+  rebalance(node) {
+    while (node !== null) {
+      this.updateHeight(node);
+      const balance = this.balanceOf(node);
+      if (balance > 1) {
+        if (this.balanceOf(node.left) < 0) this.rotateLeft(node.left);
+        node = this.rotateRight(node);
+      } else if (balance < -1) {
+        if (this.balanceOf(node.right) > 0) this.rotateRight(node.right);
+        node = this.rotateLeft(node);
+      }
+      node = node.parent;
+    }
+  }
+
+  // Internal: standard AVL rotation; returns the subtree's new root
+  rotateLeft(node) {
+    const pivot = node.right;
+    node.right = pivot.left;
+    if (pivot.left !== null) pivot.left.parent = node;
+    this.replaceInParent(node, pivot);
+    pivot.left = node;
+    node.parent = pivot;
+    this.updateHeight(node);
+    this.updateHeight(pivot);
+    return pivot;
+  }
+
+  // Internal: mirror of rotateLeft
+  rotateRight(node) {
+    const pivot = node.left;
+    node.left = pivot.right;
+    if (pivot.right !== null) pivot.right.parent = node;
+    this.replaceInParent(node, pivot);
+    pivot.right = node;
+    node.parent = pivot;
+    this.updateHeight(node);
+    this.updateHeight(pivot);
+    return pivot;
+  }
+}
+
+export { BoundIndex };

--- a/src/select.mjs
+++ b/src/select.mjs
@@ -4,10 +4,15 @@
  * chunking and pulls (issue #167; replaces the sort-based O(M log M)
  * shortcut).
  *
- * Quickselect with a median-of-medians pivot (groups of 5): the pivot is
- * guaranteed to land in the middle 40% of the range, so every round discards
- * a constant fraction and the whole selection is O(n) comparisons in the
- * worst case — with no randomness, so runs stay fully reproducible.
+ * Introselect construction: quickselect with a deterministic median-of-3
+ * pivot (~2–3n comparisons on typical inputs — well below a sort's n log n)
+ * guarded by a work budget. If pathological pivots exhaust the budget, the
+ * pivot switches to median-of-medians (groups of 5), whose guaranteed
+ * middle-40% pivot makes the remainder linear — so the whole selection is
+ * O(n) worst case. Median-of-medians alone would also be linear but costs
+ * ~10–20n comparisons, MORE than sorting at practical sizes; the budgeted
+ * hybrid keeps both the bound and the constant. No randomness anywhere:
+ * runs stay fully reproducible.
  */
 
 // Internal: swap two array slots
@@ -18,7 +23,7 @@ function swap(items, i, j) {
 }
 
 // Internal: insertion-sort the closed range [lo, hi] (only ever called on
-// groups of at most 5 elements)
+// ranges of at most 5 elements)
 function sortRange(items, lo, hi, compare) {
   for (let i = lo + 1; i <= hi; i += 1) {
     const item = items[i];
@@ -31,14 +36,25 @@ function sortRange(items, lo, hi, compare) {
   }
 }
 
-// Internal: median-of-medians pivot for the closed range [lo, hi]. Sorts
-// each group of 5, gathers the group medians at the front of the range, and
-// recursively selects their median.
-function pivotOf(items, lo, hi, compare) {
-  if (hi - lo < 5) {
-    sortRange(items, lo, hi, compare);
-    return items[lo + ((hi - lo) >> 1)];
+// Internal: cheap deterministic pivot — median of the first, middle and
+// last elements of the range
+function medianOfThree(items, lo, hi, compare) {
+  const first = items[lo];
+  const middle = items[lo + ((hi - lo) >> 1)];
+  const last = items[hi];
+  if (compare(first, middle) < 0) {
+    if (compare(middle, last) < 0) return middle;
+    return compare(first, last) < 0 ? last : first;
   }
+  if (compare(first, last) < 0) return first;
+  return compare(middle, last) < 0 ? last : middle;
+}
+
+// Internal: median-of-medians pivot for the closed range [lo, hi] — the
+// budget-exhausted fallback. Sorts each group of 5, gathers the group
+// medians at the front of the range, and recursively selects their median;
+// the result splits the range at worst 30/70.
+function medianOfMedians(items, lo, hi, compare) {
   let write = lo;
   for (let i = lo; i <= hi; i += 5) {
     const groupHi = Math.min(i + 4, hi);
@@ -47,17 +63,26 @@ function pivotOf(items, lo, hi, compare) {
     write += 1;
   }
   const mid = lo + ((write - 1 - lo) >> 1);
-  selectRange(items, mid, compare, lo, write - 1);
+  selectRange(items, mid, compare, lo, write - 1, 6 * (write - lo));
   return items[mid];
 }
 
-// Internal: quickselect on the closed range [lo, hi]. Elements outside the
-// active range are already on their correct side, so when the range narrows
-// to the rank (or the rank falls inside the pivot-equal band) the whole
-// prefix [0..rank] holds the rank+1 smallest.
-function selectRange(items, rank, compare, lo, hi) {
+// Internal: budgeted quickselect on the closed range [lo, hi]. Elements
+// outside the active range are already on their correct side, so when the
+// range narrows to the rank (or the rank falls inside the pivot-equal band)
+// the whole prefix [0..rank] holds the rank+1 smallest.
+function selectRange(items, rank, compare, lo, hi, budget) {
   while (lo < hi) {
-    const pivot = pivotOf(items, lo, hi, compare);
+    if (hi - lo < 5) {
+      sortRange(items, lo, hi, compare);
+      return;
+    }
+    const size = hi - lo + 1;
+    const pivot =
+      budget > 0
+        ? medianOfThree(items, lo, hi, compare)
+        : medianOfMedians(items, lo, hi, compare);
+    budget -= size;
     // Three-way partition: [lo, lt) < pivot, [lt, gt] == pivot, (gt, hi] >
     // pivot. The equal band makes duplicate-heavy inputs terminate in one
     // round instead of degrading.
@@ -96,10 +121,14 @@ function selectRange(items, rank, compare, lo, hi) {
  * @param {number} rank - 0-indexed target rank, 0 <= rank < items.length
  * @param {(a: *, b: *) => number} [compare] - Comparator (negative when
  *   a < b). Defaults to numeric order.
+ * @param {number} [cheapBudget] - Elements the median-of-3 phase may visit
+ *   before pivots switch to median-of-medians. Defaults to 6·items.length
+ *   (never reached on non-adversarial inputs); pass 0 to force the
+ *   median-of-medians path throughout (used by tests).
  * @returns {*} items[rank], the rank-th smallest element
  * @throws {Error} If items is not a non-empty array or rank is out of range
  */
-function partitionByRank(items, rank, compare) {
+function partitionByRank(items, rank, compare, cheapBudget) {
   if (!Array.isArray(items) || items.length === 0) {
     throw new Error("items must be a non-empty array");
   }
@@ -107,7 +136,8 @@ function partitionByRank(items, rank, compare) {
     throw new Error("rank must be an integer index into items");
   }
   const order = compare ?? ((a, b) => (a < b ? -1 : a > b ? 1 : 0));
-  selectRange(items, rank, order, 0, items.length - 1);
+  const budget = cheapBudget ?? 6 * items.length;
+  selectRange(items, rank, order, 0, items.length - 1, budget);
   return items[rank];
 }
 

--- a/src/select.mjs
+++ b/src/select.mjs
@@ -1,0 +1,114 @@
+/**
+ * Deterministic worst-case-linear selection — the "linear-time median
+ * selection" Lemma 3.3 prescribes for BlockList block splits, batch
+ * chunking and pulls (issue #167; replaces the sort-based O(M log M)
+ * shortcut).
+ *
+ * Quickselect with a median-of-medians pivot (groups of 5): the pivot is
+ * guaranteed to land in the middle 40% of the range, so every round discards
+ * a constant fraction and the whole selection is O(n) comparisons in the
+ * worst case — with no randomness, so runs stay fully reproducible.
+ */
+
+// Internal: swap two array slots
+function swap(items, i, j) {
+  const tmp = items[i];
+  items[i] = items[j];
+  items[j] = tmp;
+}
+
+// Internal: insertion-sort the closed range [lo, hi] (only ever called on
+// groups of at most 5 elements)
+function sortRange(items, lo, hi, compare) {
+  for (let i = lo + 1; i <= hi; i += 1) {
+    const item = items[i];
+    let j = i - 1;
+    while (j >= lo && compare(items[j], item) > 0) {
+      items[j + 1] = items[j];
+      j -= 1;
+    }
+    items[j + 1] = item;
+  }
+}
+
+// Internal: median-of-medians pivot for the closed range [lo, hi]. Sorts
+// each group of 5, gathers the group medians at the front of the range, and
+// recursively selects their median.
+function pivotOf(items, lo, hi, compare) {
+  if (hi - lo < 5) {
+    sortRange(items, lo, hi, compare);
+    return items[lo + ((hi - lo) >> 1)];
+  }
+  let write = lo;
+  for (let i = lo; i <= hi; i += 5) {
+    const groupHi = Math.min(i + 4, hi);
+    sortRange(items, i, groupHi, compare);
+    swap(items, write, i + ((groupHi - i) >> 1));
+    write += 1;
+  }
+  const mid = lo + ((write - 1 - lo) >> 1);
+  selectRange(items, mid, compare, lo, write - 1);
+  return items[mid];
+}
+
+// Internal: quickselect on the closed range [lo, hi]. Elements outside the
+// active range are already on their correct side, so when the range narrows
+// to the rank (or the rank falls inside the pivot-equal band) the whole
+// prefix [0..rank] holds the rank+1 smallest.
+function selectRange(items, rank, compare, lo, hi) {
+  while (lo < hi) {
+    const pivot = pivotOf(items, lo, hi, compare);
+    // Three-way partition: [lo, lt) < pivot, [lt, gt] == pivot, (gt, hi] >
+    // pivot. The equal band makes duplicate-heavy inputs terminate in one
+    // round instead of degrading.
+    let lt = lo;
+    let i = lo;
+    let gt = hi;
+    while (i <= gt) {
+      const order = compare(items[i], pivot);
+      if (order < 0) {
+        swap(items, lt, i);
+        lt += 1;
+        i += 1;
+      } else if (order > 0) {
+        swap(items, i, gt);
+        gt -= 1;
+      } else {
+        i += 1;
+      }
+    }
+    if (rank < lt) {
+      hi = lt - 1;
+    } else if (rank > gt) {
+      lo = gt + 1;
+    } else {
+      return;
+    }
+  }
+}
+
+/**
+ * Partially reorder items IN PLACE so that items[0..rank] are the rank+1
+ * smallest under compare and items[rank] is the largest of them (i.e. the
+ * rank-th smallest overall, 0-indexed). Order within the two sides is
+ * unspecified — exactly what a semi-sorted block structure needs.
+ * @param {Array<*>} items - Reordered in place
+ * @param {number} rank - 0-indexed target rank, 0 <= rank < items.length
+ * @param {(a: *, b: *) => number} [compare] - Comparator (negative when
+ *   a < b). Defaults to numeric order.
+ * @returns {*} items[rank], the rank-th smallest element
+ * @throws {Error} If items is not a non-empty array or rank is out of range
+ */
+function partitionByRank(items, rank, compare) {
+  if (!Array.isArray(items) || items.length === 0) {
+    throw new Error("items must be a non-empty array");
+  }
+  if (!Number.isInteger(rank) || rank < 0 || rank >= items.length) {
+    throw new Error("rank must be an integer index into items");
+  }
+  const order = compare ?? ((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+  selectRange(items, rank, order, 0, items.length - 1);
+  return items[rank];
+}
+
+export { partitionByRank };

--- a/test/blockList.test.mjs
+++ b/test/blockList.test.mjs
@@ -303,6 +303,103 @@ describe("BlockList batchPrepend", () => {
   });
 });
 
+describe("BlockList #167 machinery (balanced bound index + selection)", () => {
+  test("hundreds of splits at a small M still drain in sorted order", () => {
+    // M = 2 with 600 shuffled distinct inserts forces ~hundreds of d1
+    // blocks, exercising the AVL bound index's splits and searches deep
+    // into rebalancing territory
+    const M = 2;
+    const list = new BlockList(M, Infinity);
+    const values = new Map();
+    for (let i = 0; i < 600; i += 1) {
+      const value = (i * 389) % 600; // distinct values 0..599, shuffled
+      list.insert(i, value);
+      values.set(i, value);
+    }
+    expect(list.size).toBe(600);
+    let previous = -Infinity;
+    for (const { keys, bound } of drain(list)) {
+      expect(keys.size).toBeLessThanOrEqual(M);
+      const pulled = [...keys].map((k) => values.get(k));
+      expect(Math.min(...pulled)).toBeGreaterThan(previous);
+      previous = Math.max(...pulled);
+      if (bound !== Infinity) expect(bound).toBeGreaterThan(previous);
+    }
+    expect(previous).toBe(599);
+  });
+
+  test("duplicate-key replacements empty and drop interior d1 blocks", () => {
+    // Insert enough to split into several blocks, then move every key of
+    // the middle band to tiny values: each move deletes from an interior
+    // block (dropping it when emptied — a BST removal) and re-inserts
+    const M = 3;
+    const list = new BlockList(M, 1000);
+    const values = new Map();
+    for (let i = 0; i < 30; i += 1) {
+      list.insert(i, 100 + i * 10);
+      values.set(i, 100 + i * 10);
+    }
+    for (let i = 10; i < 20; i += 1) {
+      list.insert(i, i - 10); // 0..9, far below the stored 200..290
+      values.set(i, i - 10);
+    }
+    expect(list.size).toBe(30);
+    const first = list.pull();
+    expect(first.keys).toEqual(new Set([10, 11, 12]));
+    let previous = Math.max(...[...first.keys].map((k) => values.get(k)));
+    let drained = first.keys.size;
+    for (const { keys } of drain(list)) {
+      const pulled = [...keys].map((k) => values.get(k));
+      expect(Math.min(...pulled)).toBeGreaterThan(previous);
+      previous = Math.max(...pulled);
+      drained += keys.size;
+    }
+    expect(drained).toBe(30);
+    expect(previous).toBe(390); // key 29's untouched original value
+  });
+
+  test("a large batchPrepend chunks by median and drains sorted", () => {
+    const M = 8;
+    const list = new BlockList(M, Infinity);
+    list.insert("far", 1e9);
+    const values = new Map([["far", 1e9]]);
+    const batch = [];
+    for (let i = 0; i < 1000; i += 1) {
+      const value = (i * 761) % 1000; // distinct values 0..999, shuffled
+      batch.push([i, value]);
+      values.set(i, value);
+    }
+    list.batchPrepend(batch);
+    expect(list.size).toBe(1001);
+    let previous = -Infinity;
+    for (const { keys } of drain(list)) {
+      expect(keys.size).toBeLessThanOrEqual(M);
+      const pulled = [...keys].map((k) => values.get(k));
+      expect(Math.min(...pulled)).toBeGreaterThan(previous);
+      previous = Math.max(...pulled);
+    }
+    expect(previous).toBe(1e9);
+  });
+
+  test("insert replacement can empty and unlink a middle d0 block", () => {
+    // M = 1 turns every prepended pair into its own d0 block; replacing the
+    // middle block's key exercises the linked-list unlink of an interior
+    // block (head and tail unlinks are covered by the drain tests)
+    const list = new BlockList(1, 100);
+    list.insert("seed", 90);
+    list.pull();
+    list.batchPrepend([
+      ["a", 3],
+      ["b", 2],
+      ["c", 1],
+    ]);
+    list.insert("b", 0.5); // removes b from the middle d0 block, re-inserts
+    expect(list.size).toBe(3);
+    const order = drain(list).map(({ keys }) => [...keys][0]);
+    expect(order).toEqual(["b", "c", "a"]);
+  });
+});
+
 describe("BlockList stress (seeded)", () => {
   // Mimics how Algorithm 3 drives D: after a pull with separator Bi, new
   // inserts land in [Bi, B) and batch-prepends land in [Bi', Bi) — i.e. at

--- a/test/blockList.test.mjs
+++ b/test/blockList.test.mjs
@@ -358,7 +358,9 @@ describe("BlockList #167 machinery (balanced bound index + selection)", () => {
     expect(previous).toBe(390); // key 29's untouched original value
   });
 
-  test("a large batchPrepend chunks by median and drains sorted", () => {
+  test("a many-chunk batchPrepend (sort branch) drains sorted", () => {
+    // 1000 pairs at M = 8 (chunkSize 4): |L| >= chunkSize², the sort-based
+    // chunking branch
     const M = 8;
     const list = new BlockList(M, Infinity);
     list.insert("far", 1e9);
@@ -371,6 +373,31 @@ describe("BlockList #167 machinery (balanced bound index + selection)", () => {
     }
     list.batchPrepend(batch);
     expect(list.size).toBe(1001);
+    let previous = -Infinity;
+    for (const { keys } of drain(list)) {
+      expect(keys.size).toBeLessThanOrEqual(M);
+      const pulled = [...keys].map((k) => values.get(k));
+      expect(Math.min(...pulled)).toBeGreaterThan(previous);
+      previous = Math.max(...pulled);
+    }
+    expect(previous).toBe(1e9);
+  });
+
+  test("a few-chunk batchPrepend (median-recursion branch) drains sorted", () => {
+    // 2000 pairs at M = 100 (chunkSize 50): M < |L| < chunkSize², the
+    // repeated-median-splitting branch of the chunker
+    const M = 100;
+    const list = new BlockList(M, Infinity);
+    list.insert("far", 1e9);
+    const values = new Map([["far", 1e9]]);
+    const batch = [];
+    for (let i = 0; i < 2000; i += 1) {
+      const value = (i * 1223) % 2000; // distinct values 0..1999, shuffled
+      batch.push([i, value]);
+      values.set(i, value);
+    }
+    list.batchPrepend(batch);
+    expect(list.size).toBe(2001);
     let previous = -Infinity;
     for (const { keys } of drain(list)) {
       expect(keys.size).toBeLessThanOrEqual(M);

--- a/test/boundIndex.test.mjs
+++ b/test/boundIndex.test.mjs
@@ -1,0 +1,172 @@
+import { describe, test, expect } from "@jest/globals";
+import { BoundIndex } from "../src/boundIndex.mjs";
+
+// Small deterministic PRNG so stress-test failures are reproducible
+function mulberry32(seed) {
+  let a = seed >>> 0;
+  return function () {
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// In-order item walk via the public iteration surface
+function toArray(tree) {
+  const items = [];
+  for (let node = tree.first(); node !== null; node = tree.next(node)) {
+    items.push(node.item);
+  }
+  return items;
+}
+
+// Recursively verify the AVL shape: parent pointers consistent, stored
+// heights correct, every balance factor within [-1, 1]. Returns the height.
+function verifyShape(node, parent) {
+  if (node === null) return 0;
+  expect(node.parent).toBe(parent);
+  const left = verifyShape(node.left, node);
+  const right = verifyShape(node.right, node);
+  expect(node.height).toBe(1 + Math.max(left, right));
+  expect(Math.abs(left - right)).toBeLessThanOrEqual(1);
+  return node.height;
+}
+
+describe("BoundIndex basics", () => {
+  test("starts empty and clears back to empty", () => {
+    const tree = new BoundIndex();
+    expect(tree.size).toBe(0);
+    expect(tree.first()).toBeNull();
+    expect(tree.last()).toBeNull();
+    tree.append("a");
+    tree.append("b");
+    expect(tree.size).toBe(2);
+    tree.clear();
+    expect(tree.size).toBe(0);
+    expect(tree.first()).toBeNull();
+    expect(toArray(tree)).toEqual([]);
+  });
+
+  test("append keeps sequence order; first/last/next agree", () => {
+    const tree = new BoundIndex();
+    const items = ["a", "b", "c", "d", "e", "f", "g"];
+    for (const item of items) tree.append(item);
+    expect(toArray(tree)).toEqual(items);
+    expect(tree.first().item).toBe("a");
+    expect(tree.last().item).toBe("g");
+    verifyShape(tree.root, null);
+  });
+
+  test("insertBefore places items at the head and mid-sequence", () => {
+    const tree = new BoundIndex();
+    const b = tree.append("b");
+    const d = tree.append("d");
+    tree.insertBefore(b, "a"); // head insert (reference has no left child)
+    tree.insertBefore(d, "c"); // middle insert
+    tree.insertBefore(d, "c2"); // reference now has a left subtree
+    expect(toArray(tree)).toEqual(["a", "b", "c", "c2", "d"]);
+    verifyShape(tree.root, null);
+  });
+
+  test("remove handles leaves, one-child and two-children nodes", () => {
+    const tree = new BoundIndex();
+    const nodes = [];
+    for (let i = 0; i < 10; i += 1) nodes.push(tree.append(i));
+    tree.remove(nodes[9]); // leaf
+    tree.remove(nodes[0]); // edge of the sequence
+    tree.remove(tree.root); // root with two children
+    verifyShape(tree.root, null);
+    const remaining = toArray(tree);
+    expect(remaining.length).toBe(7);
+    expect(remaining).toEqual([...remaining].sort((a, b) => a - b));
+    while (tree.size > 0) tree.remove(tree.first());
+    expect(toArray(tree)).toEqual([]);
+    expect(tree.root).toBeNull();
+  });
+
+  test("findFirst returns the leftmost match of a monotone predicate", () => {
+    const tree = new BoundIndex();
+    // Non-decreasing bounds with a duplicate run, like d1 block bounds
+    const bounds = [10, 20, 20, 20, 30, 40];
+    bounds.forEach((bound, i) => tree.append({ bound, seq: i }));
+    expect(tree.findFirst((b) => b.bound >= 15).item.seq).toBe(1); // leftmost 20
+    expect(tree.findFirst((b) => b.bound >= 20).item.seq).toBe(1); // duplicate run
+    expect(tree.findFirst((b) => b.bound >= 10).item.seq).toBe(0);
+    expect(tree.findFirst((b) => b.bound >= 35).item.seq).toBe(5);
+    expect(tree.findFirst((b) => b.bound >= 41)).toBeNull();
+  });
+});
+
+describe("BoundIndex balance and stress (seeded)", () => {
+  test("stays height-balanced under append-only growth", () => {
+    const tree = new BoundIndex();
+    for (let i = 0; i < 2048; i += 1) tree.append(i);
+    verifyShape(tree.root, null);
+    // AVL height bound: ~1.44·log2(n); a plain linked chain would be 2048
+    expect(tree.root.height).toBeLessThanOrEqual(17);
+    expect(toArray(tree).length).toBe(2048);
+  });
+
+  test("random insertBefore/append/remove matches a reference array", () => {
+    const rand = mulberry32(20260721);
+    const tree = new BoundIndex();
+    const reference = []; // parallel array of node handles, in sequence order
+    let nextItem = 0;
+    for (let op = 0; op < 5000; op += 1) {
+      const roll = rand();
+      if (roll < 0.55 || reference.length === 0) {
+        // Insert at a random position (index == length appends at the end)
+        const at = Math.floor(rand() * (reference.length + 1));
+        const item = nextItem;
+        nextItem += 1;
+        const node =
+          at === reference.length
+            ? tree.append(item)
+            : tree.insertBefore(reference[at], item);
+        reference.splice(at, 0, node);
+      } else {
+        // Remove a random position
+        const at = Math.floor(rand() * reference.length);
+        tree.remove(reference[at]);
+        reference.splice(at, 1);
+      }
+      expect(tree.size).toBe(reference.length);
+    }
+    verifyShape(tree.root, null);
+    expect(toArray(tree)).toEqual(reference.map((node) => node.item));
+    // Spot-check findFirst against the reference on the monotone predicate
+    // "item >= threshold" after sorting the sequence is not applicable here
+    // (items are insertion-ordered), so verify iteration from every node
+    const fromMiddle = [];
+    let node = reference[reference.length >> 1];
+    for (; node !== null; node = tree.next(node)) fromMiddle.push(node.item);
+    expect(fromMiddle).toEqual(
+      reference.slice(reference.length >> 1).map((n) => n.item),
+    );
+  });
+
+  test("interleaved churn keeps the AVL invariants at every step", () => {
+    const rand = mulberry32(3141);
+    const tree = new BoundIndex();
+    const reference = [];
+    let nextItem = 0;
+    for (let op = 0; op < 400; op += 1) {
+      if (rand() < 0.6 || reference.length === 0) {
+        const at = Math.floor(rand() * (reference.length + 1));
+        const node =
+          at === reference.length
+            ? tree.append(nextItem)
+            : tree.insertBefore(reference[at], nextItem);
+        reference.splice(at, 0, node);
+        nextItem += 1;
+      } else {
+        const at = Math.floor(rand() * reference.length);
+        tree.remove(reference[at]);
+        reference.splice(at, 1);
+      }
+      verifyShape(tree.root, null);
+      expect(toArray(tree)).toEqual(reference.map((node) => node.item));
+    }
+  });
+});

--- a/test/select.test.mjs
+++ b/test/select.test.mjs
@@ -131,6 +131,36 @@ describe("partitionByRank selection contract", () => {
     }
   });
 
+  test("median-of-medians fallback (cheapBudget 0) selects every rank", () => {
+    // Forcing the budget to 0 routes every pivot through median-of-medians —
+    // the worst-case-linear fallback that ordinary inputs never reach
+    const rand = mulberry32(7);
+    for (let round = 0; round < 50; round += 1) {
+      const size = 5 + Math.floor(rand() * 200);
+      const original = Array.from({ length: size }, () =>
+        Math.floor(rand() * 60),
+      );
+      const rank = Math.floor(rand() * size);
+      const items = [...original];
+      partitionByRank(items, rank, (a, b) => a - b, 0);
+      expectPartitioned(items, rank, original);
+    }
+  });
+
+  test("organ-pipe input stays correct at the default budget", () => {
+    // Ascending-then-descending — a classically awkward shape for cheap
+    // quickselect pivots; the budget guard keeps it linear either way
+    const n = 1024;
+    const original = Array.from({ length: n }, (_, i) =>
+      i < n / 2 ? i : n - i,
+    );
+    for (const rank of [0, 255, 511, 512, 1023]) {
+      const items = [...original];
+      partitionByRank(items, rank, (a, b) => a - b);
+      expectPartitioned(items, rank, original);
+    }
+  });
+
   test("is deterministic: identical inputs produce identical arrangements", () => {
     const rand = mulberry32(99);
     const original = Array.from({ length: 300 }, () => Math.floor(rand() * 25));

--- a/test/select.test.mjs
+++ b/test/select.test.mjs
@@ -1,0 +1,143 @@
+import { describe, test, expect } from "@jest/globals";
+import { partitionByRank } from "../src/select.mjs";
+
+// Small deterministic PRNG so stress-test failures are reproducible
+function mulberry32(seed) {
+  let a = seed >>> 0;
+  return function () {
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// Assert the partitionByRank contract on a numeric array: items[rank] is the
+// rank-th smallest, everything before it is <= it, everything after is >= it,
+// and the array is a permutation of the original
+function expectPartitioned(items, rank, original) {
+  const sorted = [...original].sort((a, b) => a - b);
+  expect(items[rank]).toBe(sorted[rank]);
+  for (let i = 0; i < rank; i += 1) {
+    expect(items[i]).toBeLessThanOrEqual(items[rank]);
+  }
+  for (let i = rank + 1; i < items.length; i += 1) {
+    expect(items[i]).toBeGreaterThanOrEqual(items[rank]);
+  }
+  expect([...items].sort((a, b) => a - b)).toEqual(sorted);
+}
+
+describe("partitionByRank validation", () => {
+  test("rejects non-arrays and empty arrays", () => {
+    expect(() => partitionByRank("nope", 0)).toThrow(
+      "items must be a non-empty array",
+    );
+    expect(() => partitionByRank([], 0)).toThrow(
+      "items must be a non-empty array",
+    );
+  });
+
+  test("rejects out-of-range or non-integer ranks", () => {
+    expect(() => partitionByRank([3, 1, 2], -1)).toThrow(
+      "rank must be an integer index into items",
+    );
+    expect(() => partitionByRank([3, 1, 2], 3)).toThrow(
+      "rank must be an integer index into items",
+    );
+    expect(() => partitionByRank([3, 1, 2], 1.5)).toThrow(
+      "rank must be an integer index into items",
+    );
+  });
+});
+
+describe("partitionByRank selection contract", () => {
+  test("selects every rank of a small shuffled array (default comparator)", () => {
+    const original = [7, 3, 9, 1, 5, 8, 2, 6, 4, 0];
+    for (let rank = 0; rank < original.length; rank += 1) {
+      const items = [...original];
+      const value = partitionByRank(items, rank);
+      expect(value).toBe(rank);
+      expectPartitioned(items, rank, original);
+    }
+  });
+
+  test("handles sorted and reverse-sorted inputs at size 1000", () => {
+    // Large enough to exercise the median-of-medians pivot recursion; these
+    // orderings are the classic worst cases for naive quickselect
+    const ascending = Array.from({ length: 1000 }, (_, i) => i);
+    const descending = [...ascending].reverse();
+    for (const original of [ascending, descending]) {
+      for (const rank of [0, 1, 499, 500, 998, 999]) {
+        const items = [...original];
+        expect(partitionByRank(items, rank)).toBe(rank);
+        expectPartitioned(items, rank, original);
+      }
+    }
+  });
+
+  test("handles duplicate-heavy and all-equal inputs", () => {
+    const fewValues = Array.from({ length: 500 }, (_, i) => i % 3);
+    for (const rank of [0, 166, 167, 333, 334, 499]) {
+      const items = [...fewValues];
+      partitionByRank(items, rank, (a, b) => a - b);
+      expectPartitioned(items, rank, fewValues);
+    }
+    const allEqual = Array.from({ length: 100 }, () => 42);
+    const items = [...allEqual];
+    expect(partitionByRank(items, 57)).toBe(42);
+    expectPartitioned(items, 57, allEqual);
+  });
+
+  test("single-element and tiny arrays", () => {
+    expect(partitionByRank([5], 0)).toBe(5);
+    const pair = [9, 4];
+    expect(partitionByRank(pair, 0)).toBe(4);
+    expect(pair).toEqual([4, 9]);
+  });
+
+  test("works with a custom comparator over structured items", () => {
+    // [key, value] pairs ordered by value — how BlockList uses it
+    const rand = mulberry32(167);
+    const original = Array.from({ length: 200 }, (_, i) => [
+      `k${i}`,
+      Math.floor(rand() * 50),
+    ]);
+    const byValue = (a, b) => a[1] - b[1];
+    const sortedValues = original.map((p) => p[1]).sort((a, b) => a - b);
+    for (const rank of [0, 42, 99, 100, 199]) {
+      const items = original.map((p) => [...p]);
+      const picked = partitionByRank(items, rank, byValue);
+      expect(picked[1]).toBe(sortedValues[rank]);
+      for (let i = 0; i < rank; i += 1) {
+        expect(items[i][1]).toBeLessThanOrEqual(picked[1]);
+      }
+      for (let i = rank + 1; i < items.length; i += 1) {
+        expect(items[i][1]).toBeGreaterThanOrEqual(picked[1]);
+      }
+    }
+  });
+
+  test("seeded random stress across sizes and ranks", () => {
+    const rand = mulberry32(4242);
+    for (let round = 0; round < 200; round += 1) {
+      const size = 1 + Math.floor(rand() * 120);
+      const original = Array.from({ length: size }, () =>
+        Math.floor(rand() * 40),
+      );
+      const rank = Math.floor(rand() * size);
+      const items = [...original];
+      partitionByRank(items, rank, (a, b) => a - b);
+      expectPartitioned(items, rank, original);
+    }
+  });
+
+  test("is deterministic: identical inputs produce identical arrangements", () => {
+    const rand = mulberry32(99);
+    const original = Array.from({ length: 300 }, () => Math.floor(rand() * 25));
+    const first = [...original];
+    const second = [...original];
+    partitionByRank(first, 150, (a, b) => a - b);
+    partitionByRank(second, 150, (a, b) => a - b);
+    expect(first).toEqual(second);
+  });
+});


### PR DESCRIPTION
Closes #167

## Summary

Replaces `BlockList`'s two documented shortcuts with the paper's exact Lemma 3.3 machinery, behavior-preserving (all pre-existing tests pass unchanged):

- **`src/boundIndex.mjs` — `BoundIndex`**, the balanced BST over block upper bounds: a positional AVL tree holding the `d1` block sequence. `insert` finds its block via a monotone-predicate descent (O(log #blocks)), splits use `insertBefore`, emptied blocks leave via `remove` — no more O(#blocks) array `splice`/`indexOf`. `d0` became a doubly-linked list (O(1) unlink).
- **`src/select.mjs` — `partitionByRank`**, deterministic worst-case-linear selection used for block splits, `batchPrepend` chunking and pulls (replacing O(M log M) sorts). Budgeted **introselect**: median-of-3 quickselect (~2–3n comparisons) with a median-of-medians fallback that keeps the worst case linear.
- `batchPrepend` chunking is a two-branch hybrid, both inside the Lemma bound: one sort when chunks are many (|L| ≥ ⌈M/2⌉², provably within 2× of the target — the M = 1 star regime), median recursion when few.

## Measured impact

**The comparison-count crossover (the paper's own metric) moved from ~n = 1M to before n = 50k**: sparse 0.97× at 50k → 0.77× at 200k → **0.66× at 1M** (was 1.20×/1.03×/0.98×); grid 700×700 1.27× → 1.12×. Wall-clock is at-or-better than 1.1.1 on every shape (star 50k ~144 → ~131 ms; `sparse-random-l4` ~1246 → ~1083 ms).

Worth recording: the first cut used pure median-of-medians and *regressed* both metrics (star +68% wall-clock, crossover lost — MoM costs ~10–20n comparisons, worse than sorting at practical sizes); the harness caught it, and the budgeted introselect resolved it. Details in the new `HEAD-TO-HEAD.md` #167 addendum; `RESULTS.md` recaptured.

## Tests / lint

- **185 tests (184 + 1 XL opt-in), 14 suites, all green**; `npm run lint` clean; 100% statement coverage maintained.
- +22 tests: `select` (11 — every-rank contract, worst-case orderings, duplicates, forced MoM fallback via `cheapBudget: 0`, determinism), `boundIndex` (8 — sequence semantics, monotone `findFirst`, AVL invariants verified recursively under seeded churn), BlockList (+5 — both chunking branches, interior-block drops, mid-`d0` unlink, hundreds-of-splits drain).
- Extended runs green: `FUZZ_ROUNDS=25` (thousands of seeded graphs) and `FUZZ_XL=1` (2M-node round).

## Version

No bump — not a bug fix, and #168 is still open in milestone 1.2.0 (its PR will take the minor → 1.2.0).

## Roadmap proposals

1. **Comment on #168** with the post-#167 baseline: the BlockList is no longer a comparison-count factor; profiles put the dominant costs in #168's stated targets (`relaxEdge` allocation, `U`/`W` Set churn, per-level O(m+n) relax pass). Note that #168 is now 1.2.0's last open issue → milestone-closing minor bump + release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)