### PR TITLE
feat(#168): relaxation micro-optimizations — allocation-free hot loops (minor → 1.2.0)

### DIFF
--- a/.claude/knowledge/05-codebase-map.md
+++ b/.claude/knowledge/05-codebase-map.md
@@ -1,14 +1,14 @@
 # 05 — Codebase Map (current state)
 
-<!-- BOOKMARK-COMMIT: 16e53f2 -->
-<!-- PENDING-PR-BRANCH: feat/167-exact-lemma33-asymptotics -->
-<!-- Last validated: 2026-07-21 (Phase C of the #167 PR). Describes the tree as it will
-     exist once that PR merges: BlockList's two documented shortcuts replaced to meet
-     Lemma 3.3's exact bounds — the plain-array bound index by an AVL sequence tree
-     (src/boundIndex.mjs) and the sort-based splits/chunking/pulls by deterministic
-     linear-time selection (src/select.mjs, median of medians). Behavior-preserving:
-     all pre-existing tests unchanged. No version bump (not a bug fix; #168 still open
-     in milestone 1.2.0). -->
+<!-- BOOKMARK-COMMIT: 1af81c2 -->
+<!-- PENDING-PR-BRANCH: feat/168-relaxation-micro-optimizations -->
+<!-- Last validated: 2026-07-21 (Phase C of the #168 PR). Describes the tree as it will
+     exist once that PR merges: relaxation micro-optimizations — allocation-free
+     relaxEdge (RELAX_* codes), compareKeyParts for unpacked band routing, indexed edge
+     loops. Wall-clock −13–23% (sparse-l4 ~1123→~862 ms); counts −1–3%. Heap strategy
+     measured: indexed kept (lazy wins only an isolated micro-benchmark; end-to-end
+     noise). Milestone-closing PR → minor bump 1.2.0 (release in Phase E after the
+     user confirms the merge). -->
 
 
 Snapshot of what exists in `bmssp-js` today, so you know what to build on vs. what's missing.
@@ -183,18 +183,27 @@ full data + methodology in `benchmarks/HEAD-TO-HEAD.md`, latest capture in
 the same prebuilt adjacency): Dijkstra wins every shape/size; sparse-graph ratio narrows
 with n (1.0.0 record: 2.54× at 50k → **1.57× at 2M**). **Comparison counts (the paper's
 metric) crossed over at ~n = 1M sparse in the 1.0.0/1.1.1 records; after #167's
-selection-based BlockList they cross before n = 50k** — 0.97× at 50k, 0.77× at 200k,
-**0.66× at 1M** (grid 700×700 down to 1.12×): replacing the sort-based splits/pulls
-removed a major comparison cost, and #167's wall-clock is also at-or-better than 1.1.1
-on every shape (star ~134 ms vs ~144 ms at 50k, sparse ~100 ms vs ~96 ms — within noise).
-The two #182 pathologies were profiled 2026-07-21 (HEAD-TO-HEAD addendum): the **star
-blowup was quadratic `batchPrepend` bookkeeping — fixed in 1.1.1** (500k: 61 s → ~3.1 s);
-the **`topLevel` 3→4 step is an inherent ~+24%** (one extra full relax pass per level,
-measured at the exact n = 2^18 straddle) — the recorded 5× at 4M is that step plus
-GC/memory amplification at 12M edges. Note `topLevel` is **3 from n = 10k to 2M** (4 only
-in n ∈ (2^18, ~376k]) — scale tests buy volume/memory pressure, not recursion depth. The
-default suite runs in ~7.5 s; the opt-in `FUZZ_XL=1` 2M-node round takes ~33 s (#163's
-composite keys added ~10% over the ~30 s scalar baseline — candidate for #168).
+selection-based BlockList they cross before n = 50k** — with #168's routing rework the
+1.2.0 capture reads **0.95× at 50k, 0.76× at 200k, 0.65× at 1M** (grid 700×700 1.10×).
+**#168 (1.2.0) cut wall-clock a further −13–23%** over post-#167 in clean A/B (sparse 50k
+~111 → ~87 ms, star ~147 → ~127 ms, sparse-l4 300k ~1123 → ~862 ms): allocation-free
+`relaxEdge` + unpacked band routing (`compareKeyParts`) + indexed edge loops. Post-#168
+profiles put remaining self-time in `relaxEdge`'s label-Map traffic (~38%, the 5–6
+Map ops per attempt — a dense-index/typed-array core would be the next lever, but it
+changes the public label contracts: proposed for 2.0.0) and `bmssp()`'s Set bookkeeping
+(~24%). **Heap strategy (#168, measured):** the lazy duplicate-and-skip variant wins an
+isolated BaseCase micro-benchmark (~29–33 ms vs ~37–52 ms per 10k bounded runs at
+n = 100k) but BaseCase's heaps are capped at k+1 ≈ 4 entries and never register in
+end-to-end profiles — the paper-literal indexed `MinHeap` is kept. The two #182
+pathologies were profiled 2026-07-21 (HEAD-TO-HEAD addendum): the **star blowup was
+quadratic `batchPrepend` bookkeeping — fixed in 1.1.1** (500k: 61 s → ~3.1 s); the
+**`topLevel` 3→4 step is an inherent ~+24%** (one extra full relax pass per level,
+measured at the exact n = 2^18 straddle; that pass is the paper's `≤`-reuse mechanism
+for surfacing ≥-Bi neighbors — not removable as a micro-optimization) — the recorded 5×
+at 4M is that step plus GC/memory amplification at 12M edges. Note `topLevel` is **3
+from n = 10k to 2M** (4 only in n ∈ (2^18, ~376k]) — scale tests buy volume/memory
+pressure, not recursion depth. The default suite runs in ~7.5 s; the opt-in `FUZZ_XL=1`
+2M-node round takes ~33 s.
 
 ## `src/blockList.mjs` — Lemma 3.3 structure `D` (#42)
 
@@ -359,18 +368,25 @@ and direct multi-source callers may pass such sources); `bmssp()` filters them a
 
 ```js
 compareKeys(a, b)                  // lexicographic compare of [length, hops, id] triples
+compareKeyParts(length, hops, id, key) // #168: same order, left side unpacked — the hot
+                                   // loops' allocation-free compare; counts as one comparison
 toBound(B)                         // scalar B → [B, -Infinity, -Infinity] (infimum of length-B
                                    // keys, so key < toBound(B) ⇔ the strict scalar contract);
                                    // composite bounds pass through
 makeTies(hops?, preds?)            // bundle the canonical label maps (fresh by default)
 orderKey(v, dHat, ties)            // frontier key [d̂[v], hops[v] ?? 0, v]
-relaxEdge(u, v, w, dHat, ties, bound?) // canonical relaxation → { key, improved } | null:
-                                   // improved=true updated d̂/hops/preds together;
-                                   // improved=false = candidate exactly matches v's stored
-                                   // label (u is the recorded setter) — the re-enqueue signal
-resetComparisonCount() / getComparisonCount() // #170: unconditional compareKeys call counter
-                                   // (the paper's cost metric); read by the benchmark harness
-export { compareKeys, toBound, makeTies, orderKey, relaxEdge, NO_PRED,
+relaxEdge(u, v, w, dHat, ties, bound?) // canonical relaxation → RELAX_IMPROVED (d̂/hops/preds
+                                   // updated together) | RELAX_EQUAL (candidate exactly
+                                   // matches v's stored label; u is the recorded setter —
+                                   // the re-enqueue signal) | RELAX_LOST (labels untouched).
+                                   // Allocation-free since #168; callers that enqueue v
+                                   // materialize its key with orderKey only on that path
+resetComparisonCount() / getComparisonCount() // #170: unconditional comparison counter over
+                                   // compareKeys + compareKeyParts + relaxEdge's inlined
+                                   // label compare (the paper's cost metric); read by the
+                                   // benchmark harness
+export { compareKeys, compareKeyParts, toBound, makeTies, orderKey, relaxEdge,
+         NO_PRED, RELAX_LOST, RELAX_EQUAL, RELAX_IMPROVED,
          resetComparisonCount, getComparisonCount };
                                    // NOT re-exported from index.mjs — internal to the algorithm
 ```
@@ -449,8 +465,10 @@ edge-order deterministic (copies allocated in edge order); ~2m copies, ~3m edges
   bound runs, and AVL invariants (parent pointers, stored heights, |balance| ≤ 1)
   verified recursively under append-only growth (height ≤ 17 at n = 2048) and two
   seeded random-churn stresses against a reference array.
-- `test/tieBreak.test.mjs` (19, #163 + 3 counter tests from #170): unit tests for
-  `compareKeys`/`toBound`/`relaxEdge`
+- `test/tieBreak.test.mjs` (20, #163 + 3 counter tests from #170 + the #168
+  `compareKeyParts`-vs-`compareKeys` agreement sweep): unit tests for
+  `compareKeys`/`toBound`/`relaxEdge` (asserting the #168 RELAX_* code contract with
+  label state read from the maps)
   (lexicographic order, scalar-bound infimum, canonical pred choice, zero-weight-cycle
   quiescence, the equality re-enqueue signal), then the system-level properties:
   **edge-order determinism** (full runs AND bounded partial calls return identical
@@ -502,7 +520,7 @@ edge-order deterministic (copies allocated in edge order); ~2m copies, ~3m edges
   (identical maps incl. Infinity → 0; wrong/missing entries counted); `runScenarioBenchmark`
   and `runComparisonCountBenchmark` on tiny injected scenarios return the expected columns
   with **zero mismatches**.
-- Current suite: **185 tests — 184 passing + 1 XL skipped by default**, ~100% statement
+- Current suite: **186 tests — 185 passing + 1 XL skipped by default**, ~100% statement
   coverage, ~7.5 s wall-clock (the #164 distance-preservation sweeps run BMSSP/Dijkstra
   from every source). No graph data files: every generated test graph comes from a
   seed; the #162 fixtures are hand-built and fully deterministic.
@@ -551,9 +569,11 @@ BMSSP-vs-Dijkstra head-to-head itself:
 | JSDoc on `index.mjs` exports + public-API docs page | `index.mjs` + `docs/index.html` | #166 | ✅ merged (PR #196, **minor → 1.1.0**, released 2026-07-21) |
 | BMSSP-vs-Dijkstra head-to-head in the harness | `benchmarks/` + `src/tieBreak.mjs` counter | #170 | ✅ merged (PR #198, no bump) |
 | Performance-cliff investigation + quadratic batchPrepend fix | `src/blockList.mjs` + HEAD-TO-HEAD addendum | #182 | ✅ merged (PR #200, **patch → 1.1.1**, released 2026-07-21) |
-| Exact Lemma 3.3 asymptotics (BST bound index + linear selection) | `src/boundIndex.mjs` + `src/select.mjs` + `src/blockList.mjs` | #167 | ✅ done-pending-merge (this PR, no bump) |
+| Exact Lemma 3.3 asymptotics (BST bound index + linear selection) | `src/boundIndex.mjs` + `src/select.mjs` + `src/blockList.mjs` | #167 | ✅ merged (PR #202, no bump) |
+| Relaxation micro-optimizations (allocation-free relaxEdge, unpacked routing, heap measurement) | `src/tieBreak.mjs` + `src/bmssp.mjs` + `src/baseCase.mjs` + `src/findPivots.mjs` | #168 | ✅ done-pending-merge (this PR, **minor → 1.2.0**) |
 
 Milestone `1.1.0` (correctness hardening) is **closed** — released 2026-07-21 (npm +
-Docker Hub). Milestone `1.2.0` is the current focus: after #167 merges, **#168** is its
-last open issue (adjacency/relaxation micro-optimizations; the PR closing it takes the
-**minor → 1.2.0** bump); see [06-milestones-roadmap.md](06-milestones-roadmap.md).
+Docker Hub). This PR closes **#168**, milestone `1.2.0`'s last open issue → **minor bump
+1.2.0** (release + milestone close in Phase E after the merge). Next up: milestone
+`2.0.0` (#171/#172/#173 + the proposed dense-index core issue); see
+[06-milestones-roadmap.md](06-milestones-roadmap.md).

--- a/.claude/knowledge/06-milestones-roadmap.md
+++ b/.claude/knowledge/06-milestones-roadmap.md
@@ -1,10 +1,11 @@
 # 06 — Milestones Roadmap
 
-<!-- SYNCED-FROM-GITHUB: 2026-07-21 Phase C of the #167 PR (verified live at Phase A the
-     same day: 1.2.0 open with 2 open issues #167/#168 — #167 done-pending-merge in this
-     PR; 2.0.0 open with 3 open issues #171/#172/#173) -->
-<!-- Current package version: 1.1.1 — released 2026-07-21 (tag + GitHub Release with
-     Announcements discussion → npm + Docker Hub via publish.yml); tag matches -->
+<!-- SYNCED-FROM-GITHUB: 2026-07-21 Phase C of the #168 PR (verified live at RKB the
+     same day: 1.2.0 open with 1 open issue #168 — done-pending-merge in this PR;
+     2.0.0 open with 3 open issues #171/#172/#173) -->
+<!-- Current package version: 1.2.0 (bumped in the #168 PR — milestone-closing minor;
+     release fires in Phase E after the user confirms the merge. Last released: 1.1.1,
+     2026-07-21, with Announcements discussion) -->
 <!-- Release-discussion convention (user-directed 2026-07-21): every GitHub Release also
      creates a linked discussion — pass --discussion-category "Announcements" to
      gh release create (the UI's "Create a discussion for this release" checkbox) -->
@@ -43,16 +44,23 @@ it runs the same Phase C reconciliation directly on `main`.
 
 ## 📋 Roadmap proposals (pending user approval)
 
-From the #167 PR (Phase C, 2026-07-21):
+From the #168 PR (Phase C, 2026-07-21):
 
-1. **Comment on #168** with the post-#167 baseline its work should start from: the
-   BlockList is no longer a comparison-count factor at all (introselect does ~2–3n
-   comparisons where sorts did n log n — the count crossover moved from ~n = 1M to
-   before n = 50k: 0.97× at 50k, 0.66× at 1M), and wall-clock profiles now put the
-   dominant costs squarely in #168's stated targets — `relaxEdge` allocation, `U`/`W`
-   Set churn, and the per-level O(m + n) relax pass. Also note #168 is now 1.2.0's
-   last open issue, so its PR takes the **minor → 1.2.0** bump and release.
+1. **Close milestone `1.2.0`** once this PR merges — #168 is its last open issue
+   (5/5 done: #167/#168/#169/#170/#182).
+2. **Open a new 2.0.0 issue: "Dense-index core: typed-array labels + CSR adjacency".**
+   Post-#168 profiles put ~38% of self-time in `relaxEdge`'s label-Map traffic (5–6
+   `Map` ops per edge attempt) and ~24% in `bmssp()`'s Set bookkeeping. The next real
+   wall-clock lever is mapping node IDs to dense indices once and holding d̂/hops/preds
+   in typed arrays with CSR adjacency — but that reshapes the public label contracts
+   (`shortestPaths` Map, `bmssp(l, B, S)`'s in-place d̂ seeding for multi-source
+   callers), so it belongs in the 2.0.0 API-breaking milestone alongside #172
+   (typed/flexible graph inputs), not in a micro-optimization PR.
 
+_(The #167-PR proposal — the post-#167 baseline comment on **#168** (BlockList no longer
+a count factor, crossover now <50k; relaxEdge allocation / Set churn / per-level relax
+pass are the remaining targets; #168 is the milestone-closing issue) — was approved and
+executed 2026-07-21.)_
 _(The #182-PR proposals — findings comments on **#167** (remaining scope = BST bound
 index + linear-time selection; batchPrepend quadratic fixed) and **#168** (per-level
 O(m + n) relax pass dominates; relaxEdge allocation + Set churn targets; +24% level
@@ -148,7 +156,7 @@ executed 2026-07-17.)_
   5× at 4M is that step plus GC/memory amplification. **Bug fix → patch bump 1.1.1**
   (batchPrepend violated its documented Lemma 3.3 amortized bound); **1.1.1 released
   2026-07-21**. Findings posted on #167/#168 (approved proposals, executed same day).
-- **#167 done-pending-merge (this PR, 2026-07-21):** BlockList's two documented
+- **#167 merged (PR #202, 2026-07-21, commit 1af81c2; no bump):** BlockList's two documented
   shortcuts replaced to meet Lemma 3.3's exact per-operation bounds — the plain-array
   bound index by `src/boundIndex.mjs` (`BoundIndex`, a positional AVL tree searched
   through the monotone block bounds; O(log #blocks) search/split/drop) and the
@@ -165,7 +173,26 @@ executed 2026-07-17.)_
   all pre-existing tests unchanged; extended FUZZ_ROUNDS=25 and FUZZ_XL runs green.
   No bump (not a bug fix; #168 still open in 1.2.0). Addendum added to
   `HEAD-TO-HEAD.md`; `RESULTS.md` recaptured; stale crossover blurbs updated in the
-  harness and `benchmarks/README.md`.
+  harness and `benchmarks/README.md`. The Phase E proposal (baseline comment on #168)
+  was approved and posted the same day.
+- **#168 done-pending-merge (this PR, 2026-07-21; minor → 1.2.0):** relaxation
+  micro-optimizations. `relaxEdge` reworked allocation-free (returns `RELAX_LOST` /
+  `RELAX_EQUAL` / `RELAX_IMPROVED` codes; the old per-attempt `{ key, improved }`
+  object + up to three throwaway key arrays are gone — callers materialize a key with
+  `orderKey` only on enqueue paths), new `compareKeyParts(length, hops, id, key)` lets
+  the band routing in `bmssp()`/`findPivots` compare unpacked stored labels without
+  allocating, and the three hot edge loops became indexed loops (no per-edge iterator +
+  destructuring). Clean A/B vs post-#167 main: **−13–23% wall-clock** (sparse 50k ~111
+  → ~87 ms, star ~147 → ~127 ms, sparse-l4 300k ~1123 → ~862 ms), comparison counts
+  down ~1–3% (1.2.0 capture: sparse 0.95×/0.76×/0.65× at 50k/200k/1M). **Heap
+  strategy resolved by measurement:** lazy duplicate-and-skip wins an isolated
+  BaseCase micro-benchmark but BaseCase heaps are capped at k+1 ≈ 4 entries and never
+  register end-to-end — the paper-literal indexed `MinHeap` is kept. The "skip the
+  per-level re-relax pass" idea was rejected as paper-infidelity: that pass is the `≤`
+  reuse mechanism (Remark 3.4) surfacing ≥-Bi neighbors the child deliberately drops.
+  Suite 186 (+1 compareKeyParts agreement sweep; relaxEdge unit tests updated to the
+  code contract); FUZZ_ROUNDS=25 and FUZZ_XL green. Next lever (label-Map traffic,
+  ~38% self-time) proposed as a 2.0.0 dense-index issue (Roadmap proposal 2).
 - **Semver release convention (user-directed 2026-07-17, PR #186):** bumps only on bug
   fix (patch) or milestone-closing PR (minor/major) — see "Release mechanics" below.
 - **2026-07-16 reflection session (post-release):** measured the BMSSP-vs-Dijkstra
@@ -212,14 +239,14 @@ All six issues done (build order as executed — cheapest protection first, then
 
 ## Milestone `1.2.0` (milestone #3) — performance & ergonomics — CURRENT
 
-Build order: ~~#170~~ (merged, PR #198), ~~#182~~ (merged, PR #200, 1.1.1), ~~#167~~
-(done-pending-merge, this PR), then **#168** — 1.2.0's last open issue, whose PR takes
-the **minor → 1.2.0** bump and release.
+Build order (as executed): ~~#170~~ (merged, PR #198), ~~#182~~ (merged, PR #200, 1.1.1),
+~~#167~~ (merged, PR #202), ~~#168~~ (done-pending-merge, this PR, **minor → 1.2.0**) —
+all five issues done; the milestone closes in Phase E.
 
 | # | Issue | Labels | Notes |
 |---|---|---|---|
-| 167 | Restore Lemma 3.3's exact asymptotics in BlockList (balanced-BST bound index + linear-time selection) | enhancement · help wanted | ✅ done-pending-merge (this PR, no bump): `BoundIndex` AVL sequence + `partitionByRank` introselect; count crossover moved ~1M → <50k (0.66× at 1M); wall-clock at-or-better |
-| 168 | Adjacency and relaxation micro-optimizations | enhancement · help wanted | #182 findings: per-level O(m+n) relax pass dominates; relaxEdge allocation + Set churn are the targets. **Milestone-closing → minor 1.2.0** |
+| 167 | Restore Lemma 3.3's exact asymptotics in BlockList (balanced-BST bound index + linear-time selection) | enhancement · help wanted | ✅ merged (PR #202, no bump): `BoundIndex` AVL sequence + `partitionByRank` introselect; count crossover moved ~1M → <50k (0.66× at 1M); wall-clock at-or-better |
+| 168 | Adjacency and relaxation micro-optimizations | enhancement · help wanted | ✅ done-pending-merge (this PR, **minor → 1.2.0**): allocation-free relaxEdge (RELAX_* codes) + compareKeyParts routing + indexed edge loops → −13–23% wall-clock, counts down ~1–3%; heap strategy measured, indexed MinHeap kept; dense-index core proposed as a 2.0.0 issue |
 | 169 | Optional shortest-path reconstruction (`Pred[]` → paths) | enhancement · help wanted | ✅ merged (PR #189, no bump): public API + independent path oracle |
 | 170 | BMSSP-vs-Dijkstra benchmark comparison | enhancement · help wanted | ✅ merged (PR #198, no bump): head-to-head + count mode in the harness, verified outputs |
 | 182 | Investigate BMSSP performance cliffs: high-fanout (star) graphs and recursion-level transitions | enhancement · help wanted | ✅ merged (PR #200, **patch → 1.1.1**, released 2026-07-21): star = quadratic batchPrepend, fixed (61 s → ~3.1 s at 500k); level step = inherent +24%, documented (HEAD-TO-HEAD addendum) |

--- a/.claude/knowledge/07-glossary.md
+++ b/.claude/knowledge/07-glossary.md
@@ -1,9 +1,9 @@
 # 07 — Glossary
 
-<!-- Updated on: 2026-07-21 (#167 PR: BoundIndex, partitionByRank, introselect; the
-     "Bound index shortcut" entry rewritten as resolved; comparison-count crossover
-     entry updated to the post-#167 <50k figure. Previous update the same day: #166 PR
-     added the "Docs page" repo term) -->
+<!-- Updated on: 2026-07-21 (#168 PR: compareKeyParts + RELAX_* codes; relaxEdge,
+     re-enqueue-signal and indexed-vs-lazy-heap entries updated to the new contract /
+     measurement. Previous update the same day: #167 PR added BoundIndex,
+     partitionByRank, introselect) -->
 
 > **Lifecycle: dynamic — updated in Phase C of every PR.** When a PR introduces new symbols
 > or terms (module names, data-structure fields, paper notation newly used in code), add
@@ -141,7 +141,10 @@ Quick lookup for the symbols and terms used across the paper, the notes, and the
   swap; what makes `has`/`getValue` O(1) and `decreaseKey` O(log n).
 - **Indexed vs. lazy heap** — `MinHeap` is the paper-literal *indexed* variant (true
   `DecreaseKey`); `src/dijkstra.mjs` internally uses the *lazy* variant (push duplicates,
-  skip stale pops). Both are correct; §03-A discusses the trade-off.
+  skip stale pops). Both are correct; §03-A discusses the trade-off. **Resolved by
+  measurement in #168:** lazy wins an isolated BaseCase micro-benchmark, but BaseCase
+  heaps are capped at k+1 ≈ 4 entries and never register in end-to-end profiles, so the
+  indexed paper-literal `MinHeap` is kept.
 - **`baseCase(B, S, dHat, adjacency, k)`** (#40) — `src/baseCase.mjs`, Algorithm 2:
   bounded mini-Dijkstra from the singleton complete source in `S`, settling at most `k+1`
   vertices, relaxing the shared `dHat` (`d̂[·]`) **in place** (canonically, with an optional
@@ -192,13 +195,25 @@ Quick lookup for the symbols and terms used across the paper, the notes, and the
   "#vertices" tie-break — zero-weight extensions strictly increase it), `id` = pred id in
   relaxation / own id in frontier order (O(1) stand-in for the paper's vertex-sequence
   comparison). Realizes Assumption 2.1: all frontier comparisons strict.
-- **Canonical label / relaxation** (#163) — `relaxEdge(u, v, w, dHat, ties, bound?)`
-  updates `d̂`/`hops`/`preds` together iff the candidate path key beats the stored one;
-  the fixed point is the lexicographic minimum over all paths, so labels, predecessor
-  pointers and completed sets are invariant under edge/iteration order (tested in
-  `test/tieBreak.test.mjs` against an O(n²) lexicographic Dijkstra oracle).
-- **Re-enqueue signal** (#163) — `relaxEdge`'s `improved: false` result: the candidate
-  exactly matches `v`'s stored label, meaning `u` is the recorded label-setter and `v` was
+- **Canonical label / relaxation** (#163, allocation-free since #168) —
+  `relaxEdge(u, v, w, dHat, ties, bound?)` updates `d̂`/`hops`/`preds` together iff the
+  candidate path key beats the stored one; the fixed point is the lexicographic minimum
+  over all paths, so labels, predecessor pointers and completed sets are invariant under
+  edge/iteration order (tested in `test/tieBreak.test.mjs` against an O(n²)
+  lexicographic Dijkstra oracle). Since #168 it returns one of three integer codes —
+  `RELAX_IMPROVED` / `RELAX_EQUAL` / `RELAX_LOST` — and allocates nothing; a caller
+  that enqueues `v` materializes its key with `orderKey` on that path only.
+- **`compareKeyParts(length, hops, id, key)`** (#168) — `src/tieBreak.mjs`: compareKeys
+  with the left key unpacked into its components, so the hot relax/routing loops can
+  test a stored label against a band bound without building a throwaway array. Same
+  lexicographic order, counts as one comparison (agreement with `compareKeys` swept in
+  `test/tieBreak.test.mjs`).
+- **`RELAX_LOST` / `RELAX_EQUAL` / `RELAX_IMPROVED`** (#168) — `relaxEdge`'s result
+  codes (−1 / 0 / 1): candidate lost or bound-gated (labels untouched) / candidate
+  exactly matches v's canonical label (the re-enqueue signal) / labels updated.
+  Compare against the constants, not truthiness — `RELAX_EQUAL` is 0.
+- **Re-enqueue signal** (#163; `RELAX_EQUAL` since #168) — the candidate exactly
+  matches `v`'s stored label, meaning `u` is the recorded label-setter and `v` was
   labeled by a deeper call without being completed. The caller re-enqueues `v` unless it
   is already settled/completed — the paper's `≤` relaxation made canonical, firing from
   exactly one predecessor.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ with every building block shipped, tested, and released individually:
 | BMSSP-vs-Dijkstra head-to-head in the benchmark harness ([#170](https://github.com/Sirivasv/bmssp-js/issues/170)) | `npm run bench` / `npm run bench:counts` | ✅ done |
 | Performance-cliff investigation; quadratic `BatchPrepend` fixed ([#182](https://github.com/Sirivasv/bmssp-js/issues/182)) | `src/blockList.mjs` | ✅ done — **1.1.1** |
 | Exact Lemma 3.3 asymptotics: balanced-BST bound index + linear-time selection ([#167](https://github.com/Sirivasv/bmssp-js/issues/167)) | `src/boundIndex.mjs` + `src/select.mjs` | ✅ done |
+| Relaxation micro-optimizations: allocation-free hot loops, −13–23% wall-clock ([#168](https://github.com/Sirivasv/bmssp-js/issues/168)) | `src/tieBreak.mjs` + the algorithm modules | ✅ done — **1.2.0** |
 
 > **Honest note:** the paper's win is asymptotic, and this repo optimizes for correctness
 > and readability, not raw speed. Measured head-to-head (algorithm time only, graph
@@ -45,8 +46,8 @@ with every building block shipped, tested, and released individually:
 > Dijkstra still wins on wall-clock at every practical size, though the gap narrows as
 > sparse graphs grow (2.5× at 50k nodes → 1.57× at 2M). But in the paper's own metric —
 > **comparisons between path lengths** — BMSSP does **fewer comparisons than Dijkstra
-> from under n = 50k on sparse graphs** (`npm run bench:counts` measures 0.97× at 50k →
-> 0.77× at 200k → **0.66× at 1M**), and the advantage grows with size: the "sorting
+> from under n = 50k on sparse graphs** (`npm run bench:counts` measures 0.95× at 50k →
+> 0.76× at 200k → **0.65× at 1M**), and the advantage grows with size: the "sorting
 > barrier" is measurably broken; what remains is JS constant factors. That crossover
 > used to sit at ~n = 1M until [#167](https://github.com/Sirivasv/bmssp-js/issues/167)
 > replaced the block structure's sort-based internals with the paper's exact machinery
@@ -188,8 +189,8 @@ graphs in a few seconds), and set `FUZZ_XL=1` for an additional 2-million-node r
 | --- | --- | --- |
 | [`1.0.0`](https://github.com/Sirivasv/bmssp-js/milestones) | First end-to-end functional BMSSP (issues #40–#45) | ✅ done |
 | `1.1.0` | Correctness hardening — fuzz tests, edge cases, tie-breaking, input validation, constant-degree transform, API docs | ✅ done |
-| `1.2.0` | Performance & ergonomics — exact Lemma 3.3 asymptotics, BMSSP-vs-Dijkstra benchmarks, performance-cliff investigation | 🔨 current focus |
-| `2.0.0` | API generalization — public multi-source/bounded entry point, flexible inputs | planned |
+| `1.2.0` | Performance & ergonomics — exact Lemma 3.3 asymptotics, BMSSP-vs-Dijkstra benchmarks, cliff investigation, relaxation micro-optimizations | ✅ done |
+| `2.0.0` | API generalization — public multi-source/bounded entry point, flexible inputs | 🔨 next |
 
 ## Contributing (humans and AI agents welcome)
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -87,8 +87,8 @@ path lengths**. Every BMSSP-side comparison funnels through
 Dijkstra baseline counts its heap sifts, stale-pop checks and relaxations the
 same way. Counts are deterministic, so one run per side is exact. On sparse
 graphs the bmssp/dijkstra ratio falls as n grows and — since #167's
-selection-based BlockList — is **already below 1.0 at n = 50k** (2026-07-21
-capture: 0.97× at 50k → 0.77× at 200k → 0.66× at 1M), the measured form of
+selection-based BlockList — is **already below 1.0 at n = 50k** (`1.2.0`
+capture: 0.95× at 50k → 0.76× at 200k → 0.65× at 1M), the measured form of
 the paper's asymptotic claim. Before #167, sort-based splits/pulls pushed the
 crossover out to ~n = 1M (`1.0.0` record: 1.18× at 50k → 1.01× at 200k →
 0.96× at 1M → 0.91× at 2M).
@@ -110,9 +110,10 @@ harness reruns it on every `npm run bench` (fresh capture:
 - **BMSSP's asymptotics are real and visible:** on sparse graphs the
   wall-clock gap narrows with n (2.5× at 50k → 1.57× at 2M in the 1.0.0
   record), and in the paper's own metric the harness's count mode shows the
-  ratio below 1.0 from n = 50k on: **0.97× at 50k → 0.77× at 200k → 0.66×
-  at 1M** (since #167; ~1M crossover before it). The sorting barrier is
-  measurably broken; the remaining loss is constant factors.
+  ratio below 1.0 from n = 50k on: **0.95× at 50k → 0.76× at 200k → 0.65×
+  at 1M** (since #167; ~1M crossover before it; #168 shaved a further
+  ~1–3%). The sorting barrier is measurably broken; the remaining loss is
+  constant factors — #168 cut −13–23% of wall-clock from the hot loops.
 - **Shapes that blunt BMSSP's edge, per the harness:** `dense-random`
   (relaxation-bound, ~4.7×), `chain` (depth, not sorting, is the cost —
   ~7.4× against the prebuilt-adjacency baseline), `star` (extreme fanout,

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -1,6 +1,6 @@
 # bmssp-js benchmark run
 
-_Generated 2026-07-21T10:18:01.877Z · node v26.5.0 · darwin/arm64_
+_Generated 2026-07-21T10:59:44.802Z · node v26.5.0 · darwin/arm64_
 
 ## Adjacency map vs linear scan (#45)
 
@@ -8,10 +8,10 @@ Graph: 20000 nodes, 80000 edges · 5000 random per-node edge lookups.
 
 | method | median ms | per lookup µs |
 | --- | --- | --- |
-| linear scan (pre-#45) | 372.80 | 74.56 |
-| adjacency map (#45) | 0.09 | 0.02 |
+| linear scan (pre-#45) | 419.89 | 83.98 |
+| adjacency map (#45) | 0.11 | 0.02 |
 
-**Speedup: 4003.2x** faster per-node lookups with the map.
+**Speedup: 3797.0x** faster per-node lookups with the map.
 
 ## Graph-shape scenarios — BMSSP vs Dijkstra (#170)
 
@@ -19,12 +19,12 @@ Algorithm time only: both sides consume the same prebuilt adjacency Map; `mismat
 
 | scenario | nodes | edges | construct ms | dijkstra ms | bmssp ms | ratio | mismatches | notes |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| sparse-random | 50000 | 150000 | 28.68 | 35.03 | 86.20 | 2.46x | 0 | m = O(n), degree 3 — the road-network regime |
-| dense-random | 8000 | 256000 | 17.55 | 13.48 | 60.66 | 4.50x | 0 | avg degree 32 — edge-relaxation-bound |
-| grid-4nbr | 40000 | 159200 | 12.18 | 17.68 | 69.64 | 3.94x | 0 | 200x200 lattice — large diameter, low degree |
-| chain | 50000 | 49999 | 7.81 | 5.03 | 37.39 | 7.43x | 0 | single long path — worst-case depth |
-| star | 50000 | 99998 | 9.09 | 28.82 | 130.66 | 4.53x | 0 | one hub, n-1 spokes — extreme degree skew (#182) |
-| sparse-random-l4 | 300000 | 900000 | 166.84 | 365.42 | 1082.77 | 2.96x | 0 | n just past the topLevel 3→4 step at n = 2^18 (#182) |
+| sparse-random | 50000 | 150000 | 26.20 | 37.11 | 103.34 | 2.78x | 0 | m = O(n), degree 3 — the road-network regime |
+| dense-random | 8000 | 256000 | 24.04 | 16.98 | 43.95 | 2.59x | 0 | avg degree 32 — edge-relaxation-bound |
+| grid-4nbr | 40000 | 159200 | 15.55 | 19.50 | 65.93 | 3.38x | 0 | 200x200 lattice — large diameter, low degree |
+| chain | 50000 | 49999 | 10.18 | 6.59 | 43.18 | 6.55x | 0 | single long path — worst-case depth |
+| star | 50000 | 99998 | 14.03 | 31.86 | 133.82 | 4.20x | 0 | one hub, n-1 spokes — extreme degree skew (#182) |
+| sparse-random-l4 | 300000 | 900000 | 186.52 | 414.21 | 1031.01 | 2.49x | 0 | n just past the topLevel 3→4 step at n = 2^18 (#182) |
 
 ## Comparison counts — the sorting barrier, measured (#170)
 
@@ -32,7 +32,7 @@ Comparisons between path lengths (the paper's cost metric), one exact run per si
 
 | case | nodes | edges | dijkstra cmps | bmssp cmps | ratio | mismatches |
 | --- | --- | --- | --- | --- | --- | --- |
-| sparse d3 n=50k | 50000 | 150000 | 1,653,644 | 1,607,005 | 0.97x | 0 |
-| sparse d3 n=200k | 200000 | 600000 | 7,509,518 | 5,763,228 | 0.77x | 0 |
-| sparse d3 n=1M | 1000000 | 3000000 | 42,809,732 | 28,321,521 | 0.66x | 0 |
-| grid 700x700 | 490000 | 1957200 | 15,269,647 | 17,061,608 | 1.12x | 0 |
+| sparse d3 n=50k | 50000 | 150000 | 1,653,644 | 1,578,336 | 0.95x | 0 |
+| sparse d3 n=200k | 200000 | 600000 | 7,509,518 | 5,694,788 | 0.76x | 0 |
+| sparse d3 n=1M | 1000000 | 3000000 | 42,809,732 | 28,034,859 | 0.65x | 0 |
+| grid 700x700 | 490000 | 1957200 | 15,269,647 | 16,859,030 | 1.10x | 0 |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bmssp",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bmssp",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "license": "MPL-2.0",
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bmssp",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Javascript package implementation of the bmssp algorithm.",
   "main": "index.mjs",
   "keywords": [

--- a/src/baseCase.mjs
+++ b/src/baseCase.mjs
@@ -5,6 +5,7 @@ import {
   makeTies,
   orderKey,
   relaxEdge,
+  RELAX_LOST,
 } from "./tieBreak.mjs";
 
 /**
@@ -76,18 +77,25 @@ function baseCase(B, S, dHat, adjacency, k, ties = makeTies()) {
   while (!heap.isEmpty() && settled.size < cap + 1) {
     const { key: u } = heap.extractMin();
     settled.add(u);
-    for (const [v, weight] of adjacency.get(u) ?? []) {
+    const edges = adjacency.get(u);
+    if (edges === undefined) continue;
+    for (let i = 0; i < edges.length; i += 1) {
+      const edge = edges[i];
+      const v = edge[0];
       // Canonical relaxation, gated by the bound (the paper's `< B`). An
       // exact-equality result means u is v's recorded label-setter (v was
       // labeled by an earlier phase without being completed) and v must be
       // (re-)enqueued — unless this very call already settled it, which is
       // what keeps zero-weight plateaus finite.
-      const relaxed = relaxEdge(u, v, weight, dHat, ties, boundKey);
-      if (relaxed === null || settled.has(v)) continue;
+      const result = relaxEdge(u, v, edge[1], dHat, ties, boundKey);
+      if (result === RELAX_LOST || settled.has(v)) continue;
+      // Non-lost ⇒ v's stored label IS the candidate; materialize its key
+      // only here, on the enqueue path (#168)
+      const key = orderKey(v, dHat, ties);
       if (heap.has(v)) {
-        heap.decreaseKey(v, relaxed.key);
+        heap.decreaseKey(v, key);
       } else {
-        heap.insert(v, relaxed.key);
+        heap.insert(v, key);
       }
     }
   }

--- a/src/bmssp.mjs
+++ b/src/bmssp.mjs
@@ -3,10 +3,12 @@ import { findPivots } from "./findPivots.mjs";
 import { BlockList } from "./blockList.mjs";
 import {
   compareKeys,
+  compareKeyParts,
   toBound,
   makeTies,
   orderKey,
   relaxEdge,
+  RELAX_LOST,
 } from "./tieBreak.mjs";
 
 class BMSSP {
@@ -224,19 +226,26 @@ class BMSSP {
       // without completing (the paper's `≤` relaxation, deterministic here:
       // only the recorded label-setter triggers it); vertices already
       // completed at this level are filtered so re-enqueues stay finite.
+      // A non-lost relaxation leaves v's stored label equal to the
+      // candidate, so the band tests compare the unpacked stored components
+      // and a key array is built only for the enqueue itself (#168).
       const K = [];
       for (const u of Ui) {
-        for (const [v, weight] of this.adjacency.get(u) ?? []) {
-          const relaxed = relaxEdge(u, v, weight, dHat, ties);
-          if (relaxed === null || U.has(v)) continue;
-          const key = relaxed.key;
-          if (compareKeys(key, BiKey) >= 0 && compareKeys(key, boundKey) < 0) {
-            D.insert(v, key);
-          } else if (
-            compareKeys(key, BiPrimeKey) >= 0 &&
-            compareKeys(key, BiKey) < 0
-          ) {
-            K.push([v, key]);
+        const edges = this.adjacency.get(u);
+        if (edges === undefined) continue;
+        for (let i = 0; i < edges.length; i += 1) {
+          const edge = edges[i];
+          const v = edge[0];
+          const result = relaxEdge(u, v, edge[1], dHat, ties);
+          if (result === RELAX_LOST || U.has(v)) continue;
+          const length = dHat.get(v);
+          const hopCount = ties.hops.get(v) ?? 0;
+          if (compareKeyParts(length, hopCount, v, BiKey) >= 0) {
+            if (compareKeyParts(length, hopCount, v, boundKey) < 0) {
+              D.insert(v, [length, hopCount, v]);
+            }
+          } else if (compareKeyParts(length, hopCount, v, BiPrimeKey) >= 0) {
+            K.push([v, [length, hopCount, v]]);
           }
         }
       }
@@ -244,9 +253,13 @@ class BMSSP {
       // go back in front of everything else
       for (const x of Si) {
         if (U.has(x)) continue;
-        const key = orderKey(x, dHat, ties);
-        if (compareKeys(key, BiPrimeKey) >= 0 && compareKeys(key, BiKey) < 0) {
-          K.push([x, key]);
+        const length = dHat.get(x) ?? Infinity;
+        const hopCount = ties.hops.get(x) ?? 0;
+        if (
+          compareKeyParts(length, hopCount, x, BiKey) < 0 &&
+          compareKeyParts(length, hopCount, x, BiPrimeKey) >= 0
+        ) {
+          K.push([x, [length, hopCount, x]]);
         }
       }
       if (K.length > 0) D.batchPrepend(K);
@@ -256,7 +269,10 @@ class BMSSP {
     const finalKey =
       compareKeys(lastBoundKey, boundKey) < 0 ? lastBoundKey : boundKey;
     for (const x of W) {
-      if (compareKeys(orderKey(x, dHat, ties), finalKey) < 0) U.add(x);
+      const length = dHat.get(x) ?? Infinity;
+      if (compareKeyParts(length, ties.hops.get(x) ?? 0, x, finalKey) < 0) {
+        U.add(x);
+      }
     }
     return finish(finalKey, U);
   }

--- a/src/findPivots.mjs
+++ b/src/findPivots.mjs
@@ -1,4 +1,10 @@
-import { compareKeys, toBound, makeTies, relaxEdge } from "./tieBreak.mjs";
+import {
+  compareKeyParts,
+  toBound,
+  makeTies,
+  relaxEdge,
+  RELAX_LOST,
+} from "./tieBreak.mjs";
 
 /**
  * FindPivots(B, S) — Algorithm 1 of "Breaking the Sorting Barrier for Directed
@@ -75,12 +81,21 @@ function findPivots(B, S, dHat, adjacency, k, ties = makeTies()) {
   for (let i = 1; i <= rounds; i += 1) {
     const nextLayer = new Set();
     for (const u of layer) {
-      for (const [v, weight] of adjacency.get(u) ?? []) {
+      const edges = adjacency.get(u);
+      if (edges === undefined) continue;
+      for (let j = 0; j < edges.length; j += 1) {
+        const edge = edges[j];
+        const v = edge[0];
         // Canonical relaxation: d̂ updates are not gated by B (paper), and
         // both improvements and exact canonical equality admit v to the
-        // next layer when its key is below B
-        const relaxed = relaxEdge(u, v, weight, dHat, ties);
-        if (relaxed !== null && compareKeys(relaxed.key, boundKey) < 0) {
+        // next layer when its key is below B. Non-lost ⇒ v's stored label
+        // is the candidate, so the W gate compares the unpacked stored
+        // components — no key allocation (#168).
+        const result = relaxEdge(u, v, edge[1], dHat, ties);
+        if (
+          result !== RELAX_LOST &&
+          compareKeyParts(dHat.get(v), ties.hops.get(v) ?? 0, v, boundKey) < 0
+        ) {
           nextLayer.add(v);
         }
       }

--- a/src/tieBreak.mjs
+++ b/src/tieBreak.mjs
@@ -79,6 +79,26 @@ function compareKeys(a, b) {
 }
 
 /**
+ * Lexicographic comparison of an UNPACKED key (length, hops, id) against a
+ * packed one — identical order to compareKeys without materializing the
+ * left-hand array (#168: the hot relax/routing loops call this instead of
+ * allocating a throwaway key per test). Counts as one comparison.
+ * @param {number} length - Left key's length component
+ * @param {number} hops - Left key's hops component
+ * @param {*} id - Left key's id component
+ * @param {[number, number, *]} key - Right key, packed
+ * @returns {number} Negative when (length, hops, id) < key, positive when
+ *   greater, 0 when equal
+ */
+function compareKeyParts(length, hops, id, key) {
+  comparisonCount += 1;
+  if (length !== key[0]) return length < key[0] ? -1 : 1;
+  if (hops !== key[1]) return hops < key[1] ? -1 : 1;
+  if (id !== key[2]) return id < key[2] ? -1 : 1;
+  return 0;
+}
+
+/**
  * Normalize a bound to a composite key. A scalar B becomes the infimum of
  * all keys of length B, preserving the strict "distance < B" contract;
  * a composite bound (an array) passes through unchanged.
@@ -130,6 +150,11 @@ function orderKey(v, dHat, ties) {
  * tied alternative parents; callers filter already-completed vertices to
  * keep the re-enqueue finite, exactly like the paper.
  *
+ * Allocation-free since #168: the result is one of the three RELAX_* codes,
+ * and a caller that needs v's (possibly updated) order key materializes it
+ * with orderKey(v, dHat, ties) — only on the rare paths that enqueue v,
+ * instead of on every attempt.
+ *
  * @param {*} u - Edge tail (its labels are read)
  * @param {*} v - Edge head (its labels may be updated)
  * @param {number} weight - Edge weight, >= 0
@@ -137,38 +162,59 @@ function orderKey(v, dHat, ties) {
  * @param {{ hops: Map<*, number>, preds: Map<*, *> }} ties - Updated in place
  * @param {[number, number, *]} [bound] - Optional gate: skip (no d̂ update)
  *   unless the resulting order key would be strictly below this bound
- * @returns {{ key: [number, number, *], improved: boolean }|null} v's order
- *   key [d̂[v], hops[v], v] with `improved: true` when the labels were
- *   updated, `improved: false` when the candidate exactly matches v's
- *   canonical label; null when the candidate loses (or the bound gates it)
+ * @returns {number} RELAX_IMPROVED when the labels were updated,
+ *   RELAX_EQUAL when the candidate exactly matches v's canonical label
+ *   (the re-enqueue signal), RELAX_LOST when the candidate loses or the
+ *   bound gates it (labels untouched)
  */
 function relaxEdge(u, v, weight, dHat, ties, bound) {
   const length = dHat.get(u) + weight;
   const hopCount = (ties.hops.get(u) ?? 0) + 1;
-  if (bound !== undefined && compareKeys([length, hopCount, v], bound) >= 0) {
-    return null;
+  if (bound !== undefined && compareKeyParts(length, hopCount, v, bound) >= 0) {
+    return RELAX_LOST;
   }
-  const currentPathKey = [
-    dHat.get(v) ?? Infinity,
-    ties.hops.get(v) ?? 0,
-    ties.preds.has(v) ? ties.preds.get(v) : NO_PRED,
-  ];
-  const cmp = compareKeys([length, hopCount, u], currentPathKey);
-  if (cmp > 0) return null;
-  if (cmp === 0) return { key: [length, hopCount, v], improved: false };
+  // Candidate path key [length, hopCount, u] vs. v's current path key
+  // [d̂[v], hops[v], preds[v] ?? NO_PRED] — compareKeys inlined on the
+  // unpacked components (one counted comparison, no arrays)
+  comparisonCount += 1;
+  let cmp;
+  const currentLength = dHat.get(v) ?? Infinity;
+  if (length !== currentLength) {
+    cmp = length < currentLength ? -1 : 1;
+  } else {
+    const currentHops = ties.hops.get(v) ?? 0;
+    if (hopCount !== currentHops) {
+      cmp = hopCount < currentHops ? -1 : 1;
+    } else {
+      const currentPred = ties.preds.has(v) ? ties.preds.get(v) : NO_PRED;
+      cmp = u !== currentPred ? (u < currentPred ? -1 : 1) : 0;
+    }
+  }
+  if (cmp > 0) return RELAX_LOST;
+  if (cmp === 0) return RELAX_EQUAL;
   dHat.set(v, length);
   ties.hops.set(v, hopCount);
   ties.preds.set(v, u);
-  return { key: [length, hopCount, v], improved: true };
+  return RELAX_IMPROVED;
 }
+
+// relaxEdge result codes (#168): distinct, and only RELAX_LOST is falsy-like
+// in comparisons — callers must compare against the constants, not truthiness
+const RELAX_LOST = -1;
+const RELAX_EQUAL = 0;
+const RELAX_IMPROVED = 1;
 
 export {
   compareKeys,
+  compareKeyParts,
   toBound,
   makeTies,
   orderKey,
   relaxEdge,
   NO_PRED,
+  RELAX_LOST,
+  RELAX_EQUAL,
+  RELAX_IMPROVED,
   resetComparisonCount,
   getComparisonCount,
 };

--- a/test/tieBreak.test.mjs
+++ b/test/tieBreak.test.mjs
@@ -1,10 +1,14 @@
 import { describe, test, expect } from "@jest/globals";
 import {
   compareKeys,
+  compareKeyParts,
   toBound,
   makeTies,
   orderKey,
   relaxEdge,
+  RELAX_LOST,
+  RELAX_EQUAL,
+  RELAX_IMPROVED,
   resetComparisonCount,
   getComparisonCount,
 } from "../src/tieBreak.mjs";
@@ -105,6 +109,26 @@ describe("compareKeys — lexicographic composite order", () => {
       compareKeys([5, 1, 1], [Infinity, -Infinity, -Infinity]),
     ).toBeLessThan(0);
   });
+
+  test("compareKeyParts agrees with compareKeys on every component branch (#168)", () => {
+    const keys = [
+      [1, 9, 9],
+      [2, 0, 0],
+      [1, 2, 9],
+      [1, 3, 0],
+      [1, 2, 3],
+      [1, 2, 4],
+      [Infinity, 0, 1],
+      [Infinity, -Infinity, -Infinity],
+    ];
+    for (const a of keys) {
+      for (const b of keys) {
+        expect(Math.sign(compareKeyParts(a[0], a[1], a[2], b))).toBe(
+          Math.sign(compareKeys(a, b)),
+        );
+      }
+    }
+  });
 });
 
 describe("toBound — scalar bounds keep strict semantics", () => {
@@ -130,10 +154,11 @@ describe("relaxEdge — canonical relaxation", () => {
     ]);
     const ties = makeTies();
     const result = relaxEdge(0, 1, 5, dHat, ties);
-    expect(result).toEqual({ key: [5, 1, 1], improved: true });
+    expect(result).toBe(RELAX_IMPROVED);
     expect(dHat.get(1)).toBe(5);
     expect(ties.hops.get(1)).toBe(1);
     expect(ties.preds.get(1)).toBe(0);
+    expect(orderKey(1, dHat, ties)).toEqual([5, 1, 1]);
   });
 
   test("equal-length candidates win only on fewer hops, then smaller pred", () => {
@@ -154,20 +179,16 @@ describe("relaxEdge — canonical relaxation", () => {
       new Map([[5, 7]]),
     );
     // Same length (3 + 3 = 6), same hops (3), pred 9 > current pred 7: no
-    expect(relaxEdge(9, 5, 3, dHat, ties)).toBeNull();
+    expect(relaxEdge(9, 5, 3, dHat, ties)).toBe(RELAX_LOST);
     expect(ties.preds.get(5)).toBe(7);
     // Same length, same hops, pred 3 < current pred 7: canonical update
-    expect(relaxEdge(3, 5, 3, dHat, ties)).toEqual({
-      key: [6, 2, 5],
-      improved: true,
-    });
+    expect(relaxEdge(3, 5, 3, dHat, ties)).toBe(RELAX_IMPROVED);
+    expect(orderKey(5, dHat, ties)).toEqual([6, 2, 5]);
     expect(ties.preds.get(5)).toBe(3);
     // Re-relaxation from the now-canonical pred reports exact equality —
     // the caller's re-enqueue signal — without touching the labels
-    expect(relaxEdge(3, 5, 3, dHat, ties)).toEqual({
-      key: [6, 2, 5],
-      improved: false,
-    });
+    expect(relaxEdge(3, 5, 3, dHat, ties)).toBe(RELAX_EQUAL);
+    expect(orderKey(5, dHat, ties)).toEqual([6, 2, 5]);
     expect(ties.preds.get(5)).toBe(3);
   });
 
@@ -188,13 +209,11 @@ describe("relaxEdge — canonical relaxation", () => {
     );
     // 1 -> 0 with weight 0: candidate [2, 3, 1] vs current [2, 1, 5] — the
     // extra hops lose outright
-    expect(relaxEdge(1, 0, 0, dHat, ties)).toBeNull();
+    expect(relaxEdge(1, 0, 0, dHat, ties)).toBe(RELAX_LOST);
     // 0 -> 1 with weight 0 reproduces 1's canonical label exactly: reported
     // as equality, no update — so the cycle is quiescent, never looping
-    expect(relaxEdge(0, 1, 0, dHat, ties)).toEqual({
-      key: [2, 2, 1],
-      improved: false,
-    });
+    expect(relaxEdge(0, 1, 0, dHat, ties)).toBe(RELAX_EQUAL);
+    expect(orderKey(1, dHat, ties)).toEqual([2, 2, 1]);
     expect(ties.hops.get(1)).toBe(2);
   });
 
@@ -207,7 +226,7 @@ describe("relaxEdge — canonical relaxation", () => {
     // Vertex 2 is an externally seeded hop-0 source at distance 5; an
     // equal-length, equal-hops... any candidate has hops >= 1 > 0, and even
     // a shorter-hop tie would face the -Infinity pred sentinel
-    expect(relaxEdge(4, 2, 5, dHat, ties)).toBeNull();
+    expect(relaxEdge(4, 2, 5, dHat, ties)).toBe(RELAX_LOST);
     expect(dHat.get(2)).toBe(5);
   });
 
@@ -217,13 +236,11 @@ describe("relaxEdge — canonical relaxation", () => {
       [1, Infinity],
     ]);
     const ties = makeTies();
-    expect(relaxEdge(0, 1, 5, dHat, ties, toBound(5))).toBeNull();
+    expect(relaxEdge(0, 1, 5, dHat, ties, toBound(5))).toBe(RELAX_LOST);
     expect(dHat.get(1)).toBe(Infinity);
     expect(ties.preds.has(1)).toBe(false);
-    expect(relaxEdge(0, 1, 5, dHat, ties, toBound(5.1))).toEqual({
-      key: [5, 1, 1],
-      improved: true,
-    });
+    expect(relaxEdge(0, 1, 5, dHat, ties, toBound(5.1))).toBe(RELAX_IMPROVED);
+    expect(orderKey(1, dHat, ties)).toEqual([5, 1, 1]);
   });
 
   test("orderKey defaults: missing labels read as hop-0, distance Infinity", () => {


### PR DESCRIPTION
Closes #168

## Summary

Profiling-driven micro-optimizations of the hot relaxation loops, per the issue's targets and the #182/#167 findings comments:

- **Allocation-free `relaxEdge`** (`src/tieBreak.mjs`): returns `RELAX_LOST` / `RELAX_EQUAL` / `RELAX_IMPROVED` integer codes with the label comparison inlined on unpacked components — the old `{ key, improved }` object plus up to three throwaway key arrays *per edge attempt* are gone. Callers materialize a key with `orderKey` only on the rare enqueue paths.
- **`compareKeyParts(length, hops, id, key)`**: compareKeys with the left key unpacked, so `bmssp()`'s band routing and `findPivots`' W-gate test stored labels against bounds without allocating. Same order, same one-comparison counting (agreement swept in tests).
- **Indexed edge loops** in `bmssp()`/`baseCase`/`findPivots` (no per-edge iterator + destructuring).

## Measured impact (clean A/B vs post-#167 main, two alternating rounds)

| scenario | before | after | |
| --- | --- | --- | --- |
| sparse 50k | ~111 ms | ~87 ms | **−21%** |
| star 50k | ~147 ms | ~127 ms | **−13%** |
| sparse-l4 300k | ~1123 ms | ~862 ms | **−23%** |

Comparison counts also dropped ~1–3% (1.2.0 capture: sparse **0.95× / 0.76× / 0.65×** at 50k/200k/1M; grid 1.10×). `RESULTS.md` recaptured.

**Heap strategy (issue bullet 2) resolved by measurement:** the lazy duplicate-and-skip variant wins an isolated BaseCase micro-benchmark (~29–33 ms vs ~37–52 ms per 10k bounded runs), but BaseCase heaps are capped at k+1 ≈ 4 entries and never register in end-to-end profiles — the paper-literal indexed `MinHeap` stays. The "skip the per-level re-relax pass" idea was rejected as algorithmic infidelity: that pass is the paper's `≤`-reuse mechanism (Remark 3.4) for surfacing ≥-Bi neighbors.

## Tests / lint

- **186 tests (185 + 1 XL opt-in), 14 suites green**; lint clean; ~100% statement coverage. `relaxEdge` unit tests updated to the code contract (labels asserted from the maps); +1 `compareKeyParts`-vs-`compareKeys` agreement sweep. System-level contracts untouched: edge-order determinism, strict Lemma 3.1, oracle equality all pass unchanged.
- Extended runs green: `FUZZ_ROUNDS=25` and `FUZZ_XL=1` (2M nodes).

## Version

**Minor → `1.2.0`** — this closes milestone 1.2.0's last open issue (release fires in Phase E after merge confirmation).

## Roadmap proposals

1. **Close milestone `1.2.0`** once this PR merges (5/5 issues done).
2. **New 2.0.0 issue — "Dense-index core: typed-array labels + CSR adjacency":** post-#168 profiles put ~38% of self-time in `relaxEdge`'s label-Map traffic and ~24% in `bmssp()`'s Set bookkeeping; the next wall-clock lever is dense vertex indices with typed-array d̂/hops/preds and CSR adjacency, but that reshapes public label contracts (`shortestPaths` Map, in-place d̂ seeding for multi-source callers) — 2.0.0 territory alongside #172.

🤖 Generated with [Claude Code](https://claude.com/claude-code)