### PR TITLE
feat(#205): dense-index core — typed-array labels + CSR adjacency

### DIFF
--- a/.claude/knowledge/05-codebase-map.md
+++ b/.claude/knowledge/05-codebase-map.md
@@ -1,14 +1,15 @@
 # 05 — Codebase Map (current state)
 
-<!-- BOOKMARK-COMMIT: 1af81c2 -->
-<!-- PENDING-PR-BRANCH: feat/168-relaxation-micro-optimizations -->
-<!-- Last validated: 2026-07-21 (Phase C of the #168 PR). Describes the tree as it will
-     exist once that PR merges: relaxation micro-optimizations — allocation-free
-     relaxEdge (RELAX_* codes), compareKeyParts for unpacked band routing, indexed edge
-     loops. Wall-clock −13–23% (sparse-l4 ~1123→~862 ms); counts −1–3%. Heap strategy
-     measured: indexed kept (lazy wins only an isolated micro-benchmark; end-to-end
-     noise). Milestone-closing PR → minor bump 1.2.0 (release in Phase E after the
-     user confirms the merge). -->
+<!-- BOOKMARK-COMMIT: f7052c5 -->
+<!-- PENDING-PR-BRANCH: feat/205-dense-index-core -->
+<!-- Last validated: 2026-07-21 (Phase C of the #205 PR). Describes the tree as it will
+     exist once that PR merges: the dense-index engine — node ids mapped to dense
+     indices once (sorted-id order), the graph in CSR arrays, and d̂/hops/preds in typed
+     arrays (src/tieBreak.mjs makeLabels). The algorithm modules run entirely on indices;
+     the BMSSP class keeps a thin id<->index boundary (public Maps unchanged). Wall-clock
+     roughly halved (sparse 50k ~104->~53 ms, l4 300k ~982->~424 ms); counts unchanged.
+     First 2.0.0-milestone issue, mid-milestone → NO bump (the API stayed
+     backward-compatible; #173 takes the major bump). -->
 
 
 Snapshot of what exists in `bmssp-js` today, so you know what to build on vs. what's missing.
@@ -63,14 +64,15 @@ src/
   bmssp.mjs               # BMSSP class — full Algorithm 3 recursion (#43); wires the pieces below
   dijkstra.mjs            # reference Dijkstra (array binary-heap) — DONE, used as oracle
   constantDegree.mjs      # #164: opt-in constant-degree transform (in/out-degree ≤ 2); public, re-exported
-  tieBreak.mjs            # #163: composite [length, hops, id] keys — Assumption 2.1 realized (compareKeys/toBound/relaxEdge)
+  tieBreak.mjs            # #163: composite [length, hops, index] keys — Assumption 2.1 realized; since #205
+                          #      also the engine label state: makeLabels (typed d̂/hops/preds), labelKey, relaxEdge
   blockList.mjs           # #42: Lemma 3.3 block-based partial-sort structure D (comparator-aware since #163;
                           #      exact Lemma 3.3 asymptotics since #167 via boundIndex + select)
   boundIndex.mjs          # #167: AVL ordered block sequence — the paper's balanced-BST bound index (BoundIndex)
   select.mjs              # #167: deterministic worst-case-linear selection (partitionByRank, median of medians)
   heap.mjs                # #41: indexed binary min-heap (MinHeap) for BaseCase (comparator-aware since #163)
-  baseCase.mjs            # #40: BaseCase(B, S) — Algorithm 2 bounded mini-Dijkstra on composite keys
-  findPivots.mjs          # #44: FindPivots(B, S) — Algorithm 1 frontier shrink, canonical-pred forest
+  baseCase.mjs            # #40: BaseCase(B, S) — Algorithm 2 bounded mini-Dijkstra; on the CSR + typed labels (#205)
+  findPivots.mjs          # #44: FindPivots(B, S) — Algorithm 1 frontier shrink, canonical-pred forest (dense indices, #205)
 test/
   main.test.mjs           # Jest tests: constructor validation, nodeIDs, adjacency, shortestPaths, BMSSP-vs-Dijkstra (seeded 10k sparse)
   bmssp.test.mjs          # #43: 15 recursion tests — params, hand graphs, ties, Lemma 3.1 contract, seeded stress
@@ -113,7 +115,7 @@ knowledge base (markdown with pseudocode fences) isn't linted as shippable code.
 verified signatures (squash-merge via the GitHub UI signs for you), and CodeQL must pass —
 direct `git push origin main` is rejected, including for docs-only bookkeeping commits.
 
-## `src/bmssp.mjs` — the BMSSP class (Algorithm 3 wired in, #43)
+## `src/bmssp.mjs` — the BMSSP class (Algorithm 3 wired in, #43; dense-index engine, #205)
 
 ```js
 class BMSSP {
@@ -121,24 +123,32 @@ class BMSSP {
                                    // node IDs, finite non-negative weights; [] remains valid
   //   this.graph          : deep-copied edge array
   //   this.nodeIDs        : Set of all node IDs (from both endpoints)
-  //   this.shortestPaths  : Map<nodeId, distance>, initialized to Infinity  ← this is d̂[·]
-  //   this.adjacency      : Map<nodeId, Array<[to, weight]>>  ← #45, built in constructor
-  //   this.hops, this.preds : Map — #163 canonical labels (edge count + predecessor of the
-  //                           canonical shortest path), updated in lockstep with d̂
-  //   this.ties           : { hops, preds } bundle handed to relaxEdge
+  //   this.shortestPaths  : Map<nodeId, distance>, initialized to Infinity  ← public d̂[·]
+  //   this.adjacency      : Map<nodeId, Array<[to, weight]>>  ← #45 public edge view (getEdges)
+  //   this.hops, this.preds : Map — #163 canonical labels, public mirror refreshed after a run
+  //   this.ties           : { hops, preds } bundle (public boundary compatibility)
+  //   --- #205 dense engine (indices assigned in ascending-id order) ---
+  //   this.ids            : Float64Array index → original node id
+  //   this.indexOf        : Map<nodeId, index>  (inverse of ids)
+  //   this.csr            : { offsets:Uint32Array, targets:Uint32Array, weights:Float64Array }
+  //   this.labels         : { dist:Float64Array, hops:Uint32Array, preds:Int32Array } ← engine d̂
   //   this.k, this.t, this.topLevel : paper parameters, derived in the constructor
-  initializeShortestPaths()        // (re)set every nodeId's distance to Infinity; clears hops/preds
-  buildAdjacency()                 // #45: (re)build adjacency from this.graph
+  initializeShortestPaths()        // reset public Maps AND engine label arrays to ∞ / 0 / NO_PRED
+  buildAdjacency()                 // #45: (re)build the public adjacency Map from this.graph
+  buildIndex()                     // #205: sorted-id index + CSR + typed labels (called in ctor)
   getEdges(nodeId)                 // #45: O(1) outgoing-edge lookup; [] for unknown nodes
   deriveParameters()               // #43: k = max(1,⌊(log₂n)^⅓⌋), t = max(1,⌊(log₂n)^⅔⌋),
                                    //      topLevel = max(1,⌈log₂n / t⌉) — from this.nodeIDs.size
-  bmssp(l, B, S)                   // #43: Algorithm 3 → { bound, boundKey, vertices } (B', its
-                                   //      composite key, U); B scalar or composite — scalar in,
-                                   //      scalar bound out (boundKey always composite)
-  calculateShortestPaths(startNode)// #43: validates, sets d̂[start] = 0 (hop 0), runs
-                                   //      bmssp(topLevel, Infinity, {startNode}) — NO Dijkstra
-  reconstructPath(target)          // #169: source→target path from canonical preds; [] before
-                                   //      a run or when unreachable; throws for unknown target
+  syncLabelsIn() / syncLabelsOut() // #205: snapshot public shortestPaths → engine arrays before a
+                                   //      public bmssp() call, mirror arrays → public Maps after
+  boundToEngine(B) / keyToPublic(k)// #205: id↔index translation for a bound / a returned key
+  bmssp(l, B, S)                   // #205 PUBLIC wrapper (id space): sync in, translate, run
+                                   //      bmsspIndex, translate out → { bound, boundKey, vertices }
+  bmsspIndex(l, boundKey, S)       // #43 + #205: Algorithm 3 recursion, entirely in dense-index
+                                   //      space (S/U = indices, keys = [len,hops,index], CSR + labels)
+  calculateShortestPaths(startNode)// #43: validates, sets labels.dist[startIdx] = 0, runs
+                                   //      bmsspIndex(topLevel, ∞, {startIdx}), then syncLabelsOut
+  reconstructPath(target)          // #169: source→target path from the public preds mirror
 }
 ```
 
@@ -148,13 +158,35 @@ numbers, and weights must be non-negative. Failures identify the offending edge 
 An empty edge list remains valid and preserves the #162 contract: construction succeeds,
 then `calculateShortestPaths()` rejects any start node because the graph has no nodes.
 
-**`bmssp(l, B, S)` (#43):** level 0 delegates to `baseCase`. At level ≥ 1: `findPivots`
-shrinks the frontier; pivots seed a `BlockList(M = 2^((l-1)·t), B, compareKeys)`; the loop
-pulls `Bi, Si ← D.pull()`, recurses `bmssp(l-1, Bi, Si)`, relaxes edges out of the returned
-`Ui` (band `[Bi, B)` → `D.insert`, band `[Bi', Bi)` → staged `K` → `D.batchPrepend` together
-with the uncompleted `Si` members), and stops when `D` empties (success, `boundKey` = B's
-key) or `|U| ≥ k·2^(l·t)` trips (partial). Finally folds in the `W` vertices below the
-returned bound. Since `k·2^(topLevel·t) ≥ n`, the top call is always a successful execution.
+**Dense-index engine (#205).** The algorithm no longer touches Maps in its hot path. The
+constructor assigns every node id a dense index **in ascending numeric id order**
+(`buildIndex`), lays the graph out in **CSR** arrays (`offsets`/`targets`/`weights`), and
+allocates the labels as **typed arrays** (`dist:Float64Array`, `hops:Uint32Array`,
+`preds:Int32Array`; `makeLabels` in `tieBreak`). `baseCase`/`findPivots`/`bmsspIndex` all
+run purely on indices — `relaxEdge` reads/writes the typed arrays, edge loops walk CSR
+ranges. Because index order equals id order, the composite-key id tie-break picks the same
+canonical labels the pre-#205 id-keyed engine did, so **distances/hops/preds are unchanged
+and still edge-order-invariant** (the determinism fuzz + oracle suites pass untouched).
+`NO_PRED` is now `-1` (a valid `Int32Array` sentinel below every real index; was `-Infinity`).
+
+**Public boundary stays backward-compatible.** `this.shortestPaths` / `this.hops` /
+`this.preds` remain the documented public Maps (keyed by original id). The public
+`bmssp(l, B, S)` is a thin wrapper: `syncLabelsIn` snapshots seeded distances from
+`shortestPaths` into the engine arrays, the id-based `S`/bound are translated to index space
+(`boundToEngine`), `bmsspIndex` runs, then `syncLabelsOut` mirrors the arrays back and the
+result's indices/key are translated to id space (`keyToPublic`). `calculateShortestPaths`
+skips the wrapper (runs `bmsspIndex` directly, then one `syncLabelsOut`). `reconstructPath`
+reads the public `preds` mirror as before. This is why #205 is **API-non-breaking** despite
+being in the 2.0.0 milestone: it re-engineers the interior, not the surface.
+
+**`bmsspIndex(l, boundKey, S)` (#43):** level 0 delegates to `baseCase`. At level ≥ 1:
+`findPivots` shrinks the frontier; pivots seed a `BlockList(M = 2^((l-1)·t), boundKey,
+compareKeys)`; the loop pulls `Bi, Si ← D.pull()`, recurses `bmsspIndex(l-1, Bi, Si)`,
+relaxes edges out of the returned `Ui` (band `[Bi, B)` → `D.insert`, band `[Bi', Bi)` →
+staged `K` → `D.batchPrepend` together with the uncompleted `Si` members), and stops when
+`D` empties (success, `boundKey` = B's key) or `|U| ≥ k·2^(l·t)` trips (partial). Finally
+folds in the `W` vertices below the returned bound. Since `k·2^(topLevel·t) ≥ n`, the top
+call is always a successful execution.
 
 **Deterministic tie-breaking (#163, `src/tieBreak.mjs`).** All internal ordering uses
 composite `[length, hops, id]` keys (lexicographic), realizing the paper's Assumption 2.1
@@ -177,21 +209,22 @@ make every frontier comparison strict. Consequences, replacing the pre-#163 guar
 4. **Full determinism:** distances, hops, preds, and even partial-call `U`/`boundKey` are
    invariant under edge-list permutation (`test/tieBreak.test.mjs` asserts this).
 
-**Performance (measured 2026-07-16, addenda 2026-07-21; Apple Silicon, node v26.5.0 —
-full data + methodology in `benchmarks/HEAD-TO-HEAD.md`, latest capture in
+**Performance (measured 2026-07-16, addenda through 2026-07-21; Apple Silicon, node
+v26.5.0 — full data + methodology in `benchmarks/HEAD-TO-HEAD.md`, latest capture in
 `benchmarks/RESULTS.md`):** algorithm-only wall-clock (construction excluded, Dijkstra fed
-the same prebuilt adjacency): Dijkstra wins every shape/size; sparse-graph ratio narrows
-with n (1.0.0 record: 2.54× at 50k → **1.57× at 2M**). **Comparison counts (the paper's
-metric) crossed over at ~n = 1M sparse in the 1.0.0/1.1.1 records; after #167's
-selection-based BlockList they cross before n = 50k** — with #168's routing rework the
-1.2.0 capture reads **0.95× at 50k, 0.76× at 200k, 0.65× at 1M** (grid 700×700 1.10×).
-**#168 (1.2.0) cut wall-clock a further −13–23%** over post-#167 in clean A/B (sparse 50k
-~111 → ~87 ms, star ~147 → ~127 ms, sparse-l4 300k ~1123 → ~862 ms): allocation-free
-`relaxEdge` + unpacked band routing (`compareKeyParts`) + indexed edge loops. Post-#168
-profiles put remaining self-time in `relaxEdge`'s label-Map traffic (~38%, the 5–6
-Map ops per attempt — a dense-index/typed-array core would be the next lever, but it
-changes the public label contracts: proposed for 2.0.0) and `bmssp()`'s Set bookkeeping
-(~24%). **Heap strategy (#168, measured):** the lazy duplicate-and-skip variant wins an
+the same prebuilt adjacency): Dijkstra still wins every shape, but **#205's dense-index
+engine roughly halved BMSSP's time and brought sparse graphs to near-parity** — the
+2026-07-21 post-#205 capture reads **sparse-random 1.38×** (was ~2.5–2.8× at 1.2.0),
+**sparse-random-l4 1.07×**, **dense 1.16×**, grid 2.27×, chain 3.10×, star 2.48×. Clean
+A/B vs 1.2.0: sparse 50k ~104 → ~53 ms, star ~145 → ~100 ms, sparse-l4 300k ~982 →
+~424 ms. **Comparison counts are unchanged by #205** (identical algorithm, just typed
+storage): they crossed over at ~n = 1M sparse in the 1.0.0/1.1.1 records and, since #167's
+selection-based BlockList, cross before n = 50k — **0.95× at 50k, 0.76× at 200k, 0.65× at
+1M** (grid 700×700 1.10×). Earlier deltas for context: #168 (1.2.0) cut wall-clock −13–23%
+over #167 via allocation-free `relaxEdge` + unpacked band routing (`compareKeyParts`) +
+indexed edge loops; #205 then removed the label-Map traffic those profiles flagged (~38%
+self-time) by moving d̂/hops/preds into typed arrays over dense indices and the graph into
+CSR. **Heap strategy (#168, measured):** the lazy duplicate-and-skip variant wins an
 isolated BaseCase micro-benchmark (~29–33 ms vs ~37–52 ms per 10k bounded runs at
 n = 100k) but BaseCase's heaps are capped at k+1 ≈ 4 entries and never register in
 end-to-end profiles — the paper-literal indexed `MinHeap` is kept. The two #182
@@ -316,39 +349,38 @@ The **true indexed heap** from §03-A (entries array + `position` Map for O(log 
 `decreaseKey`), matching Algorithm 2 literally — deliberately not the lazy duplicate-and-skip
 variant `src/dijkstra.mjs` uses internally. An extracted key may be re-inserted later.
 
-## `src/baseCase.mjs` — `BaseCase(B, S)`, Algorithm 2 (#40)
+## `src/baseCase.mjs` — `BaseCase(B, S)`, Algorithm 2 (#40; dense engine #205)
 
 ```js
-baseCase(B, S, dHat, adjacency, k, ties?)  // → { bound, boundKey, vertices }
-// B         : strict upper bound — scalar (Infinity OK) or composite key; scalar in,
-//             scalar bound out (boundKey always the composite boundary)
-// S         : singleton Set holding the complete source x (throws otherwise)
-// dHat      : Map<nodeId, number> — the global d̂[·]; RELAXED IN PLACE
-// adjacency : Map<nodeId, [to, weight][]> — the class's this.adjacency
-// k         : settle cap >= 1 (floored); throws otherwise
-// ties      : { hops, preds } canonical labels (#163); fresh throwaway maps by default
+baseCase(B, S, labels, csr, k)  // → { bound, boundKey, vertices }
+// B      : strict upper bound — scalar (Infinity OK) or composite key; scalar in,
+//          scalar bound out (boundKey always the composite boundary)
+// S      : singleton Set holding the complete source INDEX x (throws otherwise)
+// labels : { dist, hops, preds } typed-array engine labels (#205); RELAXED IN PLACE
+// csr    : { offsets, targets, weights } — the class's CSR graph (#205)
+// k      : settle cap >= 1 (floored); throws otherwise
 export { baseCase };     // NOT re-exported from index.mjs — internal to the algorithm
 ```
 
-Bounded mini-Dijkstra from `x` on a `MinHeap(compareKeys)` ordered by composite keys,
-stopping after settling `k+1` vertices. Full success (heap exhausted at ≤ k settled) →
-`{ bound: B, vertices: U0 }`; partial (cap hit) → `boundKey` = max settled key, `vertices` =
-exactly the k strictly-closer ones (composite-strict: a returned vertex may tie the
-boundary's scalar length). Relaxation is canonical `relaxEdge` gated by `< B`; the settled
-filter only skips exact-equality re-enqueue signals, keeping zero-weight plateaus quiescent.
-`bmssp()` calls it at level 0 (the pre-#163 escape-hatch re-use is gone).
+Bounded mini-Dijkstra from `x` on a `MinHeap(compareKeys)` ordered by composite keys (now
+`[len, hops, index]`), stopping after settling `k+1` vertices. Full success (heap exhausted
+at ≤ k settled) → `{ bound: B, vertices: U0 }`; partial (cap hit) → `boundKey` = max settled
+key, `vertices` = exactly the k strictly-closer indices (composite-strict: a returned vertex
+may tie the boundary's scalar length). Relaxation is canonical `relaxEdge` gated by `< B`;
+the settled filter only skips exact-equality re-enqueue signals, keeping zero-weight plateaus
+quiescent. `bmsspIndex()` calls it at level 0. Since #205 vertices are dense indices and the
+graph is CSR — no per-edge `adjacency.get` / iterator allocation.
 
-## `src/findPivots.mjs` — `FindPivots(B, S)`, Algorithm 1 (#44)
+## `src/findPivots.mjs` — `FindPivots(B, S)`, Algorithm 1 (#44; dense engine #205)
 
 ```js
-findPivots(B, S, dHat, adjacency, k, ties?)  // → { pivots, W }
+findPivots(B, S, labels, csr, k)  // → { pivots, W }
 // B         : strict bound gating membership in W — scalar (Infinity OK) or composite key;
 //             d̂ updates are NOT gated
-// S         : non-empty Set of complete frontier sources (throws if empty / any d̂ not finite)
-// dHat      : Map<nodeId, number> — the global d̂[·]; RELAXED IN PLACE
-// adjacency : Map<nodeId, [to, weight][]> — the class's this.adjacency
+// S         : non-empty Set of complete frontier source INDICES (throws if empty / d̂ not finite)
+// labels    : { dist, hops, preds } typed-array engine labels (#205); RELAXED IN PLACE
+// csr       : { offsets, targets, weights } — the class's CSR graph (#205)
 // k         : rounds + tree-size threshold >= 1 (floored); throws otherwise
-// ties      : { hops, preds } canonical labels (#163); fresh throwaway maps by default
 export { findPivots };   // NOT re-exported from index.mjs — internal to the algorithm
 ```
 
@@ -356,47 +388,54 @@ export { findPivots };   // NOT re-exported from index.mjs — internal to the a
 `< B` in the composite order gates only membership in `W`, and exact canonical equality
 re-admits an already-labeled vertex through its recorded setter). **Early exit:** as soon
 as `|W| > k·|S|`, returns `pivots = S` (copy) with the partial `W`. Otherwise the paper's
-tight-edge forest is simply the canonical predecessor pointers: every vertex of `W \ S`
-hangs off `preds[v]` (always itself in `W`), a DAG or tight cycle is impossible (one pred
-per vertex; zero-weight edges strictly increase hops), parent chains always end in `S`,
-and `S` members are roots by definition. Pivots = `S`-roots of trees with `≥ k` vertices;
-`|pivots| ≤ |W|/k`. The two #44-era tie ambiguities are resolved by construction. Note: a
-source with key ≥ `B` can still be returned as a pivot (early exit copies all of `S`,
-and direct multi-source callers may pass such sources); `bmssp()` filters them at seeding.
+tight-edge forest is simply the canonical predecessor pointers (`labels.preds[v]`): every
+vertex of `W \ S` hangs off its pred (always itself in `W`), a DAG or tight cycle is
+impossible (one pred per vertex; zero-weight edges strictly increase hops), parent chains
+always end in `S`, and `S` members are roots by definition. Pivots = `S`-roots of trees
+with `≥ k` vertices; `|pivots| ≤ |W|/k`. The two #44-era tie ambiguities are resolved by
+construction. Note: a source with key ≥ `B` can still be returned as a pivot (early exit
+copies all of `S`, and direct multi-source callers may pass such sources); `bmsspIndex()`
+filters them at seeding.
 
-## `src/tieBreak.mjs` — composite keys, Assumption 2.1 realized (#163)
+## `src/tieBreak.mjs` — composite keys + engine labels, Assumption 2.1 realized (#163, #205)
 
 ```js
-compareKeys(a, b)                  // lexicographic compare of [length, hops, id] triples
+compareKeys(a, b)                  // lexicographic compare of [length, hops, index] triples
 compareKeyParts(length, hops, id, key) // #168: same order, left side unpacked — the hot
                                    // loops' allocation-free compare; counts as one comparison
 toBound(B)                         // scalar B → [B, -Infinity, -Infinity] (infimum of length-B
                                    // keys, so key < toBound(B) ⇔ the strict scalar contract);
                                    // composite bounds pass through
-makeTies(hops?, preds?)            // bundle the canonical label maps (fresh by default)
-orderKey(v, dHat, ties)            // frontier key [d̂[v], hops[v] ?? 0, v]
-relaxEdge(u, v, w, dHat, ties, bound?) // canonical relaxation → RELAX_IMPROVED (d̂/hops/preds
-                                   // updated together) | RELAX_EQUAL (candidate exactly
-                                   // matches v's stored label; u is the recorded setter —
-                                   // the re-enqueue signal) | RELAX_LOST (labels untouched).
-                                   // Allocation-free since #168; callers that enqueue v
-                                   // materialize its key with orderKey only on that path
+makeLabels(n)                      // #205: engine label state — { dist:Float64Array(∞),
+                                   //   hops:Uint32Array(0), preds:Int32Array(NO_PRED) }
+labelKey(v, labels)                // #205: engine frontier key [dist[v], hops[v], v]
+relaxEdge(u, v, w, labels, bound?) // #205: canonical relaxation on the typed arrays →
+                                   //   RELAX_IMPROVED (dist/hops/preds updated together) |
+                                   //   RELAX_EQUAL (candidate exactly matches v's stored
+                                   //   label; u is the recorded setter — the re-enqueue
+                                   //   signal) | RELAX_LOST (labels untouched). Allocation-
+                                   //   free; enqueue paths build the key with labelKey
+makeTies(hops?, preds?)            // #163 public-boundary label Maps (BMSSP class mirror)
+orderKey(v, dHat, ties)            // #163 Map-based frontier key [d̂[v], hops[v] ?? 0, v]
 resetComparisonCount() / getComparisonCount() // #170: unconditional comparison counter over
                                    // compareKeys + compareKeyParts + relaxEdge's inlined
-                                   // label compare (the paper's cost metric); read by the
-                                   // benchmark harness
-export { compareKeys, compareKeyParts, toBound, makeTies, orderKey, relaxEdge,
-         NO_PRED, RELAX_LOST, RELAX_EQUAL, RELAX_IMPROVED,
+                                   // label compare (the paper's cost metric)
+export { compareKeys, compareKeyParts, toBound, makeTies, makeLabels, orderKey, labelKey,
+         relaxEdge, NO_PRED, RELAX_LOST, RELAX_EQUAL, RELAX_IMPROVED,
          resetComparisonCount, getComparisonCount };
                                    // NOT re-exported from index.mjs — internal to the algorithm
 ```
 
 The paper's Assumption 2.1 ("all path lengths distinct") in code: paths ranked by
-`[length, hops, id]` — `hops` (the paper's "#vertices") makes zero-weight extensions
-strictly increasing, `id` (pred id inside relaxation, own id for frontier order) stands in
-for the paper's full vertex-sequence comparison at O(1). Sources (no stored pred) hold a
-`-Infinity` pred sentinel and never lose an equal-`(length, hops)` tie; unlabeled vertices
-read as hop-0 / distance-∞, so externally seeded multi-source calls need no extra setup.
+`[length, hops, index]` — `hops` (the paper's "#vertices") makes zero-weight extensions
+strictly increasing, the third component (pred index inside relaxation, own index for
+frontier order) stands in for the paper's full vertex-sequence comparison at O(1). Since
+#205 the engine uses dense **indices** here; because indices are assigned in ascending
+id order, the canonical choice is identical to the pre-#205 id-keyed one. Sources (no
+stored pred) hold the `NO_PRED = -1` sentinel (below every real index) and never lose an
+equal-`(length, hops)` tie; unlabeled vertices read as hop-0 / distance-∞. `makeTies` and
+`orderKey` remain for the **public boundary** — the BMSSP class mirrors the engine arrays
+into `{ hops, preds }` Maps for `reconstructPath` and external inspection.
 
 ## `src/dijkstra.mjs` — the oracle (already done)
 
@@ -442,20 +481,25 @@ edge-order deterministic (copies allocated in edge order); ~2m copies, ~3m edges
   SNAP road network with unseeded random weights — removed in PR #185 and purged from git
   history: irreproducible failures, ~71 s of every run, coverage superseded by the seeded
   fuzz + scale suite.)
-- `test/bmssp.test.mjs` (15, NEW in #43): parameter derivation (clamps, paper formulas,
+- `test/bmssp.test.mjs` (18, #43 + 3 for #205): parameter derivation (clamps, paper formulas,
   `k·2^(topLevel·t) ≥ n` guard), end-to-end hand-built graphs (README example, multi-hop vs
   direct, unreachable ⇒ Infinity, self-loop, source switch), degenerate ties (zero-weight
   cycles/clusters, layered equal-length paths, seeded 0–2-weight stress), the Lemma 3.1
   recursion contract (bounded call: complete-below-boundary, exact membership, d̂ never
   underestimates; unbounded call: successful execution returning exactly the reachable set),
-  and seeded full-map-vs-oracle stress across sizes (up to n = 2000).
+  seeded full-map-vs-oracle stress across sizes (up to n = 2000), and the **#205 public
+  boundary**: a composite bound with non-contiguous ids round-tripping id↔index, a
+  composite bound keyed on a non-node id, a partial level-0 scalar projection, and an
+  unknown-source throw.
 - `test/blockList.test.mjs` (25), `test/heap.test.mjs` (16), `test/baseCase.test.mjs` (13),
   `test/findPivots.test.mjs` (12): per-module contracts incl. seeded stress — see the
-  module sections above. (Since #163 the baseCase partial-run tests assert the composite
-  contract: strictly below `boundKey`, `≤` the scalar bound. #167 added five BlockList
-  tests: hundreds-of-splits drain at M = 2, interior-block drops via duplicate-key
-  replacement, both chunking branches of `batchPrepend` — sort and median-recursion —
-  and a middle-`d0`-block unlink.)
+  module sections above. (Since #205 the `baseCase`/`findPivots` tests drive the functions
+  in **dense-index space**: fixtures build a `BMSSP`, seed `g.labels.dist`, pass
+  `idxSet(...)` / `g.csr`, and translate results back with `g.ids`. Since #163 the baseCase
+  partial-run tests assert the composite contract: strictly below `boundKey`, `≤` the
+  scalar bound. #167 added five BlockList tests: hundreds-of-splits drain at M = 2,
+  interior-block drops via duplicate-key replacement, both chunking branches of
+  `batchPrepend` — sort and median-recursion — and a middle-`d0`-block unlink.)
 - `test/select.test.mjs` (11, #167): `partitionByRank` — validation, the every-rank
   contract on shuffled/sorted/reverse/duplicate-heavy/organ-pipe inputs, custom
   comparators, the forced median-of-medians fallback (`cheapBudget: 0`), seeded stress
@@ -465,10 +509,11 @@ edge-order deterministic (copies allocated in edge order); ~2m copies, ~3m edges
   bound runs, and AVL invariants (parent pointers, stored heights, |balance| ≤ 1)
   verified recursively under append-only growth (height ≤ 17 at n = 2048) and two
   seeded random-churn stresses against a reference array.
-- `test/tieBreak.test.mjs` (20, #163 + 3 counter tests from #170 + the #168
-  `compareKeyParts`-vs-`compareKeys` agreement sweep): unit tests for
-  `compareKeys`/`toBound`/`relaxEdge` (asserting the #168 RELAX_* code contract with
-  label state read from the maps)
+- `test/tieBreak.test.mjs` (21, #163 + 3 counter tests from #170 + the #168
+  `compareKeyParts`-vs-`compareKeys` agreement sweep + a #205 `makeLabels`-defaults check):
+  unit tests for `compareKeys`/`toBound`/`relaxEdge` (asserting the #168 RELAX_* code
+  contract, since #205 with label state read from typed **engine arrays** via `makeLabels`
+  and asserted through `labelKey`)
   (lexicographic order, scalar-bound infimum, canonical pred choice, zero-weight-cycle
   quiescence, the equality re-enqueue signal), then the system-level properties:
   **edge-order determinism** (full runs AND bounded partial calls return identical
@@ -520,10 +565,14 @@ edge-order deterministic (copies allocated in edge order); ~2m copies, ~3m edges
   (identical maps incl. Infinity → 0; wrong/missing entries counted); `runScenarioBenchmark`
   and `runComparisonCountBenchmark` on tiny injected scenarios return the expected columns
   with **zero mismatches**.
-- Current suite: **186 tests — 185 passing + 1 XL skipped by default**, ~100% statement
+- Current suite: **191 tests — 190 passing + 1 XL skipped by default**, ~100% statement
   coverage, ~7.5 s wall-clock (the #164 distance-preservation sweeps run BMSSP/Dijkstra
   from every source). No graph data files: every generated test graph comes from a
-  seed; the #162 fixtures are hand-built and fully deterministic.
+  seed; the #162 fixtures are hand-built and fully deterministic. The #205 dense-index
+  engine changed the internal function signatures (`baseCase`/`findPivots` take
+  `labels`/`csr` + index sets) but not a single oracle/determinism assertion — the fuzz,
+  edge-case, tie-break-determinism and constant-degree suites pass unchanged, which is
+  the correctness proof that the id→index refactor preserved every canonical label.
 
 ## Benchmarks (`benchmarks/`, `npm run bench` / `npm run bench:counts`)
 
@@ -537,9 +586,11 @@ BMSSP-vs-Dijkstra head-to-head itself:
   Scenario registry adds `sparse-random-l4` (n = 300k, degree 3): `topLevel` steps 3→4 at
   exactly n = 2^18 + 1 and stays 4 until t reaches 7 (~n = 376k), so 300k sits inside the
   #182 level-transition window (the step itself measures ~+24% at the exact straddle).
-  Post-#167 capture (2026-07-21): sparse 2.46×, star 4.53× (~131 ms; pre-#182 8.73×),
-  l4 2.96× — ratios are noisy run-to-run (the Dijkstra denominator swings ±20%); compare
-  `bmssp ms` across captures for regressions.
+  **Post-#205 capture (2026-07-21): sparse-random 1.38×, dense 1.16×, grid 2.27×,
+  chain 3.10×, star 2.48×, sparse-random-l4 1.07×** — the dense-index engine roughly
+  halved `bmssp ms` on every shape (sparse-l4 ~1083 → ~426 ms). Ratios are noisy
+  run-to-run (the Dijkstra denominator swings ±20%); compare `bmssp ms` across captures
+  for regressions.
 - `compare-counts.bench.mjs` (opt-in, `npm run bench:counts` or `--counts`): comparisons
   between path lengths — BMSSP counted via `tieBreak`'s unconditional `compareKeys`
   counter, Dijkstra via matching counters in `dijkstra-adj.mjs`. One exact run per side
@@ -570,10 +621,11 @@ BMSSP-vs-Dijkstra head-to-head itself:
 | BMSSP-vs-Dijkstra head-to-head in the harness | `benchmarks/` + `src/tieBreak.mjs` counter | #170 | ✅ merged (PR #198, no bump) |
 | Performance-cliff investigation + quadratic batchPrepend fix | `src/blockList.mjs` + HEAD-TO-HEAD addendum | #182 | ✅ merged (PR #200, **patch → 1.1.1**, released 2026-07-21) |
 | Exact Lemma 3.3 asymptotics (BST bound index + linear selection) | `src/boundIndex.mjs` + `src/select.mjs` + `src/blockList.mjs` | #167 | ✅ merged (PR #202, no bump) |
-| Relaxation micro-optimizations (allocation-free relaxEdge, unpacked routing, heap measurement) | `src/tieBreak.mjs` + `src/bmssp.mjs` + `src/baseCase.mjs` + `src/findPivots.mjs` | #168 | ✅ done-pending-merge (this PR, **minor → 1.2.0**) |
+| Relaxation micro-optimizations (allocation-free relaxEdge, unpacked routing, heap measurement) | `src/tieBreak.mjs` + `src/bmssp.mjs` + `src/baseCase.mjs` + `src/findPivots.mjs` | #168 | ✅ merged (PR #203, **minor → 1.2.0**, released 2026-07-21) |
+| Dense-index core: typed-array labels + CSR adjacency | `src/tieBreak.mjs` (makeLabels) + `src/bmssp.mjs` (buildIndex/CSR) + `src/baseCase.mjs` + `src/findPivots.mjs` | #205 | ✅ done-pending-merge (this PR, no bump — API-non-breaking) |
 
-Milestone `1.1.0` (correctness hardening) is **closed** — released 2026-07-21 (npm +
-Docker Hub). This PR closes **#168**, milestone `1.2.0`'s last open issue → **minor bump
-1.2.0** (release + milestone close in Phase E after the merge). Next up: milestone
-`2.0.0` (#171/#172/#173 + the proposed dense-index core issue); see
-[06-milestones-roadmap.md](06-milestones-roadmap.md).
+Milestones `1.1.0` (correctness hardening) and `1.2.0` (performance & ergonomics) are
+both **closed** — 1.2.0 released 2026-07-21 (npm + Docker Hub). Milestone `2.0.0`
+(API-breaking generalization) is current: **#205** (dense-index core) done-pending-merge
+in this PR, then **#172 → #171 → #173** (build order in `06`; #173 closes the milestone
+with the **major → 2.0.0** bump). See [06-milestones-roadmap.md](06-milestones-roadmap.md).

--- a/.claude/knowledge/06-milestones-roadmap.md
+++ b/.claude/knowledge/06-milestones-roadmap.md
@@ -1,11 +1,10 @@
 # 06 — Milestones Roadmap
 
-<!-- SYNCED-FROM-GITHUB: 2026-07-21 Phase C of the #168 PR (verified live at RKB the
-     same day: 1.2.0 open with 1 open issue #168 — done-pending-merge in this PR;
-     2.0.0 open with 3 open issues #171/#172/#173) -->
-<!-- Current package version: 1.2.0 (bumped in the #168 PR — milestone-closing minor;
-     release fires in Phase E after the user confirms the merge. Last released: 1.1.1,
-     2026-07-21, with Announcements discussion) -->
+<!-- SYNCED-FROM-GITHUB: 2026-07-21 Phase C of the #205 PR (verified live at RKB the same
+     day: 1.2.0 CLOSED with 5/5 done; 2.0.0 open with 4 open issues #171/#172/#173/#205 —
+     #205 done-pending-merge in this PR) -->
+<!-- Current package version: 1.2.0 — released 2026-07-21 (tag + GitHub Release with
+     Announcements discussion → npm + Docker Hub via publish.yml); tag matches -->
 <!-- Release-discussion convention (user-directed 2026-07-21): every GitHub Release also
      creates a linked discussion — pass --discussion-category "Announcements" to
      gh release create (the UI's "Create a discussion for this release" checkbox) -->
@@ -44,19 +43,27 @@ it runs the same Phase C reconciliation directly on `main`.
 
 ## 📋 Roadmap proposals (pending user approval)
 
-From the #168 PR (Phase C, 2026-07-21):
+From the #205 PR (Phase C, 2026-07-21):
 
-1. **Close milestone `1.2.0`** once this PR merges — #168 is its last open issue
-   (5/5 done: #167/#168/#169/#170/#182).
-2. **Open a new 2.0.0 issue: "Dense-index core: typed-array labels + CSR adjacency".**
-   Post-#168 profiles put ~38% of self-time in `relaxEdge`'s label-Map traffic (5–6
-   `Map` ops per edge attempt) and ~24% in `bmssp()`'s Set bookkeeping. The next real
-   wall-clock lever is mapping node IDs to dense indices once and holding d̂/hops/preds
-   in typed arrays with CSR adjacency — but that reshapes the public label contracts
-   (`shortestPaths` Map, `bmssp(l, B, S)`'s in-place d̂ seeding for multi-source
-   callers), so it belongs in the 2.0.0 API-breaking milestone alongside #172
-   (typed/flexible graph inputs), not in a micro-optimization PR.
+1. **Comment on #172 (typed / flexible graph inputs)** with the engine baseline it now
+   builds on: #205 landed the dense-index core, so the class already maps ids → dense
+   indices (sorted-id order) and stores the graph as CSR (`this.csr`) + typed labels.
+   #172's builder/typed-input forms should **construct straight into that index+CSR
+   layout** rather than the `[from,to,weight]` array, and #172 is the natural place to
+   expose an explicit vertex-set / id-normalization API (today ids are inferred from
+   edges and sorted). Note the surprising #205 result — the dense engine roughly halved
+   wall-clock (sparse-random head-to-head 2.5× → **1.38×**), so typed inputs are now the
+   main remaining constant-factor lever before #171/#173.
+2. **Reassess the #205↔#171 ordering (no GitHub write, build-order note):** #205 kept the
+   public API backward-compatible (the `bmssp(l,B,S)` wrapper still speaks ids and seeds
+   via `shortestPaths`), so #171's public multi-source entrypoint is now a **surface**
+   design over a finished engine — confirming the RKB build order #205 → #172 → #171 →
+   #173. No issue edit needed; recorded here and in #173's stabilization scope.
 
+_(The #168-PR proposals — close milestone **1.2.0** (5/5 done) and open the
+**dense-index core** issue (typed-array labels + CSR adjacency; label-Map traffic ~38%
+of post-#168 self-time) — were approved and executed 2026-07-21: milestone #3 closed,
+issue **#205** created in 2.0.0.)_
 _(The #167-PR proposal — the post-#167 baseline comment on **#168** (BlockList no longer
 a count factor, crossover now <50k; relaxEdge allocation / Set churn / per-level relax
 pass are the remaining targets; #168 is the milestone-closing issue) — was approved and
@@ -175,7 +182,8 @@ executed 2026-07-17.)_
   `HEAD-TO-HEAD.md`; `RESULTS.md` recaptured; stale crossover blurbs updated in the
   harness and `benchmarks/README.md`. The Phase E proposal (baseline comment on #168)
   was approved and posted the same day.
-- **#168 done-pending-merge (this PR, 2026-07-21; minor → 1.2.0):** relaxation
+- **#168 merged (PR #203, 2026-07-21, commit f7052c5; minor → 1.2.0, released and
+  milestone closed same day):** relaxation
   micro-optimizations. `relaxEdge` reworked allocation-free (returns `RELAX_LOST` /
   `RELAX_EQUAL` / `RELAX_IMPROVED` codes; the old per-attempt `{ key, improved }`
   object + up to three throwaway key arrays are gone — callers materialize a key with
@@ -193,6 +201,25 @@ executed 2026-07-17.)_
   Suite 186 (+1 compareKeyParts agreement sweep; relaxEdge unit tests updated to the
   code contract); FUZZ_ROUNDS=25 and FUZZ_XL green. Next lever (label-Map traffic,
   ~38% self-time) proposed as a 2.0.0 dense-index issue (Roadmap proposal 2).
+- **#205 done-pending-merge (this PR, 2026-07-21; no bump — API-non-breaking):** the
+  dense-index core, first issue of milestone 2.0.0. `buildIndex()` assigns every node id
+  a dense index in **ascending-id order**, lays the graph out in **CSR** typed arrays
+  (`this.csr` = offsets/targets/weights), and holds d̂/hops/preds as typed arrays
+  (`makeLabels` in `tieBreak`: Float64/Uint32/Int32). `baseCase`/`findPivots`/the new
+  `bmsspIndex` recursion run **entirely on indices** — `relaxEdge` reads/writes the typed
+  arrays, edge loops walk CSR ranges, `NO_PRED` became `-1`. Because index order = id
+  order, canonical labels are byte-for-byte identical to the Map engine (the whole
+  determinism + oracle suite passes unchanged — the correctness proof). **The public API
+  did NOT change:** `bmssp(l,B,S)` is now a thin id↔index wrapper (syncLabelsIn/Out +
+  boundToEngine/keyToPublic), `shortestPaths`/`hops`/`preds` stay the public Maps,
+  `reconstructPath` reads the mirror. **Result: roughly halved wall-clock** — clean A/B
+  vs 1.2.0: sparse 50k ~104 → ~53 ms, star ~145 → ~100 ms, sparse-l4 300k ~982 → ~424 ms;
+  head-to-head **sparse-random 2.5× → 1.38×**, l4 1.07×, dense 1.16×. Comparison counts
+  unchanged (0.95×/0.76×/0.65× sparse). Suite 191 (+5: 4 #205 boundary tests in
+  `bmssp.test.mjs` + a `makeLabels`-defaults check; `baseCase`/`findPivots`/`tieBreak`
+  unit tests rewritten to drive the index API); 100% statement coverage, lint clean,
+  FUZZ_ROUNDS=25 + FUZZ_XL green. Roadmap proposals: engine-baseline comment on #172,
+  build-order confirmation for #171/#173.
 - **Semver release convention (user-directed 2026-07-17, PR #186):** bumps only on bug
   fix (patch) or milestone-closing PR (minor/major) — see "Release mechanics" below.
 - **2026-07-16 reflection session (post-release):** measured the BMSSP-vs-Dijkstra
@@ -237,16 +264,16 @@ All six issues done (build order as executed — cheapest protection first, then
 | 5 | 164 | Optional constant-degree transform (in/out-degree ≤ 2) | enhancement · help wanted | ✅ merged (PR #195, no bump): `src/constantDegree.mjs`, opt-in + distance-preserving, re-exported |
 | 6 | 166 | JSDoc / API docs for the new modules | documentation · good first issue | ✅ merged (PR #196, **minor → `1.1.0`**, released 2026-07-21): JSDoc on `index.mjs`'s re-exports + `docs/index.html` rewritten as the public-API reference (`BMSSP`, `dijkstra`, `constantDegreeTransform`; internals stay out). **Closed milestone 1.1.0** |
 
-## Milestone `1.2.0` (milestone #3) — performance & ergonomics — CURRENT
+## Milestone `1.2.0` (milestone #3) — performance & ergonomics — ✅ CLOSED (released 2026-07-21)
 
 Build order (as executed): ~~#170~~ (merged, PR #198), ~~#182~~ (merged, PR #200, 1.1.1),
-~~#167~~ (merged, PR #202), ~~#168~~ (done-pending-merge, this PR, **minor → 1.2.0**) —
-all five issues done; the milestone closes in Phase E.
+~~#167~~ (merged, PR #202), ~~#168~~ (merged, PR #203, **minor → 1.2.0**, released
+2026-07-21) — all five issues done; milestone closed 2026-07-21.
 
 | # | Issue | Labels | Notes |
 |---|---|---|---|
 | 167 | Restore Lemma 3.3's exact asymptotics in BlockList (balanced-BST bound index + linear-time selection) | enhancement · help wanted | ✅ merged (PR #202, no bump): `BoundIndex` AVL sequence + `partitionByRank` introselect; count crossover moved ~1M → <50k (0.66× at 1M); wall-clock at-or-better |
-| 168 | Adjacency and relaxation micro-optimizations | enhancement · help wanted | ✅ done-pending-merge (this PR, **minor → 1.2.0**): allocation-free relaxEdge (RELAX_* codes) + compareKeyParts routing + indexed edge loops → −13–23% wall-clock, counts down ~1–3%; heap strategy measured, indexed MinHeap kept; dense-index core proposed as a 2.0.0 issue |
+| 168 | Adjacency and relaxation micro-optimizations | enhancement · help wanted | ✅ merged (PR #203, **minor → 1.2.0**, released 2026-07-21): allocation-free relaxEdge (RELAX_* codes) + compareKeyParts routing + indexed edge loops → −13–23% wall-clock, counts down ~1–3%; heap strategy measured, indexed MinHeap kept; dense-index follow-up = #205 (2.0.0) |
 | 169 | Optional shortest-path reconstruction (`Pred[]` → paths) | enhancement · help wanted | ✅ merged (PR #189, no bump): public API + independent path oracle |
 | 170 | BMSSP-vs-Dijkstra benchmark comparison | enhancement · help wanted | ✅ merged (PR #198, no bump): head-to-head + count mode in the harness, verified outputs |
 | 182 | Investigate BMSSP performance cliffs: high-fanout (star) graphs and recursion-level transitions | enhancement · help wanted | ✅ merged (PR #200, **patch → 1.1.1**, released 2026-07-21): star = quadratic batchPrepend, fixed (61 s → ~3.1 s at 500k); level step = inherent +24%, documented (HEAD-TO-HEAD addendum) |
@@ -255,13 +282,22 @@ _Note:_ both #182 shapes stay as regression sentinels in every `npm run bench` (
 `sparse-random-l4`), and `npm run bench:counts` reproduces the comparison-count crossover
 (below 1.0 before n = 50k since #167; ~n = 1M in the 1.0.0/1.1.1 records).
 
-## Milestone `2.0.0` (milestone #4) — API-breaking generalization
+## Milestone `2.0.0` (milestone #4) — API-breaking generalization — CURRENT
 
-| # | Issue | Labels |
-|---|---|---|
-| 171 | Public multi-source / bounded BMSSP entrypoint | enhancement · help wanted |
-| 172 | Typed / flexible graph inputs | enhancement · help wanted |
-| 173 | Stabilize the public API surface for 1.0 → 2.0 | documentation · enhancement |
+Build order (derived 2026-07-21 at RKB, after 1.2.0 closed): ~~#205~~
+(done-pending-merge, this PR) → **#172 → #171 → #173**. Rationale: the dense-index engine
+(#205) decides the internal shapes every new API wraps, so it went first — the
+alternatives would build #171/#172 on the Map core and rebuild them; typed inputs (#172)
+then feed CSR directly; the public multi-source entrypoint (#171) is designed
+value-in/value-out over the finished engine; and stabilization (#173) locks the surface
+last and takes the **major → 2.0.0** bump as the milestone-closing PR.
+
+| # | Issue | Labels | Notes |
+|---|---|---|---|
+| 205 | Dense-index core: typed-array labels + CSR adjacency | enhancement | ✅ done-pending-merge (this PR, no bump — API-non-breaking): sorted-id index + CSR + typed labels; wall-clock ~halved (sparse head-to-head 2.5× → 1.38×), counts unchanged |
+| 172 | Typed / flexible graph inputs | enhancement · help wanted | NEXT — after #205 builder forms ingest straight into index+CSR (`this.csr`); the main remaining constant-factor lever |
+| 171 | Public multi-source / bounded BMSSP entrypoint | enhancement · help wanted | value-in/value-out API over the dense engine; #205 kept the id-based `bmssp(l,B,S)` wrapper, so this is surface design |
+| 173 | Stabilize the public API surface for 1.0 → 2.0 | documentation · enhancement | milestone-closing: per-module public/private decision, migration note, **major → 2.0.0** |
 
 _Note after #43:_ `bmssp(l, B, S)` already **is** a bounded multi-source call internally —
 #171 is mostly about designing the public API around it (initial per-source distances,

--- a/.claude/knowledge/07-glossary.md
+++ b/.claude/knowledge/07-glossary.md
@@ -1,9 +1,9 @@
 # 07 — Glossary
 
-<!-- Updated on: 2026-07-21 (#168 PR: compareKeyParts + RELAX_* codes; relaxEdge,
-     re-enqueue-signal and indexed-vs-lazy-heap entries updated to the new contract /
-     measurement. Previous update the same day: #167 PR added BoundIndex,
-     partitionByRank, introselect) -->
+<!-- Updated on: 2026-07-21 (#205 PR: dense-index engine — makeLabels, labelKey, CSR,
+     dense index, buildIndex, syncLabelsIn/Out, boundToEngine/keyToPublic, bmsspIndex;
+     NO_PRED now -1; relaxEdge/baseCase/findPivots entries updated to the typed-array
+     signature. Previous update the same day: #168 PR added compareKeyParts + RELAX_*) -->
 
 > **Lifecycle: dynamic — updated in Phase C of every PR.** When a PR introduces new symbols
 > or terms (module names, data-structure fields, paper notation newly used in code), add
@@ -90,12 +90,25 @@ Quick lookup for the symbols and terms used across the paper, the notes, and the
   algorithm-internal modules). Correctness-independent: BMSSP never calls it. Usage:
   `const t = constantDegreeTransform(g); …run from t.sourceCopy(s)…; t.collapse(dist)`.
 - **`adjacency`** (#45) — `Map<nodeId, Array<[to, weight]>>` field on the `BMSSP` class:
-  a node's outgoing edges, so lookups are O(1) instead of scanning the whole edge array.
-  Every known node has an entry (empty array for sinks). Built in the constructor.
+  a node's outgoing edges. Since #205 this is the **public edge view** behind `getEdges`
+  (and the fair-baseline Dijkstra in the benchmarks); the algorithm's hot path uses the
+  CSR arrays instead. Every known node has an entry (empty array for sinks). Built in the
+  constructor.
 - **`buildAdjacency()`** (#45) — class method that (re)builds `this.adjacency` from
   `this.graph`. Called by the constructor.
 - **`getEdges(nodeId)`** (#45) — class method returning a node's outgoing edges as
   `[to, weight]` pairs; returns `[]` for unknown nodes.
+- **Dense index** (#205) — the `BMSSP` class maps every original node id to a contiguous
+  integer `0..n-1`, assigned in **ascending numeric id order** (`buildIndex`). `this.ids`
+  (`Float64Array`) is index → id, `this.indexOf` (`Map`) is the inverse. Index order
+  equals id order, so the composite-key tie-break makes the same canonical choice it did
+  on ids — the refactor is label-preserving. The algorithm modules run entirely on indices.
+- **CSR** (#205) — Compressed-Sparse-Row graph layout, `this.csr = { offsets:Uint32Array,
+  targets:Uint32Array, weights:Float64Array }`. Node `u`'s outgoing edges are
+  `targets/weights[offsets[u] .. offsets[u+1])`. Replaces per-edge `adjacency.get` +
+  iterator/destructuring in the hot loops.
+- **`buildIndex()`** (#205) — constructor step building the dense index (`ids`/`indexOf`),
+  the CSR arrays (`this.csr`), and the typed label state (`this.labels`).
 - **Adjacency list (oracle)** — the *local* adjacency `Map` that `src/dijkstra.mjs` builds
   internally per call; distinct from the class's persistent `this.adjacency`.
 - **`BlockList`** (#42) — `src/blockList.mjs`, the Lemma 3.3 structure `D`. API:
@@ -145,22 +158,23 @@ Quick lookup for the symbols and terms used across the paper, the notes, and the
   measurement in #168:** lazy wins an isolated BaseCase micro-benchmark, but BaseCase
   heaps are capped at k+1 ≈ 4 entries and never register in end-to-end profiles, so the
   indexed paper-literal `MinHeap` is kept.
-- **`baseCase(B, S, dHat, adjacency, k)`** (#40) — `src/baseCase.mjs`, Algorithm 2:
-  bounded mini-Dijkstra from the singleton complete source in `S`, settling at most `k+1`
-  vertices, relaxing the shared `dHat` (`d̂[·]`) **in place** (canonically, with an optional
-  `ties` bundle since #163). Returns `{ bound, boundKey, vertices }` (= the paper's `B'`,
-  its composite key, `U`). Internal (not re-exported from `index.mjs`).
+- **`baseCase(B, S, labels, csr, k)`** (#40; dense engine #205) — `src/baseCase.mjs`,
+  Algorithm 2: bounded mini-Dijkstra from the singleton complete source **index** in `S`,
+  settling at most `k+1` vertices, relaxing the shared typed-array `labels` (d̂/hops/preds)
+  **in place** over the `csr` graph. Returns `{ bound, boundKey, vertices }` (= the paper's
+  `B'`, its composite key, `U` as index set). Internal (not re-exported from `index.mjs`).
 - **Settled filter** (#40, re-scoped by #163) — `baseCase` never re-inserts a vertex it
   already settled in the same call. Pre-#163 this guarded against equal-sum ping-pong
   loops; since #163 strict canonical relaxation makes improvements on settled vertices
   impossible, and the filter only skips exact-equality re-enqueue signals (see
   "Re-enqueue signal"), keeping zero-weight plateaus quiescent.
-- **`findPivots(B, S, dHat, adjacency, k, ties?)`** (#44) — `src/findPivots.mjs`,
+- **`findPivots(B, S, labels, csr, k)`** (#44; dense engine #205) — `src/findPivots.mjs`,
   Algorithm 1: `k` strictly-layered rounds of canonical Bellman-Ford out of the complete
-  frontier `S`, relaxing the shared `dHat` (`d̂[·]`) **in place**; `< B` (composite) gates
-  membership in `W` only (the d̂ write is unconditional). Returns `{ pivots, W }` (= the
-  paper's `P, W`), with `|pivots| ≤ |W|/k`; the forest is the canonical `preds` pointers.
-  Internal (not re-exported from `index.mjs`).
+  frontier `S` (indices), relaxing the shared typed-array `labels` **in place** over the
+  `csr` graph; `< B` (composite) gates membership in `W` only (the d̂ write is
+  unconditional). Returns `{ pivots, W }` (= the paper's `P, W`, index sets), with
+  `|pivots| ≤ |W|/k`; the forest is the canonical `labels.preds` pointers. Internal
+  (not re-exported from `index.mjs`).
 - **Early exit** (#44) — `findPivots`' first branch: as soon as `|W| > k·|S|` after a round,
   return `pivots = S` — the frontier is already small relative to `W`.
 - **One-parent rule** (#44, superseded by #163) — pre-#163, each vertex accepted the first
@@ -168,12 +182,27 @@ Quick lookup for the symbols and terms used across the paper, the notes, and the
   made `F` a DAG. Since #163 the forest **is** the canonical `preds` pointers: exactly one
   deterministic parent per vertex of `W \ S`, no DAG possible, and tight cycles cannot
   exist (zero-weight edges strictly increase hops). `S` members are roots by definition.
-- **`bmssp(l, B, S)`** (#43) — method on the `BMSSP` class, Algorithm 3: the main bounded
-  multi-source recursion. Level 0 delegates to `baseCase`; level ≥ 1 wires `findPivots` →
-  `BlockList` → recursive `bmssp(l-1, Bi, Si)` calls with band-routed relaxation. Returns
-  `{ bound, boundKey, vertices }` (= the paper's `B'`, its composite key, `U`); scalar `B`
-  in → scalar `bound` out. `calculateShortestPaths(start)` runs
-  `bmssp(topLevel, Infinity, {start})` after setting `d̂[start] = 0`, `hops[start] = 0`.
+- **`bmssp(l, B, S)`** (#43; public wrapper since #205) — method on the `BMSSP` class:
+  the PUBLIC Algorithm 3 entry in **id space**. Snapshots seeded distances from
+  `this.shortestPaths` into the engine (`syncLabelsIn`), translates `S`/bound to indices
+  (`boundToEngine`), runs `bmsspIndex`, then mirrors labels back (`syncLabelsOut`) and
+  translates the result to ids (`keyToPublic`). Returns `{ bound, boundKey, vertices }`
+  (= the paper's `B'`, its composite key, `U`); scalar `B` in → scalar `bound` out.
+- **`bmsspIndex(l, boundKey, S)`** (#43; dense engine #205) — the actual Algorithm 3
+  recursion, **entirely in dense-index space**: `S`/`U` are index sets, keys are
+  `[len, hops, index]`, the graph is `this.csr`, labels are `this.labels`. Level 0
+  delegates to `baseCase`; level ≥ 1 wires `findPivots` → `BlockList` → recursive
+  `bmsspIndex(l-1, Bi, Si)` with band-routed relaxation. `calculateShortestPaths(start)`
+  sets `labels.dist[startIdx] = 0` and calls `bmsspIndex(topLevel, toBound(∞), {startIdx})`
+  directly (skipping the id-translation wrapper), then `syncLabelsOut`.
+- **`syncLabelsIn()` / `syncLabelsOut()`** (#205) — the public↔engine label bridge.
+  `syncLabelsIn` fills the typed arrays from `this.shortestPaths` (seeded distances only —
+  sources are hop-0 roots) before a public `bmssp()` call; `syncLabelsOut` mirrors the
+  arrays back into `shortestPaths`/`hops`/`preds` (keyed by id) after a run, skipping
+  unreached (∞) vertices and the `NO_PRED` sentinel.
+- **`boundToEngine(B)` / `keyToPublic(key)`** (#205) — id↔index translation for the public
+  boundary: a scalar bound → `toBound`, a composite bound's id → its index; a returned
+  key's index → its id (sentinel / out-of-range components pass through).
 - **`deriveParameters()`** (#43) — class method (called by the constructor) that derives and
   stores `this.k`, `this.t`, `this.topLevel` from `n = nodeIDs.size`, each clamped to ≥ 1:
   `k = ⌊(log₂n)^(1/3)⌋`, `t = ⌊(log₂n)^(2/3)⌋`, `topLevel = ⌈log₂n / t⌉`. The clamp keeps
@@ -194,15 +223,27 @@ Quick lookup for the symbols and terms used across the paper, the notes, and the
   (`src/tieBreak.mjs`): `length` = path length, `hops` = edge count (the paper's
   "#vertices" tie-break — zero-weight extensions strictly increase it), `id` = pred id in
   relaxation / own id in frontier order (O(1) stand-in for the paper's vertex-sequence
-  comparison). Realizes Assumption 2.1: all frontier comparisons strict.
-- **Canonical label / relaxation** (#163, allocation-free since #168) —
-  `relaxEdge(u, v, w, dHat, ties, bound?)` updates `d̂`/`hops`/`preds` together iff the
+  comparison). Since #205 the engine's third component is a dense **index** rather than a
+  raw id; index order equals id order, so the canonical choice is unchanged. Realizes
+  Assumption 2.1: all frontier comparisons strict.
+- **`makeLabels(n)` / `labelKey(v, labels)`** (#205) — `src/tieBreak.mjs`: the engine label
+  state and its frontier key. `makeLabels` returns `{ dist:Float64Array(∞),
+  hops:Uint32Array(0), preds:Int32Array(NO_PRED) }`; `labelKey(v, labels)` builds
+  `[dist[v], hops[v], v]`. These replace the Map-based `dHat`/`ties`/`orderKey` in the
+  algorithm's hot path (the Maps remain at the public boundary).
+- **`NO_PRED`** (#163; `-1` since #205) — the source predecessor sentinel: compares below
+  every real vertex, so a source never loses an equal-`(length, hops)` tie. Was `-Infinity`
+  when preds lived in a Map (ids could be negative); since #205 preds live in an
+  `Int32Array` over dense indices (`≥ 0`), so `-1` both fits the array and stays below all.
+- **Canonical label / relaxation** (#163; allocation-free #168; typed arrays #205) —
+  `relaxEdge(u, v, w, labels, bound?)` updates `labels.dist`/`hops`/`preds` together iff the
   candidate path key beats the stored one; the fixed point is the lexicographic minimum
   over all paths, so labels, predecessor pointers and completed sets are invariant under
   edge/iteration order (tested in `test/tieBreak.test.mjs` against an O(n²)
   lexicographic Dijkstra oracle). Since #168 it returns one of three integer codes —
   `RELAX_IMPROVED` / `RELAX_EQUAL` / `RELAX_LOST` — and allocates nothing; a caller
-  that enqueues `v` materializes its key with `orderKey` on that path only.
+  that enqueues `v` materializes its key with `labelKey` on that path only. Since #205 `u`
+  and `v` are dense indices and the labels are typed arrays.
 - **`compareKeyParts(length, hops, id, key)`** (#168) — `src/tieBreak.mjs`: compareKeys
   with the left key unpacked into its components, so the hot relax/routing loops can
   test a stored label against a band bound without building a throwaway array. Same
@@ -217,14 +258,15 @@ Quick lookup for the symbols and terms used across the paper, the notes, and the
   labeled by a deeper call without being completed. The caller re-enqueues `v` unless it
   is already settled/completed — the paper's `≤` relaxation made canonical, firing from
   exactly one predecessor.
-- **`ties`** (#163) — the `{ hops, preds }` bundle (`makeTies`) that accompanies `dHat`
-  through `baseCase`/`findPivots`/`relaxEdge`; the `BMSSP` class owns one as `this.ties`
-  (`this.hops`, `this.preds`), cleared by `initializeShortestPaths()`. Missing entries
-  read as hop-0 / no-pred, so externally seeded sources need no setup.
+- **`ties`** (#163; public boundary since #205) — the `{ hops, preds }` bundle
+  (`makeTies`) that the `BMSSP` class owns as `this.ties` (`this.hops`, `this.preds`),
+  cleared by `initializeShortestPaths()`. Since #205 these Maps are the **public mirror**
+  of the engine's typed `labels` (refreshed by `syncLabelsOut`), used by `reconstructPath`
+  and external inspection — the algorithm no longer threads them through relaxation.
 - **`reconstructPath(target)`** (#169) — public `BMSSP` method that walks the canonical
-  `preds` chain from `target` to the latest calculation's source, then reverses it into a
-  source-to-target node sequence. Returns `[]` before a calculation or for an unreachable
-  target; throws when `target` is not a known graph node.
+  `preds` chain (the public mirror Map, #205) from `target` to the latest calculation's
+  source, then reverses it into a source-to-target node sequence. Returns `[]` before a
+  calculation or for an unreachable target; throws when `target` is not a known graph node.
 - **`boundKey`** (#163) — the composite boundary in `baseCase`/`bmssp` results: every
   returned vertex's order key is strictly below it. The scalar `bound` is its projection
   (a returned vertex may tie `bound`'s length, never exceed it).

--- a/README.md
+++ b/README.md
@@ -38,17 +38,21 @@ with every building block shipped, tested, and released individually:
 | Performance-cliff investigation; quadratic `BatchPrepend` fixed ([#182](https://github.com/Sirivasv/bmssp-js/issues/182)) | `src/blockList.mjs` | ✅ done — **1.1.1** |
 | Exact Lemma 3.3 asymptotics: balanced-BST bound index + linear-time selection ([#167](https://github.com/Sirivasv/bmssp-js/issues/167)) | `src/boundIndex.mjs` + `src/select.mjs` | ✅ done |
 | Relaxation micro-optimizations: allocation-free hot loops, −13–23% wall-clock ([#168](https://github.com/Sirivasv/bmssp-js/issues/168)) | `src/tieBreak.mjs` + the algorithm modules | ✅ done — **1.2.0** |
+| Dense-index core: typed-array labels + CSR adjacency, ~½ the wall-clock ([#205](https://github.com/Sirivasv/bmssp-js/issues/205)) | `src/bmssp.mjs` (CSR) + `src/tieBreak.mjs` (typed labels) | ✅ done |
 
 > **Honest note:** the paper's win is asymptotic, and this repo optimizes for correctness
-> and readability, not raw speed. Measured head-to-head (algorithm time only, graph
-> loading excluded — rerun it yourself with `npm run bench`; methodology and the deep
-> 1.0.0 record in [benchmarks/HEAD-TO-HEAD.md](benchmarks/HEAD-TO-HEAD.md)):
-> Dijkstra still wins on wall-clock at every practical size, though the gap narrows as
-> sparse graphs grow (2.5× at 50k nodes → 1.57× at 2M). But in the paper's own metric —
+> and readability first — but the constant factors have come down a lot. Measured
+> head-to-head (algorithm time only, graph loading excluded — rerun it yourself with
+> `npm run bench`; methodology and the deep 1.0.0 record in
+> [benchmarks/HEAD-TO-HEAD.md](benchmarks/HEAD-TO-HEAD.md)): Dijkstra still wins on
+> wall-clock, but after the dense-index engine
+> ([#205](https://github.com/Sirivasv/bmssp-js/issues/205): typed-array labels + CSR
+> adjacency) **BMSSP is within ~1.1–1.4× on sparse graphs** (sparse-random 1.38×,
+> sparse-l4 1.07×, dense 1.16×) — down from ~2.5× before. And in the paper's own metric —
 > **comparisons between path lengths** — BMSSP does **fewer comparisons than Dijkstra
 > from under n = 50k on sparse graphs** (`npm run bench:counts` measures 0.95× at 50k →
 > 0.76× at 200k → **0.65× at 1M**), and the advantage grows with size: the "sorting
-> barrier" is measurably broken; what remains is JS constant factors. That crossover
+> barrier" is measurably broken. That crossover
 > used to sit at ~n = 1M until [#167](https://github.com/Sirivasv/bmssp-js/issues/167)
 > replaced the block structure's sort-based internals with the paper's exact machinery
 > (balanced-BST bound index + deterministic linear-time selection).
@@ -74,12 +78,13 @@ with every building block shipped, tested, and released individually:
    ordered *between* blocks but unsorted *within* them — enough to repeatedly pull the next
    closest batch without paying the Θ(log n)-per-vertex "sorting barrier."
 
-The wall-clock crossover point is astronomically large, but the asymptotics are real: in
-measured comparison counts this implementation already beats Dijkstra from under 50k
-nodes on sparse graphs, by a third at 1M
-([benchmarks/HEAD-TO-HEAD.md](benchmarks/HEAD-TO-HEAD.md)). This repo
-optimizes for a **correct, readable, well-tested** implementation, validated line-by-line
-against a Dijkstra oracle — not for raw speed.
+Dijkstra still wins the wall-clock race, but only by a small margin on sparse graphs now
+(~1.1–1.4× since the dense-index engine); in measured comparison counts this
+implementation already beats Dijkstra from under 50k nodes on sparse graphs, by a third
+at 1M ([benchmarks/HEAD-TO-HEAD.md](benchmarks/HEAD-TO-HEAD.md)). This repo optimizes for
+a **correct, readable, well-tested** implementation, validated line-by-line against a
+Dijkstra oracle first — with the constant factors brought down where it doesn't cost
+clarity.
 
 ## Installation
 
@@ -190,7 +195,7 @@ graphs in a few seconds), and set `FUZZ_XL=1` for an additional 2-million-node r
 | [`1.0.0`](https://github.com/Sirivasv/bmssp-js/milestones) | First end-to-end functional BMSSP (issues #40–#45) | ✅ done |
 | `1.1.0` | Correctness hardening — fuzz tests, edge cases, tie-breaking, input validation, constant-degree transform, API docs | ✅ done |
 | `1.2.0` | Performance & ergonomics — exact Lemma 3.3 asymptotics, BMSSP-vs-Dijkstra benchmarks, cliff investigation, relaxation micro-optimizations | ✅ done |
-| `2.0.0` | API generalization — public multi-source/bounded entry point, flexible inputs | 🔨 next |
+| `2.0.0` | API generalization — dense-index engine (done), typed/flexible inputs, public multi-source/bounded entry point | 🔨 current |
 
 ## Contributing (humans and AI agents welcome)
 

--- a/benchmarks/HEAD-TO-HEAD.md
+++ b/benchmarks/HEAD-TO-HEAD.md
@@ -170,3 +170,33 @@ Wall-clock stayed at-or-better than 1.1.1 on every shape (star 50k ~144 ms → ~
 sparse 50k within noise; `sparse-random-l4` ~1,246 ms → ~1,083 ms) — the AVL bound index
 and selection cost about what the array + native sort did, while doing asymptotically
 honest work. Current capture: [`RESULTS.md`](./RESULTS.md).
+
+## Addendum — #205 dense-index engine roughly halves wall-clock (2026-07-21)
+
+[#205](https://github.com/Sirivasv/bmssp-js/issues/205) replaced the Map-based label
+storage that #168's profiles flagged (`relaxEdge`'s ~38% self-time was `Map.get`/`set` on
+arbitrary node ids) with a **dense-index engine**: node ids are mapped to contiguous
+integers once (in ascending-id order, so the canonical tie-break is unchanged), the graph
+is stored in **CSR** arrays, and `d̂`/`hops`/`preds` live in **typed arrays**
+(`Float64Array`/`Uint32Array`/`Int32Array`). The algorithm runs entirely on indices; a thin
+id↔index wrapper keeps the public API identical (so #205 shipped **no** version bump).
+
+Algorithm-only wall-clock, head-to-head vs. Dijkstra on the same prebuilt adjacency
+(2026-07-21 capture, [`RESULTS.md`](./RESULTS.md)):
+
+| shape | 1.2.0 ratio | post-#205 ratio | bmssp ms (1.2.0 → #205) |
+| --- | --- | --- | --- |
+| sparse-random 50k | ~2.5–2.8× | **1.38×** | ~104 → ~48 |
+| sparse-random-l4 300k | ~2.5–3× | **1.07×** | ~1,083 → ~426 |
+| dense 8k | ~4.5× | **1.16×** | ~61 → ~18 |
+| grid 40k | ~3.9× | 2.27× | ~66 → ~38 |
+| chain 50k | ~6.5× | 3.10× | ~37 → ~23 |
+| star 50k | ~4.5× | 2.48× | ~131 → ~92 |
+
+Clean A/B (fresh processes, alternating rounds): sparse 50k ~104 → ~53 ms, star ~145 →
+~100 ms, sparse-l4 300k ~982 → ~424 ms — roughly a 2× speedup on the algorithm itself.
+**Comparison counts are unchanged** (0.95× / 0.76× / 0.65× sparse at 50k / 200k / 1M): the
+algorithm and its canonical choices are byte-for-byte identical, only the storage changed —
+which is exactly what the untouched determinism + oracle suites certify. BMSSP is now within
+~1.1–1.4× of Dijkstra's wall-clock on sparse graphs; the remaining gap is ordinary JS
+constant factors, with typed/flexible inputs (#172) the next lever.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -103,25 +103,27 @@ harness reruns it on every `npm run bench` (fresh capture:
 [`RESULTS.md`](./RESULTS.md); the deeper 1.0.0 record up to n = 4M:
 [`HEAD-TO-HEAD.md`](./HEAD-TO-HEAD.md)):
 
-- **Use Dijkstra for wall-clock speed:** it wins on every shape and size
-  measured (algorithm-only timing, ~1.6–3× on sparse graphs, more on
-  dense/chain/star). `bmssp-js` itself uses Dijkstra as the oracle precisely
+- **Use Dijkstra for wall-clock speed:** it still wins on every shape and
+  size measured — but on sparse graphs the margin is now small
+  (algorithm-only timing, **~1.1–1.4×** since the #205 dense-index engine,
+  down from ~2.5–3×). `bmssp-js` itself uses Dijkstra as the oracle precisely
   because it is correct and fast.
-- **BMSSP's asymptotics are real and visible:** on sparse graphs the
-  wall-clock gap narrows with n (2.5× at 50k → 1.57× at 2M in the 1.0.0
-  record), and in the paper's own metric the harness's count mode shows the
-  ratio below 1.0 from n = 50k on: **0.95× at 50k → 0.76× at 200k → 0.65×
-  at 1M** (since #167; ~1M crossover before it; #168 shaved a further
-  ~1–3%). The sorting barrier is measurably broken; the remaining loss is
-  constant factors — #168 cut −13–23% of wall-clock from the hot loops.
-- **Shapes that blunt BMSSP's edge, per the harness:** `dense-random`
-  (relaxation-bound, ~4.7×), `chain` (depth, not sorting, is the cost —
-  ~7.4× against the prebuilt-adjacency baseline), `star` (extreme fanout,
-  ~3.8× at 50k — the #182 quadratic-`batchPrepend` blowup is **fixed**, 500k
+- **BMSSP's asymptotics are real and visible:** after #205 (typed-array
+  labels + CSR adjacency) the sparse head-to-head reads **1.38×**
+  (sparse-random 50k), **1.07×** (sparse-random-l4 300k) and **1.16×**
+  (dense) — roughly half the pre-#205 wall-clock. In the paper's own metric
+  the harness's count mode shows the ratio below 1.0 from n = 50k on:
+  **0.95× at 50k → 0.76× at 200k → 0.65× at 1M** (unchanged by #205 —
+  identical algorithm, just typed storage; the crossover moved to <50k at
+  #167, and #168 shaved a further ~1–3%). The sorting barrier is measurably
+  broken; the remaining wall-clock loss is ordinary JS constant factors.
+- **Shapes that blunt BMSSP's edge, per the harness:** `grid` (~2.3×),
+  `chain` (depth, not sorting, is the cost — ~3.1×), `star` (extreme fanout,
+  ~2.5× at 50k — the #182 quadratic-`batchPrepend` blowup is **fixed**, 500k
   went 61 s → ~3 s and the ratio now falls with n), and the `topLevel` 3→4
-  window (`sparse-random-l4`: ~3× at 300k — a measured **~+24% step** at the
-  exact transition n = 2^18 → 2^18 + 1, inherent one-extra-relax-pass cost;
-  both stay as regression sentinels; see the #182 addendum in
+  window (`sparse-random-l4`: the measured **~+24% step** at the exact
+  transition n = 2^18 → 2^18 + 1 is an inherent one-extra-relax-pass cost;
+  both #182 shapes stay as regression sentinels; see the #182 addendum in
   [`HEAD-TO-HEAD.md`](./HEAD-TO-HEAD.md)).
 
 **Bottom line for this repo:** BMSSP is implemented here for **correctness and

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -1,6 +1,6 @@
 # bmssp-js benchmark run
 
-_Generated 2026-07-21T10:59:44.802Z · node v26.5.0 · darwin/arm64_
+_Generated 2026-07-21T11:33:08.964Z · node v26.5.0 · darwin/arm64_
 
 ## Adjacency map vs linear scan (#45)
 
@@ -8,10 +8,10 @@ Graph: 20000 nodes, 80000 edges · 5000 random per-node edge lookups.
 
 | method | median ms | per lookup µs |
 | --- | --- | --- |
-| linear scan (pre-#45) | 419.89 | 83.98 |
-| adjacency map (#45) | 0.11 | 0.02 |
+| linear scan (pre-#45) | 422.72 | 84.54 |
+| adjacency map (#45) | 0.12 | 0.02 |
 
-**Speedup: 3797.0x** faster per-node lookups with the map.
+**Speedup: 3441.4x** faster per-node lookups with the map.
 
 ## Graph-shape scenarios — BMSSP vs Dijkstra (#170)
 
@@ -19,12 +19,12 @@ Algorithm time only: both sides consume the same prebuilt adjacency Map; `mismat
 
 | scenario | nodes | edges | construct ms | dijkstra ms | bmssp ms | ratio | mismatches | notes |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| sparse-random | 50000 | 150000 | 26.20 | 37.11 | 103.34 | 2.78x | 0 | m = O(n), degree 3 — the road-network regime |
-| dense-random | 8000 | 256000 | 24.04 | 16.98 | 43.95 | 2.59x | 0 | avg degree 32 — edge-relaxation-bound |
-| grid-4nbr | 40000 | 159200 | 15.55 | 19.50 | 65.93 | 3.38x | 0 | 200x200 lattice — large diameter, low degree |
-| chain | 50000 | 49999 | 10.18 | 6.59 | 43.18 | 6.55x | 0 | single long path — worst-case depth |
-| star | 50000 | 99998 | 14.03 | 31.86 | 133.82 | 4.20x | 0 | one hub, n-1 spokes — extreme degree skew (#182) |
-| sparse-random-l4 | 300000 | 900000 | 186.52 | 414.21 | 1031.01 | 2.49x | 0 | n just past the topLevel 3→4 step at n = 2^18 (#182) |
+| sparse-random | 50000 | 150000 | 41.11 | 35.04 | 48.37 | 1.38x | 0 | m = O(n), degree 3 — the road-network regime |
+| dense-random | 8000 | 256000 | 28.90 | 15.86 | 18.33 | 1.16x | 0 | avg degree 32 — edge-relaxation-bound |
+| grid-4nbr | 40000 | 159200 | 18.74 | 16.55 | 37.54 | 2.27x | 0 | 200x200 lattice — large diameter, low degree |
+| chain | 50000 | 49999 | 13.08 | 7.42 | 22.99 | 3.10x | 0 | single long path — worst-case depth |
+| star | 50000 | 99998 | 15.76 | 37.03 | 91.66 | 2.48x | 0 | one hub, n-1 spokes — extreme degree skew (#182) |
+| sparse-random-l4 | 300000 | 900000 | 293.68 | 396.35 | 425.60 | 1.07x | 0 | n just past the topLevel 3→4 step at n = 2^18 (#182) |
 
 ## Comparison counts — the sorting barrier, measured (#170)
 
@@ -32,7 +32,7 @@ Comparisons between path lengths (the paper's cost metric), one exact run per si
 
 | case | nodes | edges | dijkstra cmps | bmssp cmps | ratio | mismatches |
 | --- | --- | --- | --- | --- | --- | --- |
-| sparse d3 n=50k | 50000 | 150000 | 1,653,644 | 1,578,336 | 0.95x | 0 |
-| sparse d3 n=200k | 200000 | 600000 | 7,509,518 | 5,694,788 | 0.76x | 0 |
-| sparse d3 n=1M | 1000000 | 3000000 | 42,809,732 | 28,034,859 | 0.65x | 0 |
-| grid 700x700 | 490000 | 1957200 | 15,269,647 | 16,859,030 | 1.10x | 0 |
+| sparse d3 n=50k | 50000 | 150000 | 1,653,644 | 1,578,335 | 0.95x | 0 |
+| sparse d3 n=200k | 200000 | 600000 | 7,509,518 | 5,694,787 | 0.76x | 0 |
+| sparse d3 n=1M | 1000000 | 3000000 | 42,809,732 | 28,034,858 | 0.65x | 0 |
+| grid 700x700 | 490000 | 1957200 | 15,269,647 | 16,859,029 | 1.10x | 0 |

--- a/src/baseCase.mjs
+++ b/src/baseCase.mjs
@@ -2,8 +2,7 @@ import { MinHeap } from "./heap.mjs";
 import {
   compareKeys,
   toBound,
-  makeTies,
-  orderKey,
+  labelKey,
   relaxEdge,
   RELAX_LOST,
 } from "./tieBreak.mjs";
@@ -15,18 +14,21 @@ import {
  * that stops after settling k + 1 vertices.
  *
  * Preconditions (guaranteed by the caller, Algorithm 3):
- * - S is a singleton {x} and x is complete (dHat holds its true distance).
+ * - S is a singleton {x} and x is complete (labels.dist holds its true
+ *   distance).
  * - Every incomplete vertex v with d(v) < B has a shortest path through x.
  *
- * Distance estimates are read from and written into dHat in place — exactly
- * like the paper's global d̂[·] labels, so improvements made here are visible
- * to the levels above. Since #163 the heap is ordered by the composite
- * [length, hops, id] keys of src/tieBreak.mjs, which realize the paper's
- * Assumption 2.1 (distinct path lengths): a settled vertex carries its
- * canonical (lexicographically minimal) label, which no later relaxation can
- * improve. The settled filter below only skips canonical re-enqueue signals
- * (exact label equality from the recorded predecessor), which is what keeps
- * zero-weight plateaus quiescent instead of looping.
+ * Since #205 the engine works on dense vertex indices: S holds indices, the
+ * graph is the class's CSR bundle, and the labels are the shared typed
+ * arrays (see tieBreak's makeLabels) — updated in place, exactly like the
+ * paper's global d̂[·], so improvements made here are visible to the levels
+ * above. The heap is ordered by the composite [length, hops, index] keys,
+ * which realize the paper's Assumption 2.1 (distinct path lengths): a
+ * settled vertex carries its canonical (lexicographically minimal) label,
+ * which no later relaxation can improve. The settled filter below only
+ * skips canonical re-enqueue signals (exact label equality from the
+ * recorded predecessor), which is what keeps zero-weight plateaus quiescent
+ * instead of looping.
  *
  * Two outcomes:
  * - Full success (fewer than k + 1 vertices exist under B): every vertex
@@ -34,26 +36,27 @@ import {
  * - Partial (the k + 1 cap was hit): boundKey = the largest settled key
  *   B' < B, and exactly the k strictly-closer vertices are returned. Under
  *   the composite order the strictly-closer filter is exact — scalar-length
- *   ties with the boundary vertex are broken by (hops, id), and a returned
- *   vertex may therefore share the boundary's scalar length (the documented
- *   d(v) <= bound caveat of the scalar view).
+ *   ties with the boundary vertex are broken by (hops, index), and a
+ *   returned vertex may therefore share the boundary's scalar length (the
+ *   documented d(v) <= bound caveat of the scalar view).
  *   Every returned vertex is complete either way.
  *
  * @param {number|[number, number, *]} B - Strict upper bound on the keys to
  *   settle: a number (Infinity is allowed) or a composite bound
- * @param {Set<*>|Iterable<*>} S - Singleton set holding the complete source x
- * @param {Map<*, number>} dHat - Global distance estimates d̂[·], updated in place
- * @param {Map<*, Array<[*, number]>>} adjacency - nodeId -> outgoing [to, weight] edges
+ * @param {Set<number>|Iterable<number>} S - Singleton set holding the
+ *   complete source index x
+ * @param {{ dist: Float64Array, hops: Uint32Array, preds: Int32Array }} labels
+ *   - Engine label state (d̂[·] and tie-break labels), updated in place
+ * @param {{ offsets: Uint32Array, targets: Uint32Array, weights: Float64Array }} csr
+ *   - The graph in CSR layout over dense indices
  * @param {number} k - Settle cap parameter, >= 1 (floored); the paper's ⌊log^(1/3) n⌋
- * @param {{ hops: Map<*, number>, preds: Map<*, *> }} [ties] - Canonical
- *   tie-break labels updated alongside dHat; fresh throwaway maps by default
- * @returns {{ bound: number|[number, number, *], boundKey: [number, number, *], vertices: Set<*> }}
+ * @returns {{ bound: number|[number, number, *], boundKey: [number, number, *], vertices: Set<number> }}
  *   The boundary B' <= B (same kind as the B passed in), its composite key,
- *   and the set U of vertices settled below it
+ *   and the set U of vertex indices settled below it
  * @throws {Error} If k is not a number >= 1, S is not a singleton, or the
  *   source has no finite distance estimate
  */
-function baseCase(B, S, dHat, adjacency, k, ties = makeTies()) {
+function baseCase(B, S, labels, csr, k) {
   if (typeof k !== "number" || Number.isNaN(k) || k < 1) {
     throw new Error("k must be a number >= 1");
   }
@@ -63,35 +66,32 @@ function baseCase(B, S, dHat, adjacency, k, ties = makeTies()) {
     throw new Error("S must contain exactly one source node");
   }
   const [x] = sources;
-  const sourceDistance = dHat.get(x);
-  if (typeof sourceDistance !== "number" || !Number.isFinite(sourceDistance)) {
+  if (!Number.isFinite(labels.dist[x])) {
     throw new Error("the source must have a finite distance estimate");
   }
   const boundKey = toBound(B);
+  const { offsets, targets, weights } = csr;
 
   // U0 in the paper: the vertices settled by this call, seeded with x
   const settled = new Set([x]);
   const heap = new MinHeap(compareKeys);
-  heap.insert(x, orderKey(x, dHat, ties));
+  heap.insert(x, labelKey(x, labels));
 
   while (!heap.isEmpty() && settled.size < cap + 1) {
     const { key: u } = heap.extractMin();
     settled.add(u);
-    const edges = adjacency.get(u);
-    if (edges === undefined) continue;
-    for (let i = 0; i < edges.length; i += 1) {
-      const edge = edges[i];
-      const v = edge[0];
+    for (let e = offsets[u]; e < offsets[u + 1]; e += 1) {
+      const v = targets[e];
       // Canonical relaxation, gated by the bound (the paper's `< B`). An
       // exact-equality result means u is v's recorded label-setter (v was
       // labeled by an earlier phase without being completed) and v must be
       // (re-)enqueued — unless this very call already settled it, which is
       // what keeps zero-weight plateaus finite.
-      const result = relaxEdge(u, v, edge[1], dHat, ties, boundKey);
+      const result = relaxEdge(u, v, weights[e], labels, boundKey);
       if (result === RELAX_LOST || settled.has(v)) continue;
       // Non-lost ⇒ v's stored label IS the candidate; materialize its key
       // only here, on the enqueue path (#168)
-      const key = orderKey(v, dHat, ties);
+      const key = labelKey(v, labels);
       if (heap.has(v)) {
         heap.decreaseKey(v, key);
       } else {
@@ -109,12 +109,12 @@ function baseCase(B, S, dHat, adjacency, k, ties = makeTies()) {
   // vertices strictly below it — exactly k of them, keys being distinct
   let boundary = null;
   for (const v of settled) {
-    const key = orderKey(v, dHat, ties);
+    const key = labelKey(v, labels);
     if (boundary === null || compareKeys(key, boundary) > 0) boundary = key;
   }
   const vertices = new Set();
   for (const v of settled) {
-    if (compareKeys(orderKey(v, dHat, ties), boundary) < 0) vertices.add(v);
+    if (compareKeys(labelKey(v, labels), boundary) < 0) vertices.add(v);
   }
   return {
     bound: typeof B === "number" ? boundary[0] : boundary,

--- a/src/bmssp.mjs
+++ b/src/bmssp.mjs
@@ -6,8 +6,10 @@ import {
   compareKeyParts,
   toBound,
   makeTies,
-  orderKey,
+  makeLabels,
+  labelKey,
   relaxEdge,
+  NO_PRED,
   RELAX_LOST,
 } from "./tieBreak.mjs";
 
@@ -24,13 +26,14 @@ class BMSSP {
     // Map to store shortest paths
     this.shortestPaths = new Map();
     // Adjacency map: nodeId -> array of [to, weight] outgoing edges.
-    // Lets the algorithm fetch a node's edges in O(1) instead of scanning
-    // the whole edge list on every lookup.
+    // The public O(1) edge-lookup view (getEdges); since #205 the algorithm
+    // itself runs on the CSR arrays built by buildIndex below.
     this.adjacency = new Map();
     // Canonical tie-break labels (#163): hops = edge count of the canonical
-    // shortest path, preds = its predecessor pointer. Updated in lockstep
-    // with shortestPaths by relaxEdge; together they realize the paper's
-    // Assumption 2.1 (distinct path lengths) via [length, hops, id] keys.
+    // shortest path, preds = its predecessor pointer. Since #205 these Maps
+    // are the PUBLIC mirror of the engine's typed-array labels, refreshed
+    // whenever a run finishes; together with shortestPaths they realize the
+    // paper's Assumption 2.1 via [length, hops, id] keys.
     this.hops = new Map();
     this.preds = new Map();
     this.ties = makeTies(this.hops, this.preds);
@@ -61,6 +64,9 @@ class BMSSP {
     // Build the adjacency map from the copied edges
     this.buildAdjacency();
 
+    // Build the dense-index engine state: sorted-id index + CSR + labels
+    this.buildIndex();
+
     // Initialize shortest paths map
     this.initializeShortestPaths();
 
@@ -85,20 +91,69 @@ class BMSSP {
     }
   }
 
+  /**
+   * Build the dense-index engine state (#205): assign every node ID a dense
+   * index, lay the graph out in CSR form over those indices, and allocate
+   * the typed-array labels.
+   *
+   * Indices are assigned in ASCENDING NUMERIC ID ORDER. That makes index
+   * order equal id order, so the composite-key id tie-break (#163) picks the
+   * same canonical labels the id-keyed engine did — and, because the
+   * assignment depends only on the node-ID set, results stay invariant
+   * under edge-list permutation.
+   */
+  buildIndex() {
+    const sorted = [...this.nodeIDs].sort((a, b) => a - b);
+    const n = sorted.length;
+    const m = this.graph.length;
+    // ids: index -> original node id; indexOf: original node id -> index
+    this.ids = Float64Array.from(sorted);
+    this.indexOf = new Map();
+    for (let i = 0; i < n; i += 1) {
+      this.indexOf.set(sorted[i], i);
+    }
+    // CSR: offsets[u]..offsets[u+1] delimit u's outgoing edges in
+    // targets/weights (edge order within a node follows this.graph; the
+    // #163 canonical labels are iteration-order independent anyway)
+    const offsets = new Uint32Array(n + 1);
+    for (const [from] of this.graph) {
+      offsets[this.indexOf.get(from) + 1] += 1;
+    }
+    for (let i = 0; i < n; i += 1) {
+      offsets[i + 1] += offsets[i];
+    }
+    const targets = new Uint32Array(m);
+    const weights = new Float64Array(m);
+    const cursor = offsets.slice(0, n);
+    for (const [from, to, weight] of this.graph) {
+      const u = this.indexOf.get(from);
+      const e = cursor[u];
+      cursor[u] += 1;
+      targets[e] = this.indexOf.get(to);
+      weights[e] = weight;
+    }
+    this.csr = { offsets, targets, weights };
+    // Engine labels: d̂ / hops / canonical preds over dense indices
+    this.labels = makeLabels(n);
+  }
+
   // Return the outgoing edges of a node as an array of [to, weight].
   // Unknown nodes return an empty array.
   getEdges(nodeId) {
     return this.adjacency.get(nodeId) ?? [];
   }
 
-  // Method to initialize the shortest paths map (and the #163 tie-break
-  // labels that travel with it)
+  // Method to initialize the shortest paths map, its #163 tie-break mirror
+  // maps, and the #205 engine arrays behind them
   initializeShortestPaths() {
     for (let nodeId of this.nodeIDs) {
       this.shortestPaths.set(nodeId, Infinity);
     }
     this.hops.clear();
     this.preds.clear();
+    this.labels.dist.fill(Infinity);
+    this.labels.hops.fill(0);
+    this.labels.preds.fill(NO_PRED);
   }
 
   /**
@@ -118,25 +173,73 @@ class BMSSP {
     this.topLevel = Math.max(1, Math.ceil(logn / this.t));
   }
 
+  // Internal (#205): load the engine arrays from the public Maps. A direct
+  // multi-source caller seeds initial state by writing this.shortestPaths
+  // (the documented contract), so the wrapper snapshots those distances into
+  // the engine. Seeded sources are roots — hop 0, no predecessor — matching
+  // both the paper and the pre-#205 behavior (the hops/preds Maps are empty
+  // after initializeShortestPaths, so they contributed nothing there either).
+  syncLabelsIn() {
+    const { dist, hops, preds } = this.labels;
+    dist.fill(Infinity);
+    hops.fill(0);
+    preds.fill(NO_PRED);
+    for (const [id, d] of this.shortestPaths) {
+      if (Number.isFinite(d)) dist[this.indexOf.get(id)] = d;
+    }
+  }
+
+  // Internal (#205): mirror the engine arrays back into the public Maps
+  // (shortestPaths / hops / preds, keyed by original ids). Unreached
+  // vertices keep their Infinity entries; sources keep no preds entry
+  // (their stored pred is the NO_PRED sentinel), which reconstructPath
+  // relies on to terminate.
+  syncLabelsOut() {
+    const { dist, hops, preds } = this.labels;
+    const ids = this.ids;
+    for (let i = 0; i < ids.length; i += 1) {
+      if (dist[i] === Infinity) continue;
+      const id = ids[i];
+      this.shortestPaths.set(id, dist[i]);
+      this.hops.set(id, hops[i]);
+      if (preds[i] !== NO_PRED) this.preds.set(id, ids[preds[i]]);
+    }
+  }
+
+  // Internal (#205): translate a caller's bound into the engine's index
+  // space. Scalar bounds become the usual [B, -Inf, -Inf] infimum key; a
+  // composite bound's id component is mapped to its index (ids not in the
+  // graph — including the -Infinity sentinel — pass through unchanged).
+  boundToEngine(B) {
+    if (typeof B === "number") return toBound(B);
+    const idx = this.indexOf.get(B[2]);
+    return [B[0], B[1], idx === undefined ? B[2] : idx];
+  }
+
+  // Internal (#205): translate an engine key's index component back to the
+  // original node id (sentinel components pass through).
+  keyToPublic(key) {
+    const idx = key[2];
+    const isIndex = Number.isInteger(idx) && idx >= 0 && idx < this.ids.length;
+    return [key[0], key[1], isIndex ? this.ids[idx] : idx];
+  }
+
   /**
    * BMSSP(l, B, S) — Algorithm 3 of "Breaking the Sorting Barrier for
    * Directed Single-Source Shortest Paths": the main bounded multi-source
    * recursion, wiring FindPivots (Algorithm 1), the Lemma 3.3 BlockList and
    * BaseCase (Algorithm 2) together.
    *
+   * Public boundary (#205): S holds original node ids and the returned
+   * vertices/boundKey are in id space; initial multi-source state is seeded
+   * by writing this.shortestPaths (the pre-#205 contract). Internally the
+   * call runs on the dense-index engine — this wrapper snapshots the Maps
+   * into the typed arrays, runs bmsspIndex, and mirrors the arrays back.
+   *
    * Preconditions (the top-level call satisfies them trivially):
    * - Every vertex in S is complete (this.shortestPaths holds its true
    *   distance), and every incomplete vertex v with d(v) < B has a shortest
    *   path through some complete vertex of S.
-   *
-   * Distance estimates live in this.shortestPaths (the paper's d̂[·]) and
-   * are relaxed in place at every level, together with the canonical hops
-   * and preds labels (#163). All internal ordering uses the composite
-   * [length, hops, id] keys of src/tieBreak.mjs, which realize the paper's
-   * Assumption 2.1: pull separators are strict, no key ever ties a bound,
-   * and the pre-#163 degenerate-tie guards (out-of-scope pivots,
-   * boundary-tied batch members, the empty-child stall escape hatch) are
-   * unnecessary by construction.
    *
    * Two outcomes (Lemma 3.1, strict under the composite order):
    * - Successful execution: the block list emptied — boundKey === B's key
@@ -150,45 +253,56 @@ class BMSSP {
    * @param {number} l - Recursion level; 0 delegates to baseCase
    * @param {number|[number, number, *]} B - Strict upper bound on the keys
    *   in scope: a number (Infinity is allowed) or a composite bound
-   * @param {Set<*>} S - Non-empty set of complete frontier sources
+   * @param {Set<*>} S - Non-empty set of complete frontier sources (ids)
    * @returns {{ bound: number|[number, number, *], boundKey: [number, number, *], vertices: Set<*> }}
    *   The boundary B' <= B (same kind as the B passed in: scalar callers
    *   get a scalar), its composite key, and the set U of vertices
-   *   completed below it
+   *   completed below it — all in original-id space
    */
   bmssp(l, B, S) {
-    const dHat = this.shortestPaths;
-    const ties = this.ties;
-    const boundKey = toBound(B);
-    const scalarB = typeof B === "number";
+    this.syncLabelsIn();
+    const boundKey = this.boundToEngine(B);
+    const SIdx = new Set();
+    for (const id of S) {
+      const idx = this.indexOf.get(id);
+      // Unknown sources keep their raw id: the engine then reads an
+      // undefined label and fails the finite-distance precondition, the
+      // same error the id-keyed engine raised
+      SIdx.add(idx === undefined ? id : idx);
+    }
+    const result = this.bmsspIndex(l, boundKey, SIdx);
+    this.syncLabelsOut();
+    const vertices = new Set();
+    for (const idx of result.vertices) {
+      vertices.add(this.ids[idx]);
+    }
+    const finalKey = this.keyToPublic(result.boundKey);
     // Project the composite result back to the caller's kind: a successful
     // execution echoes B itself, a partial one reports the separator (whose
     // length is strictly below a scalar B by construction)
-    const finish = (finalKey, vertices) => ({
-      bound: scalarB
-        ? compareKeys(finalKey, boundKey) === 0
+    const bound =
+      typeof B === "number"
+        ? compareKeys(result.boundKey, boundKey) === 0
           ? B
           : finalKey[0]
-        : finalKey,
-      boundKey: finalKey,
-      vertices,
-    });
+        : finalKey;
+    return { bound, boundKey: finalKey, vertices };
+  }
+
+  // Internal (#205): the actual Algorithm 3 recursion, entirely in dense
+  // index space — S/vertices hold indices, keys are [length, hops, index],
+  // the graph is CSR and the labels are the shared typed arrays.
+  bmsspIndex(l, boundKey, S) {
+    const labels = this.labels;
 
     if (l === 0) {
-      const result = baseCase(boundKey, S, dHat, this.adjacency, this.k, ties);
-      return finish(result.boundKey, result.vertices);
+      const result = baseCase(boundKey, S, labels, this.csr, this.k);
+      return { boundKey: result.boundKey, vertices: result.vertices };
     }
 
     // Shrink the frontier: only the pivots are worth recursing on, and W
     // is a batch of already-completed vertices folded in at the end
-    const { pivots, W } = findPivots(
-      boundKey,
-      S,
-      dHat,
-      this.adjacency,
-      this.k,
-      ties,
-    );
+    const { pivots, W } = findPivots(boundKey, S, labels, this.csr, this.k);
 
     // Seed the Lemma 3.3 block list with the pivots. lastBoundKey tracks
     // the paper's Bi': B when P is empty, min key over P before the first
@@ -199,7 +313,7 @@ class BMSSP {
     const D = new BlockList(2 ** ((l - 1) * this.t), boundKey, compareKeys);
     let lastBoundKey = boundKey;
     for (const x of pivots) {
-      const key = orderKey(x, dHat, ties);
+      const key = labelKey(x, labels);
       if (compareKeys(key, boundKey) < 0) {
         D.insert(x, key);
         if (compareKeys(key, lastBoundKey) < 0) lastBoundKey = key;
@@ -208,11 +322,12 @@ class BMSSP {
 
     const U = new Set();
     const workloadCap = this.k * 2 ** (l * this.t);
+    const { offsets, targets, weights } = this.csr;
 
     while (U.size < workloadCap && !D.isEmpty()) {
       // Bi, Si <- D.Pull(): the next-closest small batch and its separator
       const { keys: Si, bound: BiKey } = D.pull();
-      const child = this.bmssp(l - 1, BiKey, Si);
+      const child = this.bmsspIndex(l - 1, BiKey, Si);
       const BiPrimeKey = child.boundKey;
       const Ui = child.vertices;
 
@@ -231,15 +346,12 @@ class BMSSP {
       // and a key array is built only for the enqueue itself (#168).
       const K = [];
       for (const u of Ui) {
-        const edges = this.adjacency.get(u);
-        if (edges === undefined) continue;
-        for (let i = 0; i < edges.length; i += 1) {
-          const edge = edges[i];
-          const v = edge[0];
-          const result = relaxEdge(u, v, edge[1], dHat, ties);
+        for (let e = offsets[u]; e < offsets[u + 1]; e += 1) {
+          const v = targets[e];
+          const result = relaxEdge(u, v, weights[e], labels);
           if (result === RELAX_LOST || U.has(v)) continue;
-          const length = dHat.get(v);
-          const hopCount = ties.hops.get(v) ?? 0;
+          const length = labels.dist[v];
+          const hopCount = labels.hops[v];
           if (compareKeyParts(length, hopCount, v, BiKey) >= 0) {
             if (compareKeyParts(length, hopCount, v, boundKey) < 0) {
               D.insert(v, [length, hopCount, v]);
@@ -253,8 +365,8 @@ class BMSSP {
       // go back in front of everything else
       for (const x of Si) {
         if (U.has(x)) continue;
-        const length = dHat.get(x) ?? Infinity;
-        const hopCount = ties.hops.get(x) ?? 0;
+        const length = labels.dist[x];
+        const hopCount = labels.hops[x];
         if (
           compareKeyParts(length, hopCount, x, BiKey) < 0 &&
           compareKeyParts(length, hopCount, x, BiPrimeKey) >= 0
@@ -269,12 +381,11 @@ class BMSSP {
     const finalKey =
       compareKeys(lastBoundKey, boundKey) < 0 ? lastBoundKey : boundKey;
     for (const x of W) {
-      const length = dHat.get(x) ?? Infinity;
-      if (compareKeyParts(length, ties.hops.get(x) ?? 0, x, finalKey) < 0) {
+      if (compareKeyParts(labels.dist[x], labels.hops[x], x, finalKey) < 0) {
         U.add(x);
       }
     }
-    return finish(finalKey, U);
+    return { boundKey: finalKey, vertices: U };
   }
 
   // Method to calculate shortest paths from startNode via the BMSSP
@@ -282,7 +393,8 @@ class BMSSP {
   // is always a successful execution, so it completes every reachable
   // vertex; unreachable ones keep their Infinity estimate. Distances, hop
   // counts and predecessor pointers all end at their canonical values —
-  // independent of edge or iteration order (#163).
+  // independent of edge or iteration order (#163) — and are mirrored into
+  // the public Maps when the run finishes (#205).
   calculateShortestPaths(startNode) {
     // To clean the state before calculation
     this.initializeShortestPaths();
@@ -294,9 +406,10 @@ class BMSSP {
 
     // The source is complete at distance 0 with zero hops and no
     // predecessor; everything else is Infinity
-    this.shortestPaths.set(startNode, 0);
-    this.hops.set(startNode, 0);
-    this.bmssp(this.topLevel, Infinity, new Set([startNode]));
+    const s = this.indexOf.get(startNode);
+    this.labels.dist[s] = 0;
+    this.bmsspIndex(this.topLevel, toBound(Infinity), new Set([s]));
+    this.syncLabelsOut();
   }
 
   /**

--- a/src/findPivots.mjs
+++ b/src/findPivots.mjs
@@ -1,7 +1,6 @@
 import {
   compareKeyParts,
   toBound,
-  makeTies,
   relaxEdge,
   RELAX_LOST,
 } from "./tieBreak.mjs";
@@ -15,17 +14,19 @@ import {
  * the pivots need to be carried into the deeper BMSSP recursion.
  *
  * Preconditions (guaranteed by the caller, Algorithm 3):
- * - Every vertex in S is complete (dHat holds its true distance).
+ * - Every vertex in S is complete (labels.dist holds its true distance).
  * - Every incomplete vertex v with d(v) < B has a shortest path through some
  *   complete vertex in S.
  *
- * Distance estimates are read from and written into dHat in place — exactly
- * like the paper's global d̂[·] labels, so improvements made here are visible
- * to the levels above. Relaxation is canonical (#163, src/tieBreak.mjs):
- * d̂, hops and preds move together under the composite [length, hops, id]
- * order, and an exact-equality result re-admits a vertex to W through its
- * one canonical label-setter (the paper's `≤` made deterministic). The `< B`
- * test only gates membership in W; d̂ updates are not gated.
+ * Since #205 the engine works on dense vertex indices: S holds indices, the
+ * graph is the class's CSR bundle, and the labels are the shared typed
+ * arrays (see tieBreak's makeLabels) — updated in place, exactly like the
+ * paper's global d̂[·], so improvements made here are visible to the levels
+ * above. Relaxation is canonical (#163): dist, hops and preds move together
+ * under the composite [length, hops, index] order, and an exact-equality
+ * result re-admits a vertex to W through its one canonical label-setter (the
+ * paper's `≤` made deterministic). The `< B` test only gates membership in
+ * W; label updates are not gated.
  *
  * The paper's tight-edge forest falls out of the canonical labels: each
  * vertex of W \ S hangs off its recorded canonical predecessor, which is
@@ -44,19 +45,20 @@ import {
  *
  * @param {number|[number, number, *]} B - Strict upper bound gating membership
  *   in W: a number (Infinity is allowed) or a composite bound
- * @param {Set<*>|Iterable<*>} S - Non-empty set of complete frontier sources
- * @param {Map<*, number>} dHat - Global distance estimates d̂[·], updated in place
- * @param {Map<*, Array<[*, number]>>} adjacency - nodeId -> outgoing [to, weight] edges
+ * @param {Set<number>|Iterable<number>} S - Non-empty set of complete frontier
+ *   source indices
+ * @param {{ dist: Float64Array, hops: Uint32Array, preds: Int32Array }} labels
+ *   - Engine label state (d̂[·] and tie-break labels), updated in place
+ * @param {{ offsets: Uint32Array, targets: Uint32Array, weights: Float64Array }} csr
+ *   - The graph in CSR layout over dense indices
  * @param {number} k - Relaxation rounds / tree-size threshold, >= 1 (floored);
  *   the paper's ⌊log^(1/3) n⌋
- * @param {{ hops: Map<*, number>, preds: Map<*, *> }} [ties] - Canonical
- *   tie-break labels updated alongside dHat; fresh throwaway maps by default
- * @returns {{ pivots: Set<*>, W: Set<*> }} The pivot subset of S and the set W
- *   of vertices touched below B (W always contains S)
+ * @returns {{ pivots: Set<number>, W: Set<number> }} The pivot subset of S and
+ *   the set W of vertex indices touched below B (W always contains S)
  * @throws {Error} If k is not a number >= 1, S is empty, or any source has no
  *   finite distance estimate
  */
-function findPivots(B, S, dHat, adjacency, k, ties = makeTies()) {
+function findPivots(B, S, labels, csr, k) {
   if (typeof k !== "number" || Number.isNaN(k) || k < 1) {
     throw new Error("k must be a number >= 1");
   }
@@ -66,12 +68,12 @@ function findPivots(B, S, dHat, adjacency, k, ties = makeTies()) {
     throw new Error("S must contain at least one source node");
   }
   for (const x of sources) {
-    const distance = dHat.get(x);
-    if (typeof distance !== "number" || !Number.isFinite(distance)) {
+    if (!Number.isFinite(labels.dist[x])) {
       throw new Error("every source must have a finite distance estimate");
     }
   }
   const boundKey = toBound(B);
+  const { offsets, targets, weights } = csr;
 
   // W accumulates everything relaxed below B; layer is the paper's W_{i-1}
   const sourceSet = new Set(sources);
@@ -81,20 +83,17 @@ function findPivots(B, S, dHat, adjacency, k, ties = makeTies()) {
   for (let i = 1; i <= rounds; i += 1) {
     const nextLayer = new Set();
     for (const u of layer) {
-      const edges = adjacency.get(u);
-      if (edges === undefined) continue;
-      for (let j = 0; j < edges.length; j += 1) {
-        const edge = edges[j];
-        const v = edge[0];
-        // Canonical relaxation: d̂ updates are not gated by B (paper), and
-        // both improvements and exact canonical equality admit v to the
+      for (let e = offsets[u]; e < offsets[u + 1]; e += 1) {
+        const v = targets[e];
+        // Canonical relaxation: label updates are not gated by B (paper),
+        // and both improvements and exact canonical equality admit v to the
         // next layer when its key is below B. Non-lost ⇒ v's stored label
         // is the candidate, so the W gate compares the unpacked stored
         // components — no key allocation (#168).
-        const result = relaxEdge(u, v, edge[1], dHat, ties);
+        const result = relaxEdge(u, v, weights[e], labels);
         if (
           result !== RELAX_LOST &&
-          compareKeyParts(dHat.get(v), ties.hops.get(v) ?? 0, v, boundKey) < 0
+          compareKeyParts(labels.dist[v], labels.hops[v], v, boundKey) < 0
         ) {
           nextLayer.add(v);
         }
@@ -114,7 +113,7 @@ function findPivots(B, S, dHat, adjacency, k, ties = makeTies()) {
   const children = new Map();
   for (const v of W) {
     if (sourceSet.has(v)) continue;
-    const parent = ties.preds.get(v);
+    const parent = labels.preds[v];
     if (!children.has(parent)) children.set(parent, []);
     children.get(parent).push(v);
   }

--- a/src/tieBreak.mjs
+++ b/src/tieBreak.mjs
@@ -38,9 +38,11 @@
  * source is a hop-0 root) and "no predecessor" (which never loses a tie).
  */
 
-// Sentinel predecessor for sources: compares below every real id, so a
-// source's own label never loses an equal-(length, hops) comparison.
-const NO_PRED = -Infinity;
+// Sentinel predecessor for sources: compares below every real vertex index,
+// so a source's own label never loses an equal-(length, hops) comparison.
+// Since #205 the engine works on dense vertex indices (>= 0), so -1 is a
+// valid sentinel AND fits the Int32Array holding the predecessors.
+const NO_PRED = -1;
 
 // Running count of compareKeys calls — the paper's cost metric ("comparisons
 // between path lengths"). Every BMSSP-side comparison funnels through
@@ -110,13 +112,40 @@ function toBound(B) {
 }
 
 /**
- * Bundle (or create) the tie-break label maps that accompany d̂.
+ * Bundle (or create) the tie-break label maps that accompany d̂ at the PUBLIC
+ * boundary (the BMSSP class mirrors the engine's arrays into these Maps,
+ * keyed by original node ids).
  * @param {Map<*, number>} [hops] - Canonical path edge counts
  * @param {Map<*, *>} [preds] - Canonical predecessor of each vertex
  * @returns {{ hops: Map<*, number>, preds: Map<*, *> }}
  */
 function makeTies(hops = new Map(), preds = new Map()) {
   return { hops, preds };
+}
+
+/**
+ * Allocate the engine's label state for n vertices (#205): d̂, hops and
+ * canonical predecessors as typed arrays over dense vertex indices.
+ * Unlabeled vertices read as distance Infinity, hop 0, no predecessor —
+ * the same defaults the pre-#205 Maps gave via `?? Infinity` / `?? 0`.
+ * @param {number} n - Vertex count
+ * @returns {{ dist: Float64Array, hops: Uint32Array, preds: Int32Array }}
+ */
+function makeLabels(n) {
+  const dist = new Float64Array(n).fill(Infinity);
+  const hops = new Uint32Array(n);
+  const preds = new Int32Array(n).fill(NO_PRED);
+  return { dist, hops, preds };
+}
+
+/**
+ * The frontier-ordering key of vertex index v under the engine labels.
+ * @param {number} v - Dense vertex index
+ * @param {{ dist: Float64Array, hops: Uint32Array }} labels
+ * @returns {[number, number, number]} [dist[v], hops[v], v]
+ */
+function labelKey(v, labels) {
+  return [labels.dist[v], labels.hops[v], v];
 }
 
 /**
@@ -155,11 +184,16 @@ function orderKey(v, dHat, ties) {
  * with orderKey(v, dHat, ties) — only on the rare paths that enqueue v,
  * instead of on every attempt.
  *
- * @param {*} u - Edge tail (its labels are read)
- * @param {*} v - Edge head (its labels may be updated)
+ * Since #205 the labels live in typed arrays over dense vertex indices
+ * (see makeLabels); u and v are indices, and index order equals original-id
+ * order (the BMSSP class assigns indices by sorted id), so the canonical
+ * choices are identical to the pre-#205 Map engine's.
+ *
+ * @param {number} u - Edge tail index (its labels are read)
+ * @param {number} v - Edge head index (its labels may be updated)
  * @param {number} weight - Edge weight, >= 0
- * @param {Map<*, number>} dHat - Distance estimates d̂[·], updated in place
- * @param {{ hops: Map<*, number>, preds: Map<*, *> }} ties - Updated in place
+ * @param {{ dist: Float64Array, hops: Uint32Array, preds: Int32Array }} labels
+ *   - Engine label state, updated in place
  * @param {[number, number, *]} [bound] - Optional gate: skip (no d̂ update)
  *   unless the resulting order key would be strictly below this bound
  * @returns {number} RELAX_IMPROVED when the labels were updated,
@@ -167,34 +201,34 @@ function orderKey(v, dHat, ties) {
  *   (the re-enqueue signal), RELAX_LOST when the candidate loses or the
  *   bound gates it (labels untouched)
  */
-function relaxEdge(u, v, weight, dHat, ties, bound) {
-  const length = dHat.get(u) + weight;
-  const hopCount = (ties.hops.get(u) ?? 0) + 1;
+function relaxEdge(u, v, weight, labels, bound) {
+  const length = labels.dist[u] + weight;
+  const hopCount = labels.hops[u] + 1;
   if (bound !== undefined && compareKeyParts(length, hopCount, v, bound) >= 0) {
     return RELAX_LOST;
   }
   // Candidate path key [length, hopCount, u] vs. v's current path key
-  // [d̂[v], hops[v], preds[v] ?? NO_PRED] — compareKeys inlined on the
-  // unpacked components (one counted comparison, no arrays)
+  // [dist[v], hops[v], preds[v]] — compareKeys inlined on the unpacked
+  // components (one counted comparison, no arrays)
   comparisonCount += 1;
   let cmp;
-  const currentLength = dHat.get(v) ?? Infinity;
+  const currentLength = labels.dist[v];
   if (length !== currentLength) {
     cmp = length < currentLength ? -1 : 1;
   } else {
-    const currentHops = ties.hops.get(v) ?? 0;
+    const currentHops = labels.hops[v];
     if (hopCount !== currentHops) {
       cmp = hopCount < currentHops ? -1 : 1;
     } else {
-      const currentPred = ties.preds.has(v) ? ties.preds.get(v) : NO_PRED;
+      const currentPred = labels.preds[v];
       cmp = u !== currentPred ? (u < currentPred ? -1 : 1) : 0;
     }
   }
   if (cmp > 0) return RELAX_LOST;
   if (cmp === 0) return RELAX_EQUAL;
-  dHat.set(v, length);
-  ties.hops.set(v, hopCount);
-  ties.preds.set(v, u);
+  labels.dist[v] = length;
+  labels.hops[v] = hopCount;
+  labels.preds[v] = u;
   return RELAX_IMPROVED;
 }
 
@@ -209,7 +243,9 @@ export {
   compareKeyParts,
   toBound,
   makeTies,
+  makeLabels,
   orderKey,
+  labelKey,
   relaxEdge,
   NO_PRED,
   RELAX_LOST,

--- a/test/baseCase.test.mjs
+++ b/test/baseCase.test.mjs
@@ -2,7 +2,7 @@ import { describe, test, expect } from "@jest/globals";
 import { baseCase } from "../src/baseCase.mjs";
 import { BMSSP } from "../src/bmssp.mjs";
 import { dijkstra } from "../src/dijkstra.mjs";
-import { compareKeys, makeTies, orderKey } from "../src/tieBreak.mjs";
+import { compareKeys, labelKey } from "../src/tieBreak.mjs";
 
 // Small deterministic PRNG so stress-test failures are reproducible
 function mulberry32(seed) {
@@ -15,13 +15,20 @@ function mulberry32(seed) {
   };
 }
 
-// Build the shared state BaseCase runs against: the class's adjacency map
-// and d̂ labels, with the source marked complete at distance 0
+// Build the engine state BaseCase runs against (#205): a BMSSP instance
+// provides the CSR + typed-array labels; the source is marked complete at
+// distance 0 directly in the engine arrays
 function setup(edges, source) {
-  const bmssp = new BMSSP(edges);
-  bmssp.shortestPaths.set(source, 0);
-  return bmssp;
+  const g = new BMSSP(edges);
+  g.labels.dist[g.indexOf.get(source)] = 0;
+  return g;
 }
+
+// id <-> index helpers: baseCase speaks dense indices since #205
+const idx = (g, v) => g.indexOf.get(v);
+const idxSet = (g, vs) => new Set(vs.map((v) => g.indexOf.get(v)));
+const idsOf = (g, indices) => new Set([...indices].map((i) => g.ids[i]));
+const distOf = (g, v) => g.labels.dist[g.indexOf.get(v)];
 
 // Seeded random directed graph with an edge out of node 0 guaranteed
 function randomEdges(rand, n, m) {
@@ -37,30 +44,30 @@ function randomEdges(rand, n, m) {
 
 describe("baseCase validation", () => {
   test("rejects k that is not a number >= 1", () => {
-    const { shortestPaths, adjacency } = setup([[0, 1, 1]], 0);
+    const g = setup([[0, 1, 1]], 0);
     expect(() =>
-      baseCase(Infinity, new Set([0]), shortestPaths, adjacency, 0),
+      baseCase(Infinity, idxSet(g, [0]), g.labels, g.csr, 0),
     ).toThrow("k must be a number >= 1");
     expect(() =>
-      baseCase(Infinity, new Set([0]), shortestPaths, adjacency, NaN),
+      baseCase(Infinity, idxSet(g, [0]), g.labels, g.csr, NaN),
     ).toThrow("k must be a number >= 1");
   });
 
   test("rejects an S that is not a singleton", () => {
-    const { shortestPaths, adjacency } = setup([[0, 1, 1]], 0);
+    const g = setup([[0, 1, 1]], 0);
+    expect(() => baseCase(Infinity, new Set(), g.labels, g.csr, 2)).toThrow(
+      "S must contain exactly one source node",
+    );
     expect(() =>
-      baseCase(Infinity, new Set(), shortestPaths, adjacency, 2),
-    ).toThrow("S must contain exactly one source node");
-    expect(() =>
-      baseCase(Infinity, new Set([0, 1]), shortestPaths, adjacency, 2),
+      baseCase(Infinity, idxSet(g, [0, 1]), g.labels, g.csr, 2),
     ).toThrow("S must contain exactly one source node");
   });
 
   test("rejects a source without a finite distance estimate", () => {
     // No setup(): every d̂ stays Infinity, so the source is not complete
-    const bmssp = new BMSSP([[0, 1, 1]]);
+    const g = new BMSSP([[0, 1, 1]]);
     expect(() =>
-      baseCase(Infinity, new Set([0]), bmssp.shortestPaths, bmssp.adjacency, 2),
+      baseCase(Infinity, idxSet(g, [0]), g.labels, g.csr, 2),
     ).toThrow("the source must have a finite distance estimate");
   });
 });
@@ -75,44 +82,32 @@ describe("baseCase full success (fewer than k + 1 vertices under B)", () => {
   ];
 
   test("with B = Infinity settles every reachable vertex exactly", () => {
-    const { shortestPaths, adjacency } = setup(edges, 0);
-    const result = baseCase(
-      Infinity,
-      new Set([0]),
-      shortestPaths,
-      adjacency,
-      10,
-    );
+    const g = setup(edges, 0);
+    const result = baseCase(Infinity, idxSet(g, [0]), g.labels, g.csr, 10);
     expect(result.bound).toBe(Infinity);
-    expect(result.vertices).toEqual(new Set([0, 1, 2, 3]));
-    expect(shortestPaths.get(0)).toBe(0);
-    expect(shortestPaths.get(1)).toBe(2);
-    expect(shortestPaths.get(2)).toBe(3);
-    expect(shortestPaths.get(3)).toBe(4);
+    expect(idsOf(g, result.vertices)).toEqual(new Set([0, 1, 2, 3]));
+    expect(distOf(g, 0)).toBe(0);
+    expect(distOf(g, 1)).toBe(2);
+    expect(distOf(g, 2)).toBe(3);
+    expect(distOf(g, 3)).toBe(4);
     // Node 4 is not reachable from 0 and must stay untouched
-    expect(shortestPaths.get(4)).toBe(Infinity);
+    expect(distOf(g, 4)).toBe(Infinity);
   });
 
   test("a finite B keeps distances >= B out of the result and out of d̂", () => {
-    const { shortestPaths, adjacency } = setup(edges, 0);
-    const result = baseCase(4, new Set([0]), shortestPaths, adjacency, 10);
+    const g = setup(edges, 0);
+    const result = baseCase(4, idxSet(g, [0]), g.labels, g.csr, 10);
     // d(3) = 4 is not < B, so 3 is neither settled nor even relaxed
     expect(result.bound).toBe(4);
-    expect(result.vertices).toEqual(new Set([0, 1, 2]));
-    expect(shortestPaths.get(3)).toBe(Infinity);
+    expect(idsOf(g, result.vertices)).toEqual(new Set([0, 1, 2]));
+    expect(distOf(g, 3)).toBe(Infinity);
   });
 
   test("a source with no outgoing edges succeeds with just itself", () => {
-    const { shortestPaths, adjacency } = setup(edges, 3);
-    const result = baseCase(
-      Infinity,
-      new Set([3]),
-      shortestPaths,
-      adjacency,
-      5,
-    );
+    const g = setup(edges, 3);
+    const result = baseCase(Infinity, idxSet(g, [3]), g.labels, g.csr, 5);
     expect(result.bound).toBe(Infinity);
-    expect(result.vertices).toEqual(new Set([3]));
+    expect(idsOf(g, result.vertices)).toEqual(new Set([3]));
   });
 });
 
@@ -124,20 +119,14 @@ describe("baseCase partial (the k + 1 cap is hit)", () => {
       [2, 3, 1],
       [3, 4, 1],
     ];
-    const { shortestPaths, adjacency } = setup(edges, 0);
-    const result = baseCase(
-      Infinity,
-      new Set([0]),
-      shortestPaths,
-      adjacency,
-      2,
-    );
+    const g = setup(edges, 0);
+    const result = baseCase(Infinity, idxSet(g, [0]), g.labels, g.csr, 2);
     // Settled = {0, 1, 2} (k + 1 = 3 vertices), so B' = d̂(2) = 2
     expect(result.bound).toBe(2);
-    expect(result.vertices).toEqual(new Set([0, 1]));
-    expect(shortestPaths.get(0)).toBe(0);
-    expect(shortestPaths.get(1)).toBe(1);
-    expect(shortestPaths.get(2)).toBe(2);
+    expect(idsOf(g, result.vertices)).toEqual(new Set([0, 1]));
+    expect(distOf(g, 0)).toBe(0);
+    expect(distOf(g, 1)).toBe(1);
+    expect(distOf(g, 2)).toBe(2);
   });
 
   test("boundary ties are broken deterministically by the composite order (#163)", () => {
@@ -146,21 +135,17 @@ describe("baseCase partial (the k + 1 cap is hit)", () => {
       [0, 2, 5],
       [0, 3, 5],
     ];
-    const { shortestPaths, adjacency } = setup(edges, 0);
-    const result = baseCase(
-      Infinity,
-      new Set([0]),
-      shortestPaths,
-      adjacency,
-      2,
-    );
+    // Node ids 0..3 are contiguous, so dense indices coincide with ids and
+    // the boundary key below is in both spaces at once
+    const g = setup(edges, 0);
+    const result = baseCase(Infinity, idxSet(g, [0]), g.labels, g.csr, 2);
     // Settled = {0} plus the two smallest-keyed distance-5 leaves (1, 2);
     // the boundary is leaf 2's key [5, 1, 2] and the strictly-closer filter
     // keeps leaf 1 — under scalar ties, smaller ids settle first. (Before
     // #163 every tied leaf was excluded and only the source came back.)
     expect(result.bound).toBe(5);
     expect(result.boundKey).toEqual([5, 1, 2]);
-    expect(result.vertices).toEqual(new Set([0, 1]));
+    expect(idsOf(g, result.vertices)).toEqual(new Set([0, 1]));
   });
 
   test("the k + 1 cap still respects the bound B", () => {
@@ -169,12 +154,12 @@ describe("baseCase partial (the k + 1 cap is hit)", () => {
       [1, 2, 1],
       [2, 3, 1],
     ];
-    const { shortestPaths, adjacency } = setup(edges, 0);
-    const result = baseCase(2, new Set([0]), shortestPaths, adjacency, 1);
+    const g = setup(edges, 0);
+    const result = baseCase(2, idxSet(g, [0]), g.labels, g.csr, 1);
     // k + 1 = 2 settled: {0, 1}; B' = d̂(1) = 1 < B = 2
     expect(result.bound).toBe(1);
-    expect(result.vertices).toEqual(new Set([0]));
-    expect(shortestPaths.get(3)).toBe(Infinity);
+    expect(idsOf(g, result.vertices)).toEqual(new Set([0]));
+    expect(distOf(g, 3)).toBe(Infinity);
   });
 });
 
@@ -185,18 +170,12 @@ describe("baseCase equal-sum relaxations", () => {
       [1, 0, 0],
       [1, 2, 1],
     ];
-    const { shortestPaths, adjacency } = setup(edges, 0);
-    const result = baseCase(
-      Infinity,
-      new Set([0]),
-      shortestPaths,
-      adjacency,
-      10,
-    );
+    const g = setup(edges, 0);
+    const result = baseCase(Infinity, idxSet(g, [0]), g.labels, g.csr, 10);
     expect(result.bound).toBe(Infinity);
-    expect(result.vertices).toEqual(new Set([0, 1, 2]));
-    expect(shortestPaths.get(1)).toBe(0);
-    expect(shortestPaths.get(2)).toBe(1);
+    expect(idsOf(g, result.vertices)).toEqual(new Set([0, 1, 2]));
+    expect(distOf(g, 1)).toBe(0);
+    expect(distOf(g, 2)).toBe(1);
   });
 
   test("two equal-length paths to the same vertex settle it once", () => {
@@ -206,16 +185,10 @@ describe("baseCase equal-sum relaxations", () => {
       [1, 3, 1],
       [2, 3, 1],
     ];
-    const { shortestPaths, adjacency } = setup(edges, 0);
-    const result = baseCase(
-      Infinity,
-      new Set([0]),
-      shortestPaths,
-      adjacency,
-      10,
-    );
-    expect(result.vertices).toEqual(new Set([0, 1, 2, 3]));
-    expect(shortestPaths.get(3)).toBe(2);
+    const g = setup(edges, 0);
+    const result = baseCase(Infinity, idxSet(g, [0]), g.labels, g.csr, 10);
+    expect(idsOf(g, result.vertices)).toEqual(new Set([0, 1, 2, 3]));
+    expect(distOf(g, 3)).toBe(2);
   });
 });
 
@@ -224,22 +197,22 @@ describe("baseCase vs Dijkstra oracle (seeded)", () => {
     const rand = mulberry32(40);
     for (let round = 0; round < 20; round += 1) {
       const edges = randomEdges(rand, 40, 160);
-      const bmssp = setup(edges, 0);
-      const oracle = dijkstra(bmssp.graph, bmssp.nodeIDs, 0);
+      const g = setup(edges, 0);
+      const oracle = dijkstra(g.graph, g.nodeIDs, 0);
       const result = baseCase(
         Infinity,
-        new Set([0]),
-        bmssp.shortestPaths,
-        bmssp.adjacency,
-        bmssp.nodeIDs.size,
+        idxSet(g, [0]),
+        g.labels,
+        g.csr,
+        g.nodeIDs.size,
       );
       expect(result.bound).toBe(Infinity);
       const reachable = new Set(
         [...oracle].filter(([, d]) => d < Infinity).map(([v]) => v),
       );
-      expect(result.vertices).toEqual(reachable);
-      for (const v of result.vertices) {
-        expect(bmssp.shortestPaths.get(v)).toBe(oracle.get(v));
+      expect(idsOf(g, result.vertices)).toEqual(reachable);
+      for (const v of idsOf(g, result.vertices)) {
+        expect(distOf(g, v)).toBe(oracle.get(v));
       }
     }
   });
@@ -248,44 +221,37 @@ describe("baseCase vs Dijkstra oracle (seeded)", () => {
     const rand = mulberry32(41);
     for (let round = 0; round < 30; round += 1) {
       const edges = randomEdges(rand, 50, 200);
-      const bmssp = setup(edges, 0);
-      const oracle = dijkstra(bmssp.graph, bmssp.nodeIDs, 0);
+      const g = setup(edges, 0);
+      const oracle = dijkstra(g.graph, g.nodeIDs, 0);
       const finite = [...oracle.values()]
         .filter((d) => d < Infinity)
         .sort((a, b) => a - b);
       // A bound somewhere inside the distance distribution, and a small cap
       const B = finite[Math.floor(finite.length * 0.6)] + 0.5;
       const k = 1 + Math.floor(rand() * 8);
-      const ties = makeTies();
-      const result = baseCase(
-        B,
-        new Set([0]),
-        bmssp.shortestPaths,
-        bmssp.adjacency,
-        k,
-        ties,
-      );
+      const result = baseCase(B, idxSet(g, [0]), g.labels, g.csr, k);
       // B' never exceeds B, and B' = B means full success under the bound
       expect(result.bound).toBeLessThanOrEqual(B);
       // Every returned vertex is complete (d̂ = true distance) and strictly
       // below B' in the composite order (#163) — in the scalar view a
       // returned vertex may tie the boundary's length, never exceed it
-      for (const v of result.vertices) {
-        expect(bmssp.shortestPaths.get(v)).toBe(oracle.get(v));
+      for (const i of result.vertices) {
+        const v = g.ids[i];
+        expect(distOf(g, v)).toBe(oracle.get(v));
         expect(oracle.get(v)).toBeLessThanOrEqual(result.bound);
         expect(
-          compareKeys(orderKey(v, bmssp.shortestPaths, ties), result.boundKey),
+          compareKeys(labelKey(i, g.labels), result.boundKey),
         ).toBeLessThan(0);
       }
       // Completeness: everything with a true distance below B' is returned
       for (const [v, d] of oracle) {
         if (d < result.bound) {
-          expect(result.vertices.has(v)).toBe(true);
+          expect(result.vertices.has(idx(g, v))).toBe(true);
         }
       }
       // d̂ never underestimates the true distance anywhere
-      for (const [v, d] of bmssp.shortestPaths) {
-        expect(d).toBeGreaterThanOrEqual(oracle.get(v));
+      for (const v of g.nodeIDs) {
+        expect(distOf(g, v)).toBeGreaterThanOrEqual(oracle.get(v));
       }
     }
   });

--- a/test/bmssp.test.mjs
+++ b/test/bmssp.test.mjs
@@ -216,6 +216,84 @@ describe("BMSSP recursion contract (Lemma 3.1)", () => {
     }
   });
 
+  test("accepts a composite bound and translates ids across the index boundary (#205)", () => {
+    // Non-contiguous ids so dense index != id: the public wrapper must map
+    // the bound's id component to its index on the way in and the returned
+    // boundKey's index back to an id on the way out.
+    const edges = [
+      [10, 20, 3],
+      [20, 30, 4],
+      [30, 40, 5],
+      [10, 40, 100],
+    ];
+    const bmssp = new BMSSP(edges);
+    // Canonical key of vertex 30: distance 7 (10->20->30), 2 hops
+    bmssp.calculateShortestPaths(10);
+    expect(bmssp.shortestPaths.get(30)).toBe(7);
+    expect(bmssp.hops.get(30)).toBe(2);
+
+    // A composite bound exactly at vertex 30's key is strict, so 30 and
+    // everything farther (40 at distance 12) are excluded
+    bmssp.initializeShortestPaths();
+    bmssp.shortestPaths.set(10, 0);
+    const { bound, boundKey, vertices } = bmssp.bmssp(
+      bmssp.topLevel,
+      [7, 2, 30],
+      new Set([10]),
+    );
+    expect(vertices).toEqual(new Set([10, 20]));
+    // Successful execution echoes the bound back, in id space
+    expect(boundKey).toEqual([7, 2, 30]);
+    expect(bound).toEqual([7, 2, 30]);
+  });
+
+  test("a composite bound whose id is not a graph node passes through (#205)", () => {
+    // The 3rd key component only breaks ties at an identical (length, hops);
+    // a bound keyed on a non-node id must still bound correctly by length,
+    // exercising the index-translation fallbacks at the public boundary
+    const bmssp = new BMSSP([
+      [0, 1, 3],
+      [1, 2, 4],
+    ]);
+    bmssp.initializeShortestPaths();
+    bmssp.shortestPaths.set(0, 0);
+    // Length 7 with a large hop budget: every vertex (d = 0, 3, 7) is below it
+    const { boundKey, vertices } = bmssp.bmssp(
+      bmssp.topLevel,
+      [7, 5, 999],
+      new Set([0]),
+    );
+    expect(vertices).toEqual(new Set([0, 1, 2]));
+    expect(boundKey).toEqual([7, 5, 999]);
+  });
+
+  test("a direct level-0 call projects a partial scalar boundary (#205)", () => {
+    // Level 0 delegates to BaseCase; a chain longer than the settle cap k
+    // forces a partial execution, so the scalar bound is the separator's
+    // length rather than the input B
+    const bmssp = new BMSSP([
+      [0, 1, 1],
+      [1, 2, 1],
+      [2, 3, 1],
+    ]);
+    expect(bmssp.k).toBe(1); // cap k + 1 = 2 settled before stopping
+    bmssp.initializeShortestPaths();
+    bmssp.shortestPaths.set(0, 0);
+    const { bound, vertices } = bmssp.bmssp(0, Infinity, new Set([0]));
+    // Settled {0, 1}; B' = d(1) = 1, returned set is the strictly-closer {0}
+    expect(bound).toBe(1);
+    expect(vertices).toEqual(new Set([0]));
+  });
+
+  test("a public call with an unknown source id throws (#205)", () => {
+    const bmssp = new BMSSP([[0, 1, 1]]);
+    bmssp.initializeShortestPaths();
+    bmssp.shortestPaths.set(0, 0);
+    expect(() => bmssp.bmssp(bmssp.topLevel, Infinity, new Set([999]))).toThrow(
+      "finite distance estimate",
+    );
+  });
+
   test("an unbounded top call is a successful execution (B' = B)", () => {
     const rand = mulberry32(433);
     const edges = randomEdges(rand, 40, 160, 1000);

--- a/test/findPivots.test.mjs
+++ b/test/findPivots.test.mjs
@@ -14,15 +14,21 @@ function mulberry32(seed) {
   };
 }
 
-// Build the shared state FindPivots runs against: the class's adjacency map
-// and d̂ labels, with every source marked complete at its given distance
+// Build the engine state FindPivots runs against (#205): a BMSSP instance
+// provides the CSR + typed-array labels; every source is marked complete at
+// its given distance directly in the engine arrays
 function setup(edges, sourceDistances) {
-  const bmssp = new BMSSP(edges);
+  const g = new BMSSP(edges);
   for (const [source, distance] of Object.entries(sourceDistances)) {
-    bmssp.shortestPaths.set(Number(source), distance);
+    g.labels.dist[g.indexOf.get(Number(source))] = distance;
   }
-  return bmssp;
+  return g;
 }
+
+// id <-> index helpers: findPivots speaks dense indices since #205
+const idxSet = (g, vs) => new Set(vs.map((v) => g.indexOf.get(v)));
+const idsOf = (g, indices) => new Set([...indices].map((i) => g.ids[i]));
+const distOf = (g, v) => g.labels.dist[g.indexOf.get(v)];
 
 // Seeded random directed graph with an edge out of node 0 guaranteed.
 // Large weight range keeps equal-length paths (ties) rare.
@@ -39,27 +45,27 @@ function randomEdges(rand, n, m) {
 
 describe("findPivots validation", () => {
   test("rejects k that is not a number >= 1", () => {
-    const { shortestPaths, adjacency } = setup([[0, 1, 1]], { 0: 0 });
+    const g = setup([[0, 1, 1]], { 0: 0 });
     expect(() =>
-      findPivots(Infinity, new Set([0]), shortestPaths, adjacency, 0),
+      findPivots(Infinity, idxSet(g, [0]), g.labels, g.csr, 0),
     ).toThrow("k must be a number >= 1");
     expect(() =>
-      findPivots(Infinity, new Set([0]), shortestPaths, adjacency, NaN),
+      findPivots(Infinity, idxSet(g, [0]), g.labels, g.csr, NaN),
     ).toThrow("k must be a number >= 1");
   });
 
   test("rejects an empty S", () => {
-    const { shortestPaths, adjacency } = setup([[0, 1, 1]], { 0: 0 });
-    expect(() =>
-      findPivots(Infinity, new Set(), shortestPaths, adjacency, 2),
-    ).toThrow("S must contain at least one source node");
+    const g = setup([[0, 1, 1]], { 0: 0 });
+    expect(() => findPivots(Infinity, new Set(), g.labels, g.csr, 2)).toThrow(
+      "S must contain at least one source node",
+    );
   });
 
   test("rejects a source without a finite distance estimate", () => {
     // Node 1 was never completed: its d̂ is still Infinity
-    const { shortestPaths, adjacency } = setup([[0, 1, 1]], { 0: 0 });
+    const g = setup([[0, 1, 1]], { 0: 0 });
     expect(() =>
-      findPivots(Infinity, new Set([0, 1]), shortestPaths, adjacency, 2),
+      findPivots(Infinity, idxSet(g, [0, 1]), g.labels, g.csr, 2),
     ).toThrow("every source must have a finite distance estimate");
   });
 });
@@ -71,20 +77,14 @@ describe("findPivots early exit (|W| > k·|S|)", () => {
       [0, 2, 1],
       [0, 3, 1],
     ];
-    const { shortestPaths, adjacency } = setup(edges, { 0: 0 });
-    const result = findPivots(
-      Infinity,
-      new Set([0]),
-      shortestPaths,
-      adjacency,
-      1,
-    );
+    const g = setup(edges, { 0: 0 });
+    const result = findPivots(Infinity, idxSet(g, [0]), g.labels, g.csr, 1);
     // Round 1 grows W to {0,1,2,3}: 4 > k·|S| = 1, so P = S
-    expect(result.pivots).toEqual(new Set([0]));
-    expect(result.W).toEqual(new Set([0, 1, 2, 3]));
-    expect(shortestPaths.get(1)).toBe(1);
-    expect(shortestPaths.get(2)).toBe(1);
-    expect(shortestPaths.get(3)).toBe(1);
+    expect(idsOf(g, result.pivots)).toEqual(new Set([0]));
+    expect(idsOf(g, result.W)).toEqual(new Set([0, 1, 2, 3]));
+    expect(distOf(g, 1)).toBe(1);
+    expect(distOf(g, 2)).toBe(1);
+    expect(distOf(g, 3)).toBe(1);
   });
 
   test("multiple sources early-exit together", () => {
@@ -92,28 +92,22 @@ describe("findPivots early exit (|W| > k·|S|)", () => {
       [0, 1, 1],
       [4, 5, 1],
     ];
-    const { shortestPaths, adjacency } = setup(edges, { 0: 0, 4: 0 });
-    const result = findPivots(
-      Infinity,
-      new Set([0, 4]),
-      shortestPaths,
-      adjacency,
-      1,
-    );
+    const g = setup(edges, { 0: 0, 4: 0 });
+    const result = findPivots(Infinity, idxSet(g, [0, 4]), g.labels, g.csr, 1);
     // Round 1: W = {0,4,1,5}, 4 > k·|S| = 2, so P = S
-    expect(result.pivots).toEqual(new Set([0, 4]));
-    expect(result.W).toEqual(new Set([0, 4, 1, 5]));
+    expect(idsOf(g, result.pivots)).toEqual(new Set([0, 4]));
+    expect(idsOf(g, result.W)).toEqual(new Set([0, 4, 1, 5]));
   });
 });
 
 describe("findPivots relaxation semantics", () => {
   test("d̂ is updated even at/above B, but W membership is gated by < B", () => {
     const edges = [[0, 1, 5]];
-    const { shortestPaths, adjacency } = setup(edges, { 0: 0 });
-    const result = findPivots(3, new Set([0]), shortestPaths, adjacency, 2);
+    const g = setup(edges, { 0: 0 });
+    const result = findPivots(3, idxSet(g, [0]), g.labels, g.csr, 2);
     // The relaxation writes d̂(1) = 5, but 5 >= B keeps 1 out of W
-    expect(shortestPaths.get(1)).toBe(5);
-    expect(result.W).toEqual(new Set([0]));
+    expect(distOf(g, 1)).toBe(5);
+    expect(idsOf(g, result.W)).toEqual(new Set([0]));
     // A 1-vertex tree is below the k = 2 threshold: no pivots at all
     expect(result.pivots).toEqual(new Set());
   });
@@ -124,17 +118,11 @@ describe("findPivots relaxation semantics", () => {
       [1, 0, 0],
       [1, 2, 1],
     ];
-    const { shortestPaths, adjacency } = setup(edges, { 0: 0 });
-    const result = findPivots(
-      Infinity,
-      new Set([0]),
-      shortestPaths,
-      adjacency,
-      5,
-    );
-    expect(result.W).toEqual(new Set([0, 1, 2]));
-    expect(shortestPaths.get(1)).toBe(0);
-    expect(shortestPaths.get(2)).toBe(1);
+    const g = setup(edges, { 0: 0 });
+    const result = findPivots(Infinity, idxSet(g, [0]), g.labels, g.csr, 5);
+    expect(idsOf(g, result.W)).toEqual(new Set([0, 1, 2]));
+    expect(distOf(g, 1)).toBe(0);
+    expect(distOf(g, 2)).toBe(1);
     // 0 and 1 give each other parents (tight cycle), so nothing is a root
     expect(result.pivots).toEqual(new Set());
   });
@@ -146,17 +134,11 @@ describe("findPivots forest case (pivots root large tight trees)", () => {
       [0, 1, 1],
       [1, 2, 1],
     ];
-    const { shortestPaths, adjacency } = setup(edges, { 0: 0 });
-    const result = findPivots(
-      Infinity,
-      new Set([0]),
-      shortestPaths,
-      adjacency,
-      3,
-    );
+    const g = setup(edges, { 0: 0 });
+    const result = findPivots(Infinity, idxSet(g, [0]), g.labels, g.csr, 3);
     // W = {0,1,2} stays within k·|S| = 3; the tree at 0 has 3 >= k vertices
-    expect(result.pivots).toEqual(new Set([0]));
-    expect(result.W).toEqual(new Set([0, 1, 2]));
+    expect(idsOf(g, result.pivots)).toEqual(new Set([0]));
+    expect(idsOf(g, result.W)).toEqual(new Set([0, 1, 2]));
   });
 
   test("sources with small trees are dropped, large ones kept", () => {
@@ -165,17 +147,11 @@ describe("findPivots forest case (pivots root large tight trees)", () => {
       [1, 2, 1],
       [4, 5, 1],
     ];
-    const { shortestPaths, adjacency } = setup(edges, { 0: 0, 4: 0 });
-    const result = findPivots(
-      Infinity,
-      new Set([0, 4]),
-      shortestPaths,
-      adjacency,
-      3,
-    );
+    const g = setup(edges, { 0: 0, 4: 0 });
+    const result = findPivots(Infinity, idxSet(g, [0, 4]), g.labels, g.csr, 3);
     // Tree at 0 = {0,1,2} (3 >= k) is a pivot; tree at 4 = {4,5} (2 < k) is not
-    expect(result.pivots).toEqual(new Set([0]));
-    expect(result.W).toEqual(new Set([0, 4, 1, 5, 2]));
+    expect(idsOf(g, result.pivots)).toEqual(new Set([0]));
+    expect(idsOf(g, result.W)).toEqual(new Set([0, 4, 1, 5, 2]));
   });
 
   test("equal-length paths (DAG of tight edges) keep tree sizes well-defined", () => {
@@ -185,18 +161,12 @@ describe("findPivots forest case (pivots root large tight trees)", () => {
       [1, 3, 1],
       [2, 3, 1],
     ];
-    const { shortestPaths, adjacency } = setup(edges, { 0: 0 });
-    const result = findPivots(
-      Infinity,
-      new Set([0]),
-      shortestPaths,
-      adjacency,
-      4,
-    );
+    const g = setup(edges, { 0: 0 });
+    const result = findPivots(Infinity, idxSet(g, [0]), g.labels, g.csr, 4);
     // Both 1->3 and 2->3 are tight; 3 gets exactly one parent, so the tree
     // at 0 counts each vertex once: size 4 >= k = 4
-    expect(result.pivots).toEqual(new Set([0]));
-    expect(result.W).toEqual(new Set([0, 1, 2, 3]));
+    expect(idsOf(g, result.pivots)).toEqual(new Set([0]));
+    expect(idsOf(g, result.W)).toEqual(new Set([0, 1, 2, 3]));
   });
 });
 
@@ -205,24 +175,18 @@ describe("findPivots vs Dijkstra oracle (seeded)", () => {
     const rand = mulberry32(44);
     for (let round = 0; round < 20; round += 1) {
       const edges = randomEdges(rand, 40, 160);
-      const bmssp = setup(edges, { 0: 0 });
-      const oracle = dijkstra(bmssp.graph, bmssp.nodeIDs, 0);
-      const n = bmssp.nodeIDs.size;
+      const g = setup(edges, { 0: 0 });
+      const oracle = dijkstra(g.graph, g.nodeIDs, 0);
+      const n = g.nodeIDs.size;
       // k = n rounds of Bellman-Ford complete everything, and the early
       // exit (|W| > n·1) can never fire since W has at most n vertices
-      const result = findPivots(
-        Infinity,
-        new Set([0]),
-        bmssp.shortestPaths,
-        bmssp.adjacency,
-        n,
-      );
+      const result = findPivots(Infinity, idxSet(g, [0]), g.labels, g.csr, n);
       const reachable = new Set(
         [...oracle].filter(([, d]) => d < Infinity).map(([v]) => v),
       );
-      expect(result.W).toEqual(reachable);
-      for (const v of result.W) {
-        expect(bmssp.shortestPaths.get(v)).toBe(oracle.get(v));
+      expect(idsOf(g, result.W)).toEqual(reachable);
+      for (const v of idsOf(g, result.W)) {
+        expect(distOf(g, v)).toBe(oracle.get(v));
       }
     }
   });
@@ -231,44 +195,37 @@ describe("findPivots vs Dijkstra oracle (seeded)", () => {
     const rand = mulberry32(45);
     for (let round = 0; round < 25; round += 1) {
       const edges = randomEdges(rand, 30, 90);
-      const bmssp = setup(edges, { 0: 0 });
-      const oracle = dijkstra(bmssp.graph, bmssp.nodeIDs, 0);
+      const g = setup(edges, { 0: 0 });
+      const oracle = dijkstra(g.graph, g.nodeIDs, 0);
       const finite = [...oracle.values()]
         .filter((d) => d < Infinity)
         .sort((a, b) => a - b);
       // A bound somewhere inside the distance distribution, and a small k
       const B = finite[Math.floor(finite.length * 0.6)] + 0.5;
       const k = 1 + Math.floor(rand() * 5);
-      const result = findPivots(
-        B,
-        new Set([0]),
-        bmssp.shortestPaths,
-        bmssp.adjacency,
-        k,
-      );
+      const result = findPivots(B, idxSet(g, [0]), g.labels, g.csr, k);
+      const pivotIds = idsOf(g, result.pivots);
+      const wIds = idsOf(g, result.W);
 
       // Pivots are a subset of S, and |P| <= |W| / k
-      for (const p of result.pivots) {
+      for (const p of pivotIds) {
         expect(p).toBe(0);
       }
-      expect(result.pivots.size * k).toBeLessThanOrEqual(result.W.size);
+      expect(pivotIds.size * k).toBeLessThanOrEqual(wIds.size);
 
       // d̂ never underestimates the true distance anywhere
-      for (const [v, d] of bmssp.shortestPaths) {
-        expect(d).toBeGreaterThanOrEqual(oracle.get(v));
+      for (const v of g.nodeIDs) {
+        expect(distOf(g, v)).toBeGreaterThanOrEqual(oracle.get(v));
       }
 
       // The frontier-shrink contract: every vertex with d(v) < B is either
       // complete in W, or some shortest path to it visits a pivot
       const pivotOracles = new Map(
-        [...result.pivots].map((p) => [
-          p,
-          dijkstra(bmssp.graph, bmssp.nodeIDs, p),
-        ]),
+        [...pivotIds].map((p) => [p, dijkstra(g.graph, g.nodeIDs, p)]),
       );
       for (const [v, d] of oracle) {
         if (d >= B) continue;
-        const completeInW = result.W.has(v) && bmssp.shortestPaths.get(v) === d;
+        const completeInW = wIds.has(v) && distOf(g, v) === d;
         const throughPivot = [...pivotOracles].some(
           ([p, fromP]) => oracle.get(p) + fromP.get(v) === d,
         );

--- a/test/tieBreak.test.mjs
+++ b/test/tieBreak.test.mjs
@@ -4,8 +4,11 @@ import {
   compareKeyParts,
   toBound,
   makeTies,
+  makeLabels,
   orderKey,
+  labelKey,
   relaxEdge,
+  NO_PRED,
   RELAX_LOST,
   RELAX_EQUAL,
   RELAX_IMPROVED,
@@ -146,101 +149,81 @@ describe("toBound — scalar bounds keep strict semantics", () => {
   });
 });
 
-describe("relaxEdge — canonical relaxation", () => {
+describe("relaxEdge — canonical relaxation (on #205 engine labels)", () => {
   test("updates d̂, hops and preds together on improvement", () => {
-    const dHat = new Map([
-      [0, 0],
-      [1, Infinity],
-    ]);
-    const ties = makeTies();
-    const result = relaxEdge(0, 1, 5, dHat, ties);
+    const labels = makeLabels(2);
+    labels.dist[0] = 0;
+    const result = relaxEdge(0, 1, 5, labels);
     expect(result).toBe(RELAX_IMPROVED);
-    expect(dHat.get(1)).toBe(5);
-    expect(ties.hops.get(1)).toBe(1);
-    expect(ties.preds.get(1)).toBe(0);
-    expect(orderKey(1, dHat, ties)).toEqual([5, 1, 1]);
+    expect(labels.dist[1]).toBe(5);
+    expect(labels.hops[1]).toBe(1);
+    expect(labels.preds[1]).toBe(0);
+    expect(labelKey(1, labels)).toEqual([5, 1, 1]);
   });
 
   test("equal-length candidates win only on fewer hops, then smaller pred", () => {
-    const dHat = new Map([
-      [0, 0],
-      [7, 3],
-      [3, 3],
-      [9, 3],
-      [5, 6],
-    ]);
-    const ties = makeTies(
-      new Map([
-        [7, 1],
-        [3, 1],
-        [9, 1],
-        [5, 2],
-      ]),
-      new Map([[5, 7]]),
-    );
+    const labels = makeLabels(10);
+    labels.dist[0] = 0;
+    labels.dist[7] = 3;
+    labels.dist[3] = 3;
+    labels.dist[9] = 3;
+    labels.dist[5] = 6;
+    labels.hops[7] = 1;
+    labels.hops[3] = 1;
+    labels.hops[9] = 1;
+    labels.hops[5] = 2;
+    labels.preds[5] = 7;
     // Same length (3 + 3 = 6), same hops (3), pred 9 > current pred 7: no
-    expect(relaxEdge(9, 5, 3, dHat, ties)).toBe(RELAX_LOST);
-    expect(ties.preds.get(5)).toBe(7);
+    expect(relaxEdge(9, 5, 3, labels)).toBe(RELAX_LOST);
+    expect(labels.preds[5]).toBe(7);
     // Same length, same hops, pred 3 < current pred 7: canonical update
-    expect(relaxEdge(3, 5, 3, dHat, ties)).toBe(RELAX_IMPROVED);
-    expect(orderKey(5, dHat, ties)).toEqual([6, 2, 5]);
-    expect(ties.preds.get(5)).toBe(3);
+    expect(relaxEdge(3, 5, 3, labels)).toBe(RELAX_IMPROVED);
+    expect(labelKey(5, labels)).toEqual([6, 2, 5]);
+    expect(labels.preds[5]).toBe(3);
     // Re-relaxation from the now-canonical pred reports exact equality —
     // the caller's re-enqueue signal — without touching the labels
-    expect(relaxEdge(3, 5, 3, dHat, ties)).toBe(RELAX_EQUAL);
-    expect(orderKey(5, dHat, ties)).toEqual([6, 2, 5]);
-    expect(ties.preds.get(5)).toBe(3);
+    expect(relaxEdge(3, 5, 3, labels)).toBe(RELAX_EQUAL);
+    expect(labelKey(5, labels)).toEqual([6, 2, 5]);
+    expect(labels.preds[5]).toBe(3);
   });
 
   test("a zero-weight edge strictly increases the key: cycles cannot loop", () => {
-    const dHat = new Map([
-      [0, 2],
-      [1, 2],
-    ]);
-    const ties = makeTies(
-      new Map([
-        [0, 1],
-        [1, 2],
-      ]),
-      new Map([
-        [0, 5],
-        [1, 0],
-      ]),
-    );
+    const labels = makeLabels(6);
+    labels.dist[0] = 2;
+    labels.dist[1] = 2;
+    labels.hops[0] = 1;
+    labels.hops[1] = 2;
+    labels.preds[0] = 5;
+    labels.preds[1] = 0;
     // 1 -> 0 with weight 0: candidate [2, 3, 1] vs current [2, 1, 5] — the
     // extra hops lose outright
-    expect(relaxEdge(1, 0, 0, dHat, ties)).toBe(RELAX_LOST);
+    expect(relaxEdge(1, 0, 0, labels)).toBe(RELAX_LOST);
     // 0 -> 1 with weight 0 reproduces 1's canonical label exactly: reported
     // as equality, no update — so the cycle is quiescent, never looping
-    expect(relaxEdge(0, 1, 0, dHat, ties)).toBe(RELAX_EQUAL);
-    expect(orderKey(1, dHat, ties)).toEqual([2, 2, 1]);
-    expect(ties.hops.get(1)).toBe(2);
+    expect(relaxEdge(0, 1, 0, labels)).toBe(RELAX_EQUAL);
+    expect(labelKey(1, labels)).toEqual([2, 2, 1]);
+    expect(labels.hops[1]).toBe(2);
   });
 
   test("a source (no stored pred) never loses an equal-(length, hops) tie", () => {
-    const dHat = new Map([
-      [4, 0],
-      [2, 5],
-    ]);
-    const ties = makeTies(new Map([[2, 0]]), new Map());
-    // Vertex 2 is an externally seeded hop-0 source at distance 5; an
-    // equal-length, equal-hops... any candidate has hops >= 1 > 0, and even
-    // a shorter-hop tie would face the -Infinity pred sentinel
-    expect(relaxEdge(4, 2, 5, dHat, ties)).toBe(RELAX_LOST);
-    expect(dHat.get(2)).toBe(5);
+    const labels = makeLabels(5);
+    labels.dist[4] = 0;
+    labels.dist[2] = 5;
+    // Vertex 2 is an externally seeded hop-0 source at distance 5; any
+    // candidate has hops >= 1 > 0, and even a shorter-hop tie would face
+    // the NO_PRED sentinel, which compares below every real index
+    expect(relaxEdge(4, 2, 5, labels)).toBe(RELAX_LOST);
+    expect(labels.dist[2]).toBe(5);
   });
 
   test("the optional bound gates the update entirely (paper's < B)", () => {
-    const dHat = new Map([
-      [0, 0],
-      [1, Infinity],
-    ]);
-    const ties = makeTies();
-    expect(relaxEdge(0, 1, 5, dHat, ties, toBound(5))).toBe(RELAX_LOST);
-    expect(dHat.get(1)).toBe(Infinity);
-    expect(ties.preds.has(1)).toBe(false);
-    expect(relaxEdge(0, 1, 5, dHat, ties, toBound(5.1))).toBe(RELAX_IMPROVED);
-    expect(orderKey(1, dHat, ties)).toEqual([5, 1, 1]);
+    const labels = makeLabels(2);
+    labels.dist[0] = 0;
+    expect(relaxEdge(0, 1, 5, labels, toBound(5))).toBe(RELAX_LOST);
+    expect(labels.dist[1]).toBe(Infinity);
+    expect(labels.preds[1]).toBe(NO_PRED);
+    expect(relaxEdge(0, 1, 5, labels, toBound(5.1))).toBe(RELAX_IMPROVED);
+    expect(labelKey(1, labels)).toEqual([5, 1, 1]);
   });
 
   test("orderKey defaults: missing labels read as hop-0, distance Infinity", () => {
@@ -248,6 +231,13 @@ describe("relaxEdge — canonical relaxation", () => {
     const ties = makeTies();
     expect(orderKey(3, dHat, ties)).toEqual([4, 0, 3]);
     expect(orderKey(99, dHat, ties)).toEqual([Infinity, 0, 99]);
+  });
+
+  test("makeLabels defaults match the Map engine's ?? fallbacks", () => {
+    const labels = makeLabels(3);
+    expect(labelKey(2, labels)).toEqual([Infinity, 0, 2]);
+    expect(labels.preds[0]).toBe(NO_PRED);
+    expect(NO_PRED).toBeLessThan(0); // below every real vertex index
   });
 });
 
@@ -438,13 +428,10 @@ describe("comparison counter (#170): benchmark instrumentation", () => {
   });
 
   test("counts comparisons made inside relaxEdge", () => {
-    const dHat = new Map([
-      [0, 0],
-      [1, Infinity],
-    ]);
-    const ties = makeTies();
+    const labels = makeLabels(2);
+    labels.dist[0] = 0;
     resetComparisonCount();
-    relaxEdge(0, 1, 5, dHat, ties);
+    relaxEdge(0, 1, 5, labels);
     expect(getComparisonCount()).toBeGreaterThan(0);
   });
 


### PR DESCRIPTION
Closes #205

## Summary

Replaces the Map-based label storage that #168's profiles flagged (`relaxEdge` spent ~38% of self-time in `Map.get`/`set` on arbitrary node ids) with a **dense-index engine**:

- **`buildIndex()`** maps every node id to a contiguous integer `0..n-1`, assigned in **ascending numeric id order** (`this.ids` / `this.indexOf`).
- The graph is stored in **CSR** arrays (`this.csr` = `offsets`/`targets`/`weights`).
- `d̂`/`hops`/`preds` live in **typed arrays** (`Float64Array`/`Uint32Array`/`Int32Array`; `makeLabels` in `tieBreak`). `NO_PRED` is now `-1`.
- `baseCase` / `findPivots` / the new `bmsspIndex` recursion run **entirely on indices** — `relaxEdge` reads/writes the typed arrays, edge loops walk CSR ranges.

Because index order equals id order, the composite-key tie-break makes the **same canonical choice** it made on ids, so distances/hops/preds are byte-for-byte identical and still edge-order-invariant — the untouched determinism + oracle suites are the correctness proof.

## API is unchanged (so: no version bump)

`this.shortestPaths` / `this.hops` / `this.preds` stay the public Maps. The public `bmssp(l, B, S)` is now a thin id↔index wrapper (`syncLabelsIn`/`syncLabelsOut`, `boundToEngine`/`keyToPublic`); `calculateShortestPaths` and `reconstructPath` behave exactly as before. #205 re-engineers the interior, not the surface — the API-breaking work stays with #171/#172/#173, and #173 takes the milestone-closing major bump.

## Measured impact — roughly 2× faster

Algorithm-only head-to-head vs. Dijkstra (2026-07-21 capture, `benchmarks/RESULTS.md`):

| shape | 1.2.0 ratio | post-#205 ratio |
| --- | --- | --- |
| sparse-random 50k | ~2.5–2.8× | **1.38×** |
| sparse-random-l4 300k | ~2.5–3× | **1.07×** |
| dense 8k | ~4.5× | **1.16×** |
| grid / chain / star | 3.9× / 6.5× / 4.5× | 2.27× / 3.10× / 2.48× |

Clean A/B (fresh processes, alternating rounds): sparse 50k ~104 → ~53 ms, star ~145 → ~100 ms, sparse-l4 300k ~982 → ~424 ms. **Comparison counts are unchanged** (0.95× / 0.76× / 0.65× sparse at 50k / 200k / 1M) — identical algorithm, just typed storage. Full write-up in the new `HEAD-TO-HEAD.md` #205 addendum.

## Tests / lint

- **191 tests (190 + 1 XL opt-in), 14 suites green**; `npm run lint` clean; **100% statement coverage**, 99.35% branch.
- `baseCase`/`findPivots`/`tieBreak` unit tests rewritten to drive the dense-index API (fixtures seed `g.labels.dist`, pass `idxSet(...)`/`g.csr`, translate results via `g.ids`). +5 tests: four #205 public-boundary cases in `bmssp.test.mjs` (composite bound with non-contiguous ids round-tripping id↔index; composite bound on a non-node id; partial level-0 scalar projection; unknown-source throw) and a `makeLabels`-defaults check.
- Extended runs green: `FUZZ_ROUNDS=25` and `FUZZ_XL=1` (2M nodes). Manually verified correct on negative / fractional / non-contiguous ids.

## Roadmap proposals

1. **Comment on #172** with the engine baseline it now builds on (the class already holds the graph as CSR + typed labels, so typed/builder inputs should ingest straight into that layout; #172 is the natural place for an explicit vertex-set / id-normalization API). Note the headline that the dense engine roughly halved wall-clock, making typed inputs the main remaining constant-factor lever.
2. Build-order confirmation only (no GitHub write): #205 kept the API backward-compatible, so #171's public multi-source entrypoint is surface design over a finished engine — confirming #205 → #172 → #171 → #173.

🤖 Generated with [Claude Code](https://claude.com/claude-code)