### PR TITLE
chore(examples): standalone example gallery + modernized Docker image

### DIFF
--- a/.claude/knowledge/05-codebase-map.md
+++ b/.claude/knowledge/05-codebase-map.md
@@ -1,15 +1,17 @@
 # 05 — Codebase Map (current state)
 
-<!-- BOOKMARK-COMMIT: f7052c5 -->
-<!-- PENDING-PR-BRANCH: feat/205-dense-index-core -->
-<!-- Last validated: 2026-07-21 (Phase C of the #205 PR). Describes the tree as it will
-     exist once that PR merges: the dense-index engine — node ids mapped to dense
-     indices once (sorted-id order), the graph in CSR arrays, and d̂/hops/preds in typed
-     arrays (src/tieBreak.mjs makeLabels). The algorithm modules run entirely on indices;
-     the BMSSP class keeps a thin id<->index boundary (public Maps unchanged). Wall-clock
-     roughly halved (sparse 50k ~104->~53 ms, l4 300k ~982->~424 ms); counts unchanged.
-     First 2.0.0-milestone issue, mid-milestone → NO bump (the API stayed
-     backward-compatible; #173 takes the major bump). -->
+<!-- BOOKMARK-COMMIT: cbcaab1 -->
+<!-- PENDING-PR-BRANCH: chore/examples-docker-gallery -->
+<!-- Last validated: 2026-07-21 (Phase C of the examples/Docker PR, branch
+     chore/examples-docker-gallery, based on main cbcaab1). This PR rewrites the examples/
+     directory into a standalone gallery (01-basic, 02-dijkstra-oracle, 03-constant-degree,
+     04-larger-graph, run-all + README), modernizes the Dockerfile (COPY examples/ dir,
+     OCI labels, run-all as default CMD), and refreshes the README Docker section. No src/
+     test change; no version bump (docs/tooling, no bug fix, no milestone close). Verified
+     end-to-end inside Docker (docker build + run: all four examples + oracle checks pass;
+     single-example override and volume-mount forms confirmed). Not tied to a GitHub issue
+     (user-directed). Body describes post-merge reality; markers flip on the next session's
+     Phase A fast path. -->
 
 
 Snapshot of what exists in `bmssp-js` today, so you know what to build on vs. what's missing.
@@ -100,8 +102,15 @@ benchmarks/               # dependency-free benchmark harness, `npm run bench` /
   README.md               #   methodology + "when to use which" guidance
   RESULTS.md              #   captured `npm run bench:counts` report (2026-07-21)
   HEAD-TO-HEAD.md         #   frozen 1.0.0 measurement record (up to n = 4M): wall-clock + comparison counts
-examples/
-  main.mjs                # tiny usage example (constructs BMSSP, prints .graph)
+examples/                 # standalone, copy-pasteable gallery — each file imports from the
+                          # PUBLISHED `bmssp` package (not relative src), so users run them
+                          # after `npm install bmssp`; also bundled into the Docker image
+  01-basic.mjs            #   calculateShortestPaths() + reconstructPath() on a tiny digraph
+  02-dijkstra-oracle.mjs  #   validate BMSSP against the exported `dijkstra` oracle (per-node table)
+  03-constant-degree.mjs  #   the opt-in constantDegreeTransform (sourceCopy/collapse)
+  04-larger-graph.mjs     #   a generated 40×40 grid — timing + oracle spot-check
+  run-all.mjs             #   runs all four in order (the Docker image's default CMD)
+  README.md               #   gallery index + Docker run/override/mount recipes
 docs/index.html           # public-API reference (GitHub Pages via static.yml) — rewritten in
                           # #166 from a stale landing page (wrong repo link, stray </svg>);
                           # documents the three exports only, internals explicitly excluded
@@ -622,10 +631,10 @@ BMSSP-vs-Dijkstra head-to-head itself:
 | Performance-cliff investigation + quadratic batchPrepend fix | `src/blockList.mjs` + HEAD-TO-HEAD addendum | #182 | ✅ merged (PR #200, **patch → 1.1.1**, released 2026-07-21) |
 | Exact Lemma 3.3 asymptotics (BST bound index + linear selection) | `src/boundIndex.mjs` + `src/select.mjs` + `src/blockList.mjs` | #167 | ✅ merged (PR #202, no bump) |
 | Relaxation micro-optimizations (allocation-free relaxEdge, unpacked routing, heap measurement) | `src/tieBreak.mjs` + `src/bmssp.mjs` + `src/baseCase.mjs` + `src/findPivots.mjs` | #168 | ✅ merged (PR #203, **minor → 1.2.0**, released 2026-07-21) |
-| Dense-index core: typed-array labels + CSR adjacency | `src/tieBreak.mjs` (makeLabels) + `src/bmssp.mjs` (buildIndex/CSR) + `src/baseCase.mjs` + `src/findPivots.mjs` | #205 | ✅ done-pending-merge (this PR, no bump — API-non-breaking) |
+| Dense-index core: typed-array labels + CSR adjacency | `src/tieBreak.mjs` (makeLabels) + `src/bmssp.mjs` (buildIndex/CSR) + `src/baseCase.mjs` + `src/findPivots.mjs` | #205 | ✅ merged (PR #206, no bump — API-non-breaking) |
 
 Milestones `1.1.0` (correctness hardening) and `1.2.0` (performance & ergonomics) are
 both **closed** — 1.2.0 released 2026-07-21 (npm + Docker Hub). Milestone `2.0.0`
-(API-breaking generalization) is current: **#205** (dense-index core) done-pending-merge
-in this PR, then **#172 → #171 → #173** (build order in `06`; #173 closes the milestone
-with the **major → 2.0.0** bump). See [06-milestones-roadmap.md](06-milestones-roadmap.md).
+(API-breaking generalization) is current: **#205** (dense-index core) merged (PR #206,
+no bump), then **#172 → #171 → #173** (build order in `06`; #172 is next, #173 closes the
+milestone with the **major → 2.0.0** bump). See [06-milestones-roadmap.md](06-milestones-roadmap.md).

--- a/.claude/knowledge/06-milestones-roadmap.md
+++ b/.claude/knowledge/06-milestones-roadmap.md
@@ -1,8 +1,7 @@
 # 06 — Milestones Roadmap
 
-<!-- SYNCED-FROM-GITHUB: 2026-07-21 Phase C of the #205 PR (verified live at RKB the same
-     day: 1.2.0 CLOSED with 5/5 done; 2.0.0 open with 4 open issues #171/#172/#173/#205 —
-     #205 done-pending-merge in this PR) -->
+<!-- SYNCED-FROM-GITHUB: 2026-07-21 Phase E of the #205 PR (PR #206 merged as cbcaab1):
+     1.2.0 CLOSED; 2.0.0 open with 3 open issues #171/#172/#173 (#205 closed) — #172 next -->
 <!-- Current package version: 1.2.0 — released 2026-07-21 (tag + GitHub Release with
      Announcements discussion → npm + Docker Hub via publish.yml); tag matches -->
 <!-- Release-discussion convention (user-directed 2026-07-21): every GitHub Release also
@@ -43,23 +42,25 @@ it runs the same Phase C reconciliation directly on `main`.
 
 ## 📋 Roadmap proposals (pending user approval)
 
-From the #205 PR (Phase C, 2026-07-21):
+**From the examples/Docker PR (`chore/examples-docker-gallery`, no issue, no bump):**
 
-1. **Comment on #172 (typed / flexible graph inputs)** with the engine baseline it now
-   builds on: #205 landed the dense-index core, so the class already maps ids → dense
-   indices (sorted-id order) and stores the graph as CSR (`this.csr`) + typed labels.
-   #172's builder/typed-input forms should **construct straight into that index+CSR
-   layout** rather than the `[from,to,weight]` array, and #172 is the natural place to
-   expose an explicit vertex-set / id-normalization API (today ids are inferred from
-   edges and sorted). Note the surprising #205 result — the dense engine roughly halved
-   wall-clock (sparse-random head-to-head 2.5× → **1.38×**), so typed inputs are now the
-   main remaining constant-factor lever before #171/#173.
-2. **Reassess the #205↔#171 ordering (no GitHub write, build-order note):** #205 kept the
-   public API backward-compatible (the `bmssp(l,B,S)` wrapper still speaks ids and seeds
-   via `shortestPaths`), so #171's public multi-source entrypoint is now a **surface**
-   design over a finished engine — confirming the RKB build order #205 → #172 → #171 →
-   #173. No issue edit needed; recorded here and in #173's stabilization scope.
+1. **Comment on #173** (Stabilize the public API surface) — the new `examples/` gallery
+   now exercises exactly the three public exports (`BMSSP`, `dijkstra`,
+   `constantDegreeTransform`) as a real consumer, importing from the published package.
+   When #173 writes the migration note / public-surface decision, point it at
+   `examples/` as the canonical, runnable usage reference (and keep the gallery in lockstep
+   with any 2.0.0 surface change). _Rationale: the examples are now the de-facto public-API
+   contract users copy from; #173 should own keeping them honest._
 
+_(These are the only proposals; the PR touches examples/docs/tooling only, so it teaches
+nothing about the #172/#171 algorithm-surface work.)_
+
+_(The #205-PR proposals — engine-baseline comment on **#172** (class now holds the graph
+as index+CSR + typed labels; typed inputs should ingest straight into it and expose an
+explicit vertex-set API; #205 ~halved wall-clock so #172 is the next lever) and a
+build-order confirmation (#205 kept the API backward-compatible → #171 is surface design;
+order stays #205 → #172 → #171 → #173) — were handled 2026-07-21: the #172 comment was
+approved and posted; the ordering note needed no GitHub write.)_
 _(The #168-PR proposals — close milestone **1.2.0** (5/5 done) and open the
 **dense-index core** issue (typed-array labels + CSR adjacency; label-Map traffic ~38%
 of post-#168 self-time) — were approved and executed 2026-07-21: milestone #3 closed,
@@ -201,7 +202,7 @@ executed 2026-07-17.)_
   Suite 186 (+1 compareKeyParts agreement sweep; relaxEdge unit tests updated to the
   code contract); FUZZ_ROUNDS=25 and FUZZ_XL green. Next lever (label-Map traffic,
   ~38% self-time) proposed as a 2.0.0 dense-index issue (Roadmap proposal 2).
-- **#205 done-pending-merge (this PR, 2026-07-21; no bump — API-non-breaking):** the
+- **#205 merged (PR #206, 2026-07-21, commit cbcaab1; no bump — API-non-breaking):** the
   dense-index core, first issue of milestone 2.0.0. `buildIndex()` assigns every node id
   a dense index in **ascending-id order**, lays the graph out in **CSR** typed arrays
   (`this.csr` = offsets/targets/weights), and holds d̂/hops/preds as typed arrays
@@ -218,8 +219,21 @@ executed 2026-07-17.)_
   unchanged (0.95×/0.76×/0.65× sparse). Suite 191 (+5: 4 #205 boundary tests in
   `bmssp.test.mjs` + a `makeLabels`-defaults check; `baseCase`/`findPivots`/`tieBreak`
   unit tests rewritten to drive the index API); 100% statement coverage, lint clean,
-  FUZZ_ROUNDS=25 + FUZZ_XL green. Roadmap proposals: engine-baseline comment on #172,
-  build-order confirmation for #171/#173.
+  FUZZ_ROUNDS=25 + FUZZ_XL green. Phase E: engine-baseline comment posted on #172; the
+  build-order confirmation needed no GitHub write. **#172 is next.**
+- **Examples + Docker refresh (branch `chore/examples-docker-gallery`, 2026-07-21;
+  user-directed, no issue, no bump):** the stale single `examples/main.mjs` (it only
+  printed the raw edge list — never ran the algorithm) is replaced by a standalone gallery
+  — `01-basic` (calculateShortestPaths + reconstructPath), `02-dijkstra-oracle` (per-node
+  match table vs the exported oracle), `03-constant-degree` (transform + sourceCopy/collapse),
+  `04-larger-graph` (generated 40×40 grid, timing + oracle spot-check), `run-all` and a
+  gallery `README`. Each file imports from the **published** `bmssp` package, so users run
+  them after `npm install bmssp`. The Dockerfile now `COPY examples/`-es the whole dir,
+  carries OCI image labels + `--omit=dev`, and defaults its `CMD` to `run-all.mjs` (was the
+  trivial example); the README Docker section documents the run / single-example-override /
+  volume-mount recipes. Verified end-to-end with the local docker CLI (build + run: all four
+  examples green, oracle checks pass; override and mount forms confirmed). No src/test
+  change; docs/tooling only → no bump, no release.
 - **Semver release convention (user-directed 2026-07-17, PR #186):** bumps only on bug
   fix (patch) or milestone-closing PR (minor/major) — see "Release mechanics" below.
 - **2026-07-16 reflection session (post-release):** measured the BMSSP-vs-Dijkstra
@@ -285,7 +299,7 @@ _Note:_ both #182 shapes stay as regression sentinels in every `npm run bench` (
 ## Milestone `2.0.0` (milestone #4) — API-breaking generalization — CURRENT
 
 Build order (derived 2026-07-21 at RKB, after 1.2.0 closed): ~~#205~~
-(done-pending-merge, this PR) → **#172 → #171 → #173**. Rationale: the dense-index engine
+(merged, PR #206) → **#172 → #171 → #173**. Rationale: the dense-index engine
 (#205) decides the internal shapes every new API wraps, so it went first — the
 alternatives would build #171/#172 on the Map core and rebuild them; typed inputs (#172)
 then feed CSR directly; the public multi-source entrypoint (#171) is designed
@@ -294,8 +308,8 @@ last and takes the **major → 2.0.0** bump as the milestone-closing PR.
 
 | # | Issue | Labels | Notes |
 |---|---|---|---|
-| 205 | Dense-index core: typed-array labels + CSR adjacency | enhancement | ✅ done-pending-merge (this PR, no bump — API-non-breaking): sorted-id index + CSR + typed labels; wall-clock ~halved (sparse head-to-head 2.5× → 1.38×), counts unchanged |
-| 172 | Typed / flexible graph inputs | enhancement · help wanted | NEXT — after #205 builder forms ingest straight into index+CSR (`this.csr`); the main remaining constant-factor lever |
+| 205 | Dense-index core: typed-array labels + CSR adjacency | enhancement | ✅ merged (PR #206, no bump — API-non-breaking): sorted-id index + CSR + typed labels; wall-clock ~halved (sparse head-to-head 2.5× → 1.38×), counts unchanged |
+| 172 | Typed / flexible graph inputs | enhancement · help wanted | **NEXT** — after #205 builder forms ingest straight into index+CSR (`this.csr`) + expose an explicit vertex-set API; the main remaining constant-factor lever (baseline comment posted 2026-07-21) |
 | 171 | Public multi-source / bounded BMSSP entrypoint | enhancement · help wanted | value-in/value-out API over the dense engine; #205 kept the id-based `bmssp(l,B,S)` wrapper, so this is surface design |
 | 173 | Stabilize the public API surface for 1.0 → 2.0 | documentation · enhancement | milestone-closing: per-module public/private decision, migration note, **major → 2.0.0** |
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,19 @@
 FROM node:26-alpine@sha256:e88a35be04478413b7c71c455cd9865de9b9360e1f43456be5951032d7ac1a66
 
+LABEL org.opencontainers.image.title="bmssp-js" \
+      org.opencontainers.image.description="Pre-configured playground for the bmssp package — runs the bundled examples." \
+      org.opencontainers.image.source="https://github.com/Sirivasv/bmssp-js" \
+      org.opencontainers.image.licenses="MPL-2.0"
+
 WORKDIR /bmssp-js
 
-RUN npm install bmssp@latest
+# Install the published package. `--omit=dev` keeps the image lean; there is
+# no application package.json here — bmssp is the only dependency.
+RUN npm install --omit=dev bmssp@latest
 
-COPY examples/main.mjs .
+# Bundle the example gallery (imports from the installed `bmssp` package).
+COPY examples/ ./examples/
 
-CMD ["node", "main.mjs"]
+# Default: run every example in order. Override with e.g.
+#   docker run --rm sirivasv/bmssp-js node examples/01-basic.mjs
+CMD ["node", "examples/run-all.mjs"]

--- a/README.md
+++ b/README.md
@@ -147,17 +147,24 @@ picks a valid start copy for an original node.
 
 ### Using the Docker image
 
-Run the bundled example:
+The published image is a pre-configured Node environment with `bmssp` installed and the
+[`examples/`](examples/) gallery bundled. Run the whole gallery — basic shortest paths,
+Dijkstra-oracle validation, the constant-degree transform, and a larger generated grid:
 
 ```bash
-docker run -it sirivasv/bmssp-js:latest
+docker run --rm sirivasv/bmssp-js:latest
 ```
 
-Or run your own tests in a pre-configured environment (replace `folder-mytest/` with your
-tests folder and `index.mjs` with your test file):
+Run a single bundled example instead:
 
 ```bash
-docker run -it -v ./folder-mytest/:/bmssp-js/folder-mytest/ sirivasv/bmssp-js:latest node /bmssp-js/folder-mytest/index.mjs
+docker run --rm sirivasv/bmssp-js:latest node examples/02-dijkstra-oracle.mjs
+```
+
+Or mount your own script and run it in the same environment (no local Node install needed):
+
+```bash
+docker run --rm -v "$PWD/mine.mjs:/bmssp-js/mine.mjs" sirivasv/bmssp-js:latest node mine.mjs
 ```
 
 Other image versions are on [Docker Hub](https://hub.docker.com/r/sirivasv/bmssp-js/tags).

--- a/examples/01-basic.mjs
+++ b/examples/01-basic.mjs
@@ -1,0 +1,35 @@
+// Example 1 — basic shortest paths and path reconstruction.
+//
+// Standalone: after `npm install bmssp` run `node 01-basic.mjs`.
+// The `bmssp` package is ESM-only; graphs are arrays of `[from, to, weight]`
+// edges with finite numeric node IDs and finite, non-negative weights.
+
+import { BMSSP } from "bmssp";
+
+export function run() {
+  // A tiny weighted digraph. The direct 0->2 edge (25) beats the
+  // two-hop 0->1->2 route (50 + 75 = 125).
+  const graph = new BMSSP([
+    [0, 1, 50],
+    [1, 2, 75],
+    [0, 2, 25],
+    [2, 3, 10],
+  ]);
+
+  graph.calculateShortestPaths(0);
+
+  console.log("Shortest distances from node 0:");
+  for (const [node, dist] of graph.shortestPaths) {
+    console.log(`  0 -> ${node}: ${dist}`);
+  }
+
+  console.log("\nReconstructed paths:");
+  for (const node of graph.nodeIDs) {
+    const path = graph.reconstructPath(node);
+    const shown = path.length ? path.join(" -> ") : "(unreachable)";
+    console.log(`  to ${node}: ${shown}`);
+  }
+}
+
+import { fileURLToPath } from "node:url";
+if (process.argv[1] === fileURLToPath(import.meta.url)) run();

--- a/examples/02-dijkstra-oracle.mjs
+++ b/examples/02-dijkstra-oracle.mjs
@@ -1,0 +1,50 @@
+// Example 2 — validate BMSSP against the exported Dijkstra oracle.
+//
+// The package also exports a reference `dijkstra`, the ground truth the
+// BMSSP test suite is checked against. Its signature is
+// `dijkstra(edges, nodeIDs, source)` and it returns a Map of distances.
+// Here we run both on the same graph and confirm every node matches.
+
+import { BMSSP, dijkstra } from "bmssp";
+
+export function run() {
+  const edges = [
+    [0, 1, 7],
+    [0, 2, 9],
+    [0, 5, 14],
+    [1, 2, 10],
+    [1, 3, 15],
+    [2, 3, 11],
+    [2, 5, 2],
+    [3, 4, 6],
+    [5, 4, 9],
+  ];
+  const source = 0;
+
+  const graph = new BMSSP(edges);
+  graph.calculateShortestPaths(source);
+
+  // The oracle takes the raw edge list and the node-ID set (both exposed
+  // on the BMSSP instance) plus the source.
+  const oracle = dijkstra(graph.graph, graph.nodeIDs, source);
+
+  console.log("node │ BMSSP │ Dijkstra │ match");
+  console.log("─────┼───────┼──────────┼──────");
+  let allMatch = true;
+  for (const node of [...graph.nodeIDs].sort((a, b) => a - b)) {
+    const b = graph.shortestPaths.get(node);
+    const d = oracle.get(node);
+    const ok = b === d;
+    allMatch &&= ok;
+    console.log(
+      `${String(node).padStart(4)} │ ${String(b).padStart(5)} │ ${String(d).padStart(8)} │ ${ok ? "✓" : "✗"}`,
+    );
+  }
+
+  console.log(
+    `\n${allMatch ? "✓ BMSSP matches the Dijkstra oracle on every node." : "✗ MISMATCH — this should never happen."}`,
+  );
+}
+
+import { fileURLToPath } from "node:url";
+if (process.argv[1] === fileURLToPath(import.meta.url)) run();

--- a/examples/03-constant-degree.mjs
+++ b/examples/03-constant-degree.mjs
@@ -1,0 +1,44 @@
+// Example 3 — the opt-in constant-degree transform.
+//
+// The paper's O(m·log^(2/3) n) bound assumes every vertex has in-degree and
+// out-degree <= 2. That preprocessing is NOT required for correctness here,
+// but it is available: `constantDegreeTransform` rewrites any graph into that
+// shape by splitting each vertex into a zero-weight cycle of "port" copies.
+// The rewrite is distance-preserving, so you run on the transformed graph and
+// fold the result back onto your original node IDs.
+
+import { BMSSP, constantDegreeTransform } from "bmssp";
+
+export function run() {
+  // Node 0 has out-degree 3 — above the paper's degree-2 assumption.
+  const original = [
+    [0, 1, 50],
+    [0, 2, 25],
+    [0, 3, 40],
+    [1, 2, 75],
+    [2, 3, 10],
+  ];
+
+  const t = constantDegreeTransform(original);
+
+  console.log(
+    `Original: ${new Set(original.flatMap((e) => [e[0], e[1]])).size} nodes, ${original.length} edges`,
+  );
+  console.log(
+    `Transformed: every vertex now has in/out-degree <= 2 (${t.edges.length} edges after splitting).`,
+  );
+
+  const g = new BMSSP(t.edges);
+  g.calculateShortestPaths(t.sourceCopy(0)); // start from a copy of node 0
+
+  // `collapse` folds transformed distances back onto original node IDs.
+  const distances = t.collapse(g.shortestPaths);
+
+  console.log("\nShortest distances from original node 0:");
+  for (const [node, dist] of [...distances].sort((a, b) => a[0] - b[0])) {
+    console.log(`  0 -> ${node}: ${dist}`);
+  }
+}
+
+import { fileURLToPath } from "node:url";
+if (process.argv[1] === fileURLToPath(import.meta.url)) run();

--- a/examples/04-larger-graph.mjs
+++ b/examples/04-larger-graph.mjs
@@ -1,0 +1,66 @@
+// Example 4 — a larger, programmatically generated graph.
+//
+// Builds an N x N grid of nodes wired to their right/down neighbours with
+// deterministic pseudo-random weights, then runs BMSSP from a corner and
+// cross-checks a few nodes against the Dijkstra oracle. Shows the API on
+// something bigger than a hand-drawn example, with a rough timing.
+
+import { BMSSP, dijkstra } from "bmssp";
+
+// Deterministic weight generator so the run is reproducible.
+function makeWeight(seed) {
+  let s = seed >>> 0;
+  return () => {
+    s = (s * 1664525 + 1013904223) >>> 0;
+    return 1 + (s % 100); // 1..100
+  };
+}
+
+function buildGrid(n) {
+  const nextWeight = makeWeight(12345);
+  const edges = [];
+  const id = (r, c) => r * n + c;
+  for (let r = 0; r < n; r++) {
+    for (let c = 0; c < n; c++) {
+      if (c + 1 < n) edges.push([id(r, c), id(r, c + 1), nextWeight()]);
+      if (r + 1 < n) edges.push([id(r, c), id(r + 1, c), nextWeight()]);
+    }
+  }
+  return edges;
+}
+
+export function run() {
+  const n = 40; // 1,600 nodes
+  const edges = buildGrid(n);
+
+  const graph = new BMSSP(edges);
+
+  const t0 = performance.now();
+  graph.calculateShortestPaths(0);
+  const ms = performance.now() - t0;
+
+  const corner = n * n - 1; // bottom-right node
+  console.log(
+    `Grid ${n}x${n}: ${graph.nodeIDs.size} nodes, ${edges.length} edges.`,
+  );
+  console.log(`BMSSP run: ${ms.toFixed(2)} ms.`);
+  console.log(
+    `Distance from top-left (0) to bottom-right (${corner}): ${graph.shortestPaths.get(corner)}`,
+  );
+  console.log(
+    `Path length (hops) to bottom-right: ${graph.reconstructPath(corner).length - 1}`,
+  );
+
+  // Spot-check against the oracle on a handful of nodes.
+  const oracle = dijkstra(graph.graph, graph.nodeIDs, 0);
+  const sample = [corner, Math.floor((n * n) / 2), n - 1, n * (n - 1)];
+  const allMatch = sample.every(
+    (node) => graph.shortestPaths.get(node) === oracle.get(node),
+  );
+  console.log(
+    `\n${allMatch ? "✓ Sampled nodes all match the Dijkstra oracle." : "✗ MISMATCH — this should never happen."}`,
+  );
+}
+
+import { fileURLToPath } from "node:url";
+if (process.argv[1] === fileURLToPath(import.meta.url)) run();

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,40 @@
+# bmssp examples
+
+A small gallery of standalone, copy-pasteable examples for the [`bmssp`](https://www.npmjs.com/package/bmssp)
+package. Each file imports from the published package (`import { … } from "bmssp"`),
+so after `npm install bmssp` you can run any of them directly:
+
+```bash
+node 01-basic.mjs
+```
+
+Or run the whole gallery at once (this is also the Docker image's default command):
+
+```bash
+node run-all.mjs
+```
+
+| File | Shows |
+| --- | --- |
+| [`01-basic.mjs`](01-basic.mjs) | `calculateShortestPaths()` and `reconstructPath()` on a tiny digraph |
+| [`02-dijkstra-oracle.mjs`](02-dijkstra-oracle.mjs) | Validating BMSSP against the exported reference `dijkstra` oracle |
+| [`03-constant-degree.mjs`](03-constant-degree.mjs) | The opt-in, distance-preserving `constantDegreeTransform` |
+| [`04-larger-graph.mjs`](04-larger-graph.mjs) | Building a larger grid graph programmatically and timing a run |
+| [`run-all.mjs`](run-all.mjs) | Runs every example above in order |
+
+## Running without installing (Docker)
+
+The published image bundles these examples in a pre-configured Node environment:
+
+```bash
+docker run --rm sirivasv/bmssp-js:latest          # runs run-all.mjs
+docker run --rm sirivasv/bmssp-js:latest node examples/01-basic.mjs
+```
+
+Mount your own script to run it in the same environment:
+
+```bash
+docker run --rm -v "$PWD/mine.mjs:/bmssp-js/mine.mjs" sirivasv/bmssp-js:latest node mine.mjs
+```
+
+See the [repository README](../README.md) for the full API reference.

--- a/examples/main.mjs
+++ b/examples/main.mjs
@@ -1,9 +1,0 @@
-import { BMSSP } from "bmssp";
-
-const myBMSSP = new BMSSP([
-  [0, 1, 50],
-  [1, 2, 75],
-  [0, 2, 25],
-]);
-
-console.log(myBMSSP.graph);

--- a/examples/run-all.mjs
+++ b/examples/run-all.mjs
@@ -1,0 +1,24 @@
+// Runs every example in order with a header between each. This is the
+// default command of the Docker image (`docker run … sirivasv/bmssp-js`),
+// and can be run directly after `npm install bmssp`: `node run-all.mjs`.
+
+import { run as basic } from "./01-basic.mjs";
+import { run as oracle } from "./02-dijkstra-oracle.mjs";
+import { run as constantDegree } from "./03-constant-degree.mjs";
+import { run as largerGraph } from "./04-larger-graph.mjs";
+
+const examples = [
+  ["01 · Basic shortest paths & path reconstruction", basic],
+  ["02 · Validate against the Dijkstra oracle", oracle],
+  ["03 · Opt-in constant-degree transform", constantDegree],
+  ["04 · A larger generated grid graph", largerGraph],
+];
+
+const rule = "─".repeat(64);
+for (const [title, fn] of examples) {
+  console.log(`\n${rule}\n  ${title}\n${rule}`);
+  fn();
+}
+console.log(
+  `\n${rule}\n  Done. Edit these files or mount your own — see the README.\n${rule}`,
+);


### PR DESCRIPTION
No linked issue — user-directed refresh of the `examples/` directory, the Dockerfile, and the README Docker instructions, which had gone stale.

## Problem

`examples/main.mjs` only did `console.log(myBMSSP.graph)` — it printed the raw edge list back and **never ran the algorithm**. The Docker image's `CMD` ran exactly that file, so `docker run … sirivasv/bmssp-js` showed a user nothing about BMSSP. The README's Docker section documented that stale behavior.

## Change

Replace the single trivial example with a standalone, copy-pasteable **gallery** that exercises the real public API. Each file imports from the **published** `bmssp` package (`import { … } from "bmssp"`), so a user can `npm install bmssp` and run any of them directly:

| File | Shows |
| --- | --- |
| `01-basic.mjs` | `calculateShortestPaths()` + `reconstructPath()` on a tiny digraph |
| `02-dijkstra-oracle.mjs` | validating BMSSP against the exported `dijkstra` oracle (per-node table) |
| `03-constant-degree.mjs` | the opt-in `constantDegreeTransform` (`sourceCopy`/`collapse`) |
| `04-larger-graph.mjs` | a generated 40×40 grid — timing + oracle spot-check |
| `run-all.mjs` | runs all four in order (the Docker image's default `CMD`) |
| `README.md` | gallery index + Docker run/override/mount recipes |

- **Dockerfile:** `COPY examples/` (whole dir), OCI image labels, `npm install --omit=dev`, and `CMD ["node", "examples/run-all.mjs"]` (was the trivial example).
- **README:** rewrote the "Using the Docker image" section — run the gallery, override with a single example, or volume-mount your own script.

## Verification

- `npm test` → 190 passed, 1 skipped; `npm run lint` clean.
- Built and ran the image with the local docker CLI (`--no-cache` rebuild): all four examples run green, every oracle check matches.
- Confirmed both documented override forms: `docker run … node examples/01-basic.mjs` and `docker run … -v "$PWD/mine.mjs:/bmssp-js/mine.mjs" … node mine.mjs`.
- No `src/`/`test/` change → **no version bump, no release**.

## Roadmap proposals

1. **Comment on #173** (Stabilize the public API surface): the new `examples/` gallery now exercises exactly the three public exports as a real consumer — point #173's migration note at `examples/` as the canonical runnable usage reference, and keep the gallery in lockstep with any 2.0.0 surface change.

(Only proposal — the PR is examples/docs/tooling and teaches nothing about the #172/#171 algorithm-surface work.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)