### PR TITLE
feat(#172): typed / flexible graph inputs — Graph builder + adjacency Map/object

### DIFF
--- a/.claude/knowledge/05-codebase-map.md
+++ b/.claude/knowledge/05-codebase-map.md
@@ -1,17 +1,16 @@
 # 05 — Codebase Map (current state)
 
-<!-- BOOKMARK-COMMIT: cbcaab1 -->
-<!-- PENDING-PR-BRANCH: chore/examples-docker-gallery -->
-<!-- Last validated: 2026-07-21 (Phase C of the examples/Docker PR, branch
-     chore/examples-docker-gallery, based on main cbcaab1). This PR rewrites the examples/
-     directory into a standalone gallery (01-basic, 02-dijkstra-oracle, 03-constant-degree,
-     04-larger-graph, run-all + README), modernizes the Dockerfile (COPY examples/ dir,
-     OCI labels, run-all as default CMD), and refreshes the README Docker section. No src/
-     test change; no version bump (docs/tooling, no bug fix, no milestone close). Verified
-     end-to-end inside Docker (docker build + run: all four examples + oracle checks pass;
-     single-example override and volume-mount forms confirmed). Not tied to a GitHub issue
-     (user-directed). Body describes post-merge reality; markers flip on the next session's
-     Phase A fast path. -->
+<!-- BOOKMARK-COMMIT: 50faa4a -->
+<!-- PENDING-PR-BRANCH: feat/172-typed-flexible-inputs -->
+<!-- Last validated: 2026-07-21 (Phase C of the #172 PR, branch
+     feat/172-typed-flexible-inputs, based on main 50faa4a). This PR adds typed/flexible
+     graph inputs (milestone 2.0.0, mid-milestone → no bump): new src/graph.mjs (`Graph`
+     builder + `normalizeGraphInput`), re-exported `Graph` from index.mjs, and a BMSSP
+     constructor that accepts an edge array (unchanged), an adjacency Map/object, or a
+     Graph — plus an explicit declarable vertex universe (isolated nodes). Node IDs stay
+     finite numbers; canonical [length, hops, id] tie-break order unchanged. Body describes
+     post-merge reality; markers fast-path on the next session's Phase A. Also folds in the
+     PR #207 marker flip (BOOKMARK 50faa4a) that had been left as a local bookkeeping edit. -->
 
 
 Snapshot of what exists in `bmssp-js` today, so you know what to build on vs. what's missing.
@@ -60,10 +59,15 @@ feature branch name. Step 2 above then fast-paths the post-merge session start.
 ## Layout
 
 ```
-index.mjs                 # re-exports { BMSSP }, { dijkstra } and { constantDegreeTransform },
-                          # each with public-API JSDoc (#166); internals stay unexported
+index.mjs                 # re-exports { BMSSP }, { dijkstra }, { constantDegreeTransform }
+                          # and { Graph } (#172), each with public-API JSDoc (#166);
+                          # algorithm internals stay unexported
 src/
-  bmssp.mjs               # BMSSP class — full Algorithm 3 recursion (#43); wires the pieces below
+  bmssp.mjs               # BMSSP class — full Algorithm 3 recursion (#43); wires the pieces below.
+                          #      Constructor accepts flexible inputs via normalizeGraphInput (#172)
+  graph.mjs               # #172: public `Graph` input builder (addVertex/addEdge, chainable) +
+                          #      normalizeGraphInput — edge array | adjacency Map/object | Graph →
+                          #      canonical { edges, vertices }; `vertices` = explicit vertex universe
   dijkstra.mjs            # reference Dijkstra (array binary-heap) — DONE, used as oracle
   constantDegree.mjs      # #164: opt-in constant-degree transform (in/out-degree ≤ 2); public, re-exported
   tieBreak.mjs            # #163: composite [length, hops, index] keys — Assumption 2.1 realized; since #205
@@ -82,6 +86,7 @@ test/
   edgeCases.test.mjs      # #162: 9 deterministic disconnection fixtures — isolated/sink sources, many components, source switching
   tieBreak.test.mjs       # #163: 16 tests — key order, canonical relaxEdge, edge-order determinism, strict Lemma 3.1, lex-oracle hops/preds
   constantDegree.test.mjs # #164: 11 tests — degree ≤ 2 on hand + seeded shapes (incl. star hub), distance preservation via oracle, BMSSP-on-transform, determinism, empty/validation
+  graph.test.mjs          # #172: 18 tests — Graph builder (chain/idempotent/copies/eager validation), adjacency Map/object inputs, object-key coercion, isolated vertices (empty & null neighbor lists, declared, as source), cross-shape oracle equivalence (seeded 2k), unrecognized-input + malformed-adjacency throws
   pathReconstruction.test.mjs # #169: 3 public-API tests — Dijkstra path oracle, unreachable/pre-run/source switching, target validation
   blockList.test.mjs      # #42: 25 BlockList tests incl. seeded random stress, #182 many-chunk/M=1 regression tests + #167 machinery tests
   boundIndex.test.mjs     # #167: 8 BoundIndex tests — sequence ops, monotone findFirst, AVL invariants under seeded churn
@@ -128,8 +133,11 @@ direct `git push origin main` is rejected, including for docs-only bookkeeping c
 
 ```js
 class BMSSP {
-  constructor(inputGraph)          // validates an array of [from, to, weight]: finite numeric
-                                   // node IDs, finite non-negative weights; [] remains valid
+  constructor(inputGraph)          // #172: normalizeGraphInput accepts an edge array,
+                                   // an adjacency Map/object, or a Graph builder → { edges,
+                                   // vertices }; validates edges (finite numeric node IDs,
+                                   // finite non-negative weights) + folds in declared
+                                   // vertices (isolated OK); [] / {} / empty Graph remain valid
   //   this.graph          : deep-copied edge array
   //   this.nodeIDs        : Set of all node IDs (from both endpoints)
   //   this.shortestPaths  : Map<nodeId, distance>, initialized to Infinity  ← public d̂[·]
@@ -161,11 +169,30 @@ class BMSSP {
 }
 ```
 
-**Constructor input validation (#165).** `inputGraph` must be an array; every entry must be
-an exact three-element `[from, to, weight]` array. Node IDs and weights must be finite
-numbers, and weights must be non-negative. Failures identify the offending edge index.
-An empty edge list remains valid and preserves the #162 contract: construction succeeds,
-then `calculateShortestPaths()` rejects any start node because the graph has no nodes.
+**Constructor input validation (#165, generalized by #172).** The constructor first calls
+`normalizeGraphInput` (`src/graph.mjs`) to reduce the input to `{ edges, vertices }`, then
+validates the edges: every entry must be an exact three-element `[from, to, weight]` array,
+node IDs and weights must be finite numbers, and weights non-negative — failures identify the
+offending edge index (unchanged messages). Declared `vertices` (the explicit universe from a
+`Graph`/adjacency form) must be finite numbers too. An empty graph in any form
+(`[]` / `{}` / `new Map()` / `new Graph()`) remains valid and preserves the #162 contract:
+construction succeeds, then `calculateShortestPaths()` rejects any start node because the
+graph has no nodes.
+
+**Flexible inputs (#172, `src/graph.mjs`).** `normalizeGraphInput(input)` recognizes four
+shapes and always yields `{ edges: [[from,to,weight]…], vertices: [id…] }`:
+- a **`Graph`** builder instance → `input.toNormalized()`;
+- an **edge array** → `{ edges: input, vertices: [] }` (nodes inferred from edges — exact
+  pre-#172 behavior);
+- an **adjacency `Map`** `Map<from, Iterable<[to,weight]>>` → keys declare the vertex
+  universe (a key with an empty/`null` list is an isolated vertex);
+- a **plain object** `{ from: [[to,weight]…] }` → same as Map, but string keys are coerced to
+  numbers (`Number(key)`; non-numeric keys fail the constructor's finite-vertex check).
+Only structural checks live in the normalizer; per-edge value validation stays in the
+constructor so the "Edge at index N" messages remain the single source of truth. Node-ID
+semantics are unchanged (finite numbers, indices assigned in ascending-id order), so the
+canonical `[length, hops, id]` tie-break and every oracle/determinism assertion are
+untouched — this is a **surface generalization, not an engine change**.
 
 **Dense-index engine (#205).** The algorithm no longer touches Maps in its hot path. The
 constructor assigns every node id a dense index **in ascending numeric id order**
@@ -480,6 +507,29 @@ calls it; BMSSP is correct on the untransformed graph. A caller opts in by trans
 graph, running from `sourceCopy(source)`, and `collapse()`-ing the result. Output is
 edge-order deterministic (copies allocated in edge order); ~2m copies, ~3m edges — O(m).
 
+## `src/graph.mjs` — flexible input builder + normalizer (#172)
+
+```js
+class Graph {                    // PUBLIC — re-exported from index.mjs (like constantDegree)
+  addVertex(id)                  // declare a vertex (isolated OK); finite-number; idempotent; → this
+  addEdge(from, to, weight)      // directed edge, endpoints auto-declared; validates eagerly; → this
+  hasVertex(id) / vertexCount / edgeCount
+  toNormalized()                 // → { edges: [[f,t,w]…] (copies), vertices: [id…] }
+}
+normalizeGraphInput(input)       // → { edges, vertices }; accepts Graph | edge array |
+                                 //   adjacency Map | plain object (numeric-string keys)
+export { Graph, normalizeGraphInput };  // Graph is public; normalizeGraphInput is used by
+                                 //   the BMSSP constructor (not re-exported from index.mjs)
+```
+
+The builder is the ergonomic front door: mutators chain
+(`new Graph().addEdge(0,1,50).addVertex(9)`), `addVertex` is the only way to introduce an
+isolated vertex, and both mutators validate at the call site (friendlier than the
+constructor's index-based errors). `toNormalized` deep-copies edges so mutating the builder
+after `new BMSSP(g)` can't reach the constructed graph. `normalizeGraphInput` is the shared
+reducer described in the BMSSP-class section above — the constructor's sole entry point for
+every accepted shape. See §"Flexible inputs (#172)" for the per-shape contract.
+
 ## Tests — the contract
 
 - `test/main.test.mjs` (16): constructor input-validation failures (#165), nodeIDs,
@@ -546,6 +596,14 @@ edge-order deterministic (copies allocated in edge order); ~2m copies, ~3m edges
   checked against an independent Dijkstra path oracle, including competing paths, an
   unreachable vertex, calls before a run, source switching on one instance, and rejection
   of a target that is not in the graph.
+- `test/graph.test.mjs` (18, #172): the flexible-input surface. `Graph` builder
+  (chaining, idempotent `addVertex`, endpoint auto-declare, `toNormalized` copy isolation,
+  eager id/weight validation); `new BMSSP` from an adjacency **object** and **Map** and a
+  **`Graph`** all equal the edge-array result; object string-keys coerce to numeric ids;
+  isolated vertices via empty/`null` neighbor lists and `addVertex` (present-but-∞, and
+  valid as a source reaching only itself); cross-shape **oracle equivalence** on a seeded
+  2k sparse graph; and the failure modes — unrecognized top-level input, malformed
+  adjacency entry, non-finite declared vertex, and the unchanged indexed edge-array messages.
 - `test/edgeCases.test.mjs` (9, #162): deterministic hand-built disconnection fixtures,
   each checked against a hand-computed full distance map **and** the Dijkstra oracle
   (Infinity entries included): self-loop-only source, sink source (adjacency keeps an
@@ -574,10 +632,11 @@ edge-order deterministic (copies allocated in edge order); ~2m copies, ~3m edges
   (identical maps incl. Infinity → 0; wrong/missing entries counted); `runScenarioBenchmark`
   and `runComparisonCountBenchmark` on tiny injected scenarios return the expected columns
   with **zero mismatches**.
-- Current suite: **191 tests — 190 passing + 1 XL skipped by default**, ~100% statement
-  coverage, ~7.5 s wall-clock (the #164 distance-preservation sweeps run BMSSP/Dijkstra
-  from every source). No graph data files: every generated test graph comes from a
-  seed; the #162 fixtures are hand-built and fully deterministic. The #205 dense-index
+- Current suite: **209 tests — 208 passing + 1 XL skipped by default** (#172 added the
+  18-test `graph.test.mjs`; `bmssp.mjs`, `index.mjs` and the new `graph.mjs` at 100%),
+  ~100% statement coverage, ~7.5 s wall-clock (the #164 distance-preservation sweeps run
+  BMSSP/Dijkstra from every source). No graph data files: every generated test graph comes
+  from a seed; the #162 fixtures are hand-built and fully deterministic. The #205 dense-index
   engine changed the internal function signatures (`baseCase`/`findPivots` take
   `labels`/`csr` + index sets) but not a single oracle/determinism assertion — the fuzz,
   edge-case, tie-break-determinism and constant-degree suites pass unchanged, which is
@@ -632,9 +691,11 @@ BMSSP-vs-Dijkstra head-to-head itself:
 | Exact Lemma 3.3 asymptotics (BST bound index + linear selection) | `src/boundIndex.mjs` + `src/select.mjs` + `src/blockList.mjs` | #167 | ✅ merged (PR #202, no bump) |
 | Relaxation micro-optimizations (allocation-free relaxEdge, unpacked routing, heap measurement) | `src/tieBreak.mjs` + `src/bmssp.mjs` + `src/baseCase.mjs` + `src/findPivots.mjs` | #168 | ✅ merged (PR #203, **minor → 1.2.0**, released 2026-07-21) |
 | Dense-index core: typed-array labels + CSR adjacency | `src/tieBreak.mjs` (makeLabels) + `src/bmssp.mjs` (buildIndex/CSR) + `src/baseCase.mjs` + `src/findPivots.mjs` | #205 | ✅ merged (PR #206, no bump — API-non-breaking) |
+| Typed / flexible graph inputs (Graph builder + adjacency Map/object + explicit vertex universe) | `src/graph.mjs` (new) + `src/bmssp.mjs` (constructor) + `index.mjs` (Graph export) + `test/graph.test.mjs` | #172 | ✅ done-pending-merge (this PR, no bump — mid-2.0.0) |
 
 Milestones `1.1.0` (correctness hardening) and `1.2.0` (performance & ergonomics) are
 both **closed** — 1.2.0 released 2026-07-21 (npm + Docker Hub). Milestone `2.0.0`
-(API-breaking generalization) is current: **#205** (dense-index core) merged (PR #206,
-no bump), then **#172 → #171 → #173** (build order in `06`; #172 is next, #173 closes the
-milestone with the **major → 2.0.0** bump). See [06-milestones-roadmap.md](06-milestones-roadmap.md).
+(API-breaking generalization) is current: **#205** (dense-index core) merged (PR #206) and
+**#172** (typed/flexible inputs) done-pending-merge (this PR, no bump), leaving
+**#171 → #173** (build order in `06`; #171 next, #173 closes the milestone with the
+**major → 2.0.0** bump). See [06-milestones-roadmap.md](06-milestones-roadmap.md).

--- a/.claude/knowledge/06-milestones-roadmap.md
+++ b/.claude/knowledge/06-milestones-roadmap.md
@@ -1,7 +1,8 @@
 # 06 — Milestones Roadmap
 
-<!-- SYNCED-FROM-GITHUB: 2026-07-21 Phase E of the #205 PR (PR #206 merged as cbcaab1):
-     1.2.0 CLOSED; 2.0.0 open with 3 open issues #171/#172/#173 (#205 closed) — #172 next -->
+<!-- SYNCED-FROM-GITHUB: 2026-07-21 (RKB at start of the #172 session): 1.2.0 CLOSED; 2.0.0
+     open, 1 closed (#205) + 3 open (#171/#172/#173). #172 is done-pending-merge on branch
+     feat/172-typed-flexible-inputs (not yet closed on GitHub — Phase E) → #171 next -->
 <!-- Current package version: 1.2.0 — released 2026-07-21 (tag + GitHub Release with
      Announcements discussion → npm + Docker Hub via publish.yml); tag matches -->
 <!-- Release-discussion convention (user-directed 2026-07-21): every GitHub Release also
@@ -42,18 +43,33 @@ it runs the same Phase C reconciliation directly on `main`.
 
 ## 📋 Roadmap proposals (pending user approval)
 
-**From the examples/Docker PR (`chore/examples-docker-gallery`, no issue, no bump):**
+**From the #172 PR (`feat/172-typed-flexible-inputs`, no issue-close beyond #172, no bump):**
 
-1. **Comment on #173** (Stabilize the public API surface) — the new `examples/` gallery
-   now exercises exactly the three public exports (`BMSSP`, `dijkstra`,
-   `constantDegreeTransform`) as a real consumer, importing from the published package.
-   When #173 writes the migration note / public-surface decision, point it at
-   `examples/` as the canonical, runnable usage reference (and keep the gallery in lockstep
-   with any 2.0.0 surface change). _Rationale: the examples are now the de-facto public-API
-   contract users copy from; #173 should own keeping them honest._
+1. **Comment on #172 before closing it** — record what shipped vs. deferred: the flexible
+   input *surface* (`Graph` builder + adjacency Map/object + explicit vertex universe) is
+   done, but the #206-comment's "construct straight into index+CSR without the
+   `[from,to,weight]` round-trip" perf lever was **not** taken, because `this.graph` /
+   `this.adjacency` are public tested fields the constructor must populate anyway. That
+   construction-perf optimization is coupled to whether those fields stay public → carry it
+   into #173. _Rationale: keeps the issue's history honest about the scope call and prevents
+   a future reader assuming direct-CSR construction landed here._
 
-_(These are the only proposals; the PR touches examples/docs/tooling only, so it teaches
-nothing about the #172/#171 algorithm-surface work.)_
+2. **Comment on #173** (Stabilize the public API surface) — add two concrete decisions this
+   PR surfaces: (a) whether `this.graph` / `this.adjacency` stay public (if they go, the
+   constructor can build CSR directly from normalized input — the deferred #172 perf lever);
+   and (b) document the new `Graph` / adjacency-input surface + the numeric-string object-key
+   coercion rule in the 1.0→2.0 migration note, and mirror a `Graph`-builder example into the
+   `examples/` gallery (which #173 already owns per the PR #207 proposal). _Rationale: #173 is
+   the natural home for the public/private field decision the input work depends on._
+
+_(No proposal on #171 beyond the existing build order: #172's normalization + explicit
+vertex-set API is exactly the substrate #171's public multi-source entrypoint will consume,
+which the current #171 notes already anticipate.)_
+
+_(The examples/Docker-PR proposal (PR #207) — comment on **#173** pointing its migration
+note / public-surface decision at the new `examples/` gallery as the canonical runnable
+public-API reference, and keeping the gallery in lockstep with any 2.0.0 surface change —
+was approved and executed 2026-07-21: comment posted on #173.)_
 
 _(The #205-PR proposals — engine-baseline comment on **#172** (class now holds the graph
 as index+CSR + typed labels; typed inputs should ingest straight into it and expose an
@@ -221,7 +237,25 @@ executed 2026-07-17.)_
   unit tests rewritten to drive the index API); 100% statement coverage, lint clean,
   FUZZ_ROUNDS=25 + FUZZ_XL green. Phase E: engine-baseline comment posted on #172; the
   build-order confirmation needed no GitHub write. **#172 is next.**
-- **Examples + Docker refresh (branch `chore/examples-docker-gallery`, 2026-07-21;
+- **#172 done-pending-merge (branch `feat/172-typed-flexible-inputs`, 2026-07-21; no
+  bump — mid-2.0.0):** typed / flexible graph inputs. New `src/graph.mjs` exports a
+  chainable **`Graph`** builder (`addVertex`/`addEdge`, isolated-vertex declaration) and
+  `normalizeGraphInput`; the BMSSP constructor now accepts an **edge array** (unchanged),
+  an **adjacency `Map`**, a **plain adjacency object** (`{ from: [[to,weight]…] }`,
+  numeric-string keys coerced), or a **`Graph`** — all reduced to `{ edges, vertices }`,
+  with `vertices` the explicit declarable universe (isolated nodes get an index, an empty
+  CSR range, an ∞ estimate, and are valid as a source). `Graph` re-exported from
+  `index.mjs` (now four public exports). Node-ID semantics unchanged (finite numbers,
+  ascending-id indices) → canonical `[length, hops, id]` tie-break and every
+  oracle/determinism assertion untouched; 18-test `graph.test.mjs` (cross-shape oracle
+  equivalence on seeded 2k + all failure modes), suite 209 (208 + 1 XL skip), `graph.mjs`
+  100%, lint clean. **Scope boundary (flag for review):** this delivers the flexible-input
+  *surface* but keeps the internal edge-list round-trip — the #206 comment's "construct
+  straight into CSR without the `[from,to,weight]` array" perf lever was **deferred**,
+  because `this.graph` (and `this.adjacency`) are public, tested fields that must be
+  populated regardless; removing them to build CSR directly is a breaking change better
+  owned by **#173** (API stabilization). See Roadmap proposals.
+- **Examples + Docker refresh (PR #207 merged, 2026-07-21, commit 50faa4a;
   user-directed, no issue, no bump):** the stale single `examples/main.mjs` (it only
   printed the raw edge list — never ran the algorithm) is replaced by a standalone gallery
   — `01-basic` (calculateShortestPaths + reconstructPath), `02-dijkstra-oracle` (per-node
@@ -299,19 +333,19 @@ _Note:_ both #182 shapes stay as regression sentinels in every `npm run bench` (
 ## Milestone `2.0.0` (milestone #4) — API-breaking generalization — CURRENT
 
 Build order (derived 2026-07-21 at RKB, after 1.2.0 closed): ~~#205~~
-(merged, PR #206) → **#172 → #171 → #173**. Rationale: the dense-index engine
-(#205) decides the internal shapes every new API wraps, so it went first — the
-alternatives would build #171/#172 on the Map core and rebuild them; typed inputs (#172)
-then feed CSR directly; the public multi-source entrypoint (#171) is designed
-value-in/value-out over the finished engine; and stabilization (#173) locks the surface
-last and takes the **major → 2.0.0** bump as the milestone-closing PR.
+(merged, PR #206) → ~~#172~~ (done-pending-merge, this PR) → **#171 → #173**. Rationale:
+the dense-index engine (#205) decides the internal shapes every new API wraps, so it went
+first; typed/flexible inputs (#172) generalized the constructor surface over it; the public
+multi-source entrypoint (#171) is designed value-in/value-out over the finished engine and
+reuses #172's normalization + explicit vertex-set substrate; and stabilization (#173) locks
+the surface last and takes the **major → 2.0.0** bump as the milestone-closing PR.
 
 | # | Issue | Labels | Notes |
 |---|---|---|---|
 | 205 | Dense-index core: typed-array labels + CSR adjacency | enhancement | ✅ merged (PR #206, no bump — API-non-breaking): sorted-id index + CSR + typed labels; wall-clock ~halved (sparse head-to-head 2.5× → 1.38×), counts unchanged |
-| 172 | Typed / flexible graph inputs | enhancement · help wanted | **NEXT** — after #205 builder forms ingest straight into index+CSR (`this.csr`) + expose an explicit vertex-set API; the main remaining constant-factor lever (baseline comment posted 2026-07-21) |
-| 171 | Public multi-source / bounded BMSSP entrypoint | enhancement · help wanted | value-in/value-out API over the dense engine; #205 kept the id-based `bmssp(l,B,S)` wrapper, so this is surface design |
-| 173 | Stabilize the public API surface for 1.0 → 2.0 | documentation · enhancement | milestone-closing: per-module public/private decision, migration note, **major → 2.0.0** |
+| 172 | Typed / flexible graph inputs | enhancement · help wanted | ✅ done-pending-merge (this PR, no bump): `Graph` builder + adjacency Map/object inputs + explicit declarable vertex universe, reduced via `normalizeGraphInput`; node-ID semantics unchanged. Deferred the direct-CSR construction perf lever to #173 (coupled to public `this.graph`) — see Roadmap proposals |
+| 171 | Public multi-source / bounded BMSSP entrypoint | enhancement · help wanted | **NEXT** — value-in/value-out API over the dense engine; #205 kept the id-based `bmssp(l,B,S)` wrapper and #172 added the input normalization + vertex-set substrate it consumes, so this is surface design |
+| 173 | Stabilize the public API surface for 1.0 → 2.0 | documentation · enhancement | milestone-closing: per-module public/private decision (incl. whether `this.graph`/`this.adjacency` stay public — the deferred #172 direct-CSR lever), migration note + `Graph` example, **major → 2.0.0** |
 
 _Note after #43:_ `bmssp(l, B, S)` already **is** a bounded multi-source call internally —
 #171 is mostly about designing the public API around it (initial per-source distances,

--- a/.claude/knowledge/07-glossary.md
+++ b/.claude/knowledge/07-glossary.md
@@ -1,9 +1,10 @@
 # 07 — Glossary
 
-<!-- Updated on: 2026-07-21 (#205 PR: dense-index engine — makeLabels, labelKey, CSR,
-     dense index, buildIndex, syncLabelsIn/Out, boundToEngine/keyToPublic, bmsspIndex;
-     NO_PRED now -1; relaxEdge/baseCase/findPivots entries updated to the typed-array
-     signature. Previous update the same day: #168 PR added compareKeyParts + RELAX_*) -->
+<!-- Updated on: 2026-07-21 (#172 PR: flexible inputs — Graph builder, normalizeGraphInput,
+     explicit vertex universe; four public exports now. Previous update the same day:
+     #205 PR dense-index engine — makeLabels, labelKey, CSR, dense index, buildIndex,
+     syncLabelsIn/Out, boundToEngine/keyToPublic, bmsspIndex; NO_PRED now -1;
+     relaxEdge/baseCase/findPivots typed-array signatures; #168 compareKeyParts + RELAX_*) -->
 
 > **Lifecycle: dynamic — updated in Phase C of every PR.** When a PR introduces new symbols
 > or terms (module names, data-structure fields, paper notation newly used in code), add
@@ -89,6 +90,29 @@ Quick lookup for the symbols and terms used across the paper, the notes, and the
   IDs (min over a vertex's copies). **Public** — re-exported from `index.mjs` (unlike the
   algorithm-internal modules). Correctness-independent: BMSSP never calls it. Usage:
   `const t = constantDegreeTransform(g); …run from t.sourceCopy(s)…; t.collapse(dist)`.
+- **`Graph`** (#172) — `src/graph.mjs`, a small mutable input builder. **Public** —
+  re-exported from `index.mjs`. `addVertex(id)` declares a vertex (the only way to add an
+  **isolated** one; idempotent), `addEdge(from, to, weight)` adds a directed edge and
+  auto-declares its endpoints; both validate eagerly (finite numeric IDs, finite
+  non-negative weights) and return `this` so calls chain. `hasVertex`/`vertexCount`/
+  `edgeCount` introspect; `toNormalized()` → `{ edges, vertices }` (deep-copied edges, so
+  later mutation can't reach a constructed graph). Hand it straight to `new BMSSP(g)`.
+- **`normalizeGraphInput(input)`** (#172) — `src/graph.mjs`, the shared reducer the BMSSP
+  constructor calls on every input: a `Graph`, an edge array, an adjacency
+  `Map<from, Iterable<[to,weight]>>`, or a plain object `{ from: [[to,weight]…] }`
+  (numeric-string keys coerced via `Number`). Always returns
+  `{ edges: [[f,t,w]…], vertices: [id…] }`; `vertices` is the **explicit vertex universe**
+  (declared nodes incl. isolated — an adjacency key with an empty/`null` list). Only
+  structural checks live here; per-edge value validation stays in the constructor (the
+  "Edge at index N" messages). **Not** re-exported from `index.mjs` (only `Graph` is public).
+  An edge-array input yields empty `vertices`, reproducing the pre-#172 "infer nodes from
+  edges" behavior exactly.
+- **explicit vertex universe** (#172) — the set of nodes a caller *declares*, as opposed to
+  the set *inferred* from edge endpoints. Before #172 the vertex set was always inferred; a
+  `Graph` (`addVertex`) or an adjacency form (a key with no neighbors) can now declare
+  **isolated** vertices, which flow through to `nodeIDs` and get an index, an empty CSR
+  range, an empty adjacency list, an ∞ estimate, and are valid as a `calculateShortestPaths`
+  source (reaching only themselves).
 - **`adjacency`** (#45) — `Map<nodeId, Array<[to, weight]>>` field on the `BMSSP` class:
   a node's outgoing edges. Since #205 this is the **public edge view** behind `getEdges`
   (and the fair-baseline Dijkstra in the benchmarks); the algorithm's hot path uses the
@@ -338,7 +362,10 @@ Quick lookup for the symbols and terms used across the paper, the notes, and the
   known behavior, constant-factor work tracked in #168. Both shapes stay as regression
   sentinels in every `npm run bench` (`star`, `sparse-random-l4`).
 - **Docs page (#166)** — `docs/index.html`, the GitHub-Pages-published public-API reference
-  (deployed by `static.yml` on `docs/**` changes). Documents exactly the three `index.mjs`
+  (deployed by `static.yml` on `docs/**` changes). Documents the `index.mjs`
   exports — `BMSSP` (constructor contract, `calculateShortestPaths`, `reconstructPath`),
   `dijkstra`, `constantDegreeTransform` — and explicitly keeps algorithm internals out.
-  Static, dependency-free HTML.
+  Static, dependency-free HTML. **Note:** the #172 `Graph` export + flexible-input surface
+  is **not yet on this page** — it reaches npm only with the 2.0.0 release, and the docs
+  pass is folded into #173 (migration note + public-surface doc); tracked in the #172
+  Roadmap proposals.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ with every building block shipped, tested, and released individually:
 | Exact Lemma 3.3 asymptotics: balanced-BST bound index + linear-time selection ([#167](https://github.com/Sirivasv/bmssp-js/issues/167)) | `src/boundIndex.mjs` + `src/select.mjs` | ✅ done |
 | Relaxation micro-optimizations: allocation-free hot loops, −13–23% wall-clock ([#168](https://github.com/Sirivasv/bmssp-js/issues/168)) | `src/tieBreak.mjs` + the algorithm modules | ✅ done — **1.2.0** |
 | Dense-index core: typed-array labels + CSR adjacency, ~½ the wall-clock ([#205](https://github.com/Sirivasv/bmssp-js/issues/205)) | `src/bmssp.mjs` (CSR) + `src/tieBreak.mjs` (typed labels) | ✅ done |
+| Typed / flexible graph inputs: `Graph` builder + adjacency Map/object + explicit vertex universe ([#172](https://github.com/Sirivasv/bmssp-js/issues/172)) | `src/graph.mjs` + `BMSSP` constructor | ✅ done |
 
 > **Honest note:** the paper's win is asymptotic, and this repo optimizes for correctness
 > and readability first — but the constant factors have come down a lot. Measured
@@ -118,6 +119,35 @@ when the target is unreachable (or before any run) and throws for a node outside
 A reference `dijkstra` implementation is also exported. See the `examples/` directory for
 more, or the [public API reference](https://sirivasv.github.io/bmssp-js/) for the complete
 documented surface.
+
+### Flexible graph inputs
+
+The constructor also accepts an **adjacency map/object** or a small **`Graph` builder** — all
+equivalent to the edge-array form (node IDs stay finite numbers). The builder is also the way
+to declare an **isolated vertex** (one with no incident edges), which the plain edge list
+can't express:
+
+```javascript
+import { BMSSP, Graph } from "bmssp";
+
+// Adjacency object ({ from: [[to, weight], ...] }) or a Map with the same shape:
+new BMSSP({ 0: [[1, 50], [2, 25]], 1: [[2, 75]] });
+
+// Or the chainable builder — addVertex declares nodes (incl. isolated ones):
+const g = new Graph()
+  .addEdge(0, 1, 50)
+  .addEdge(0, 2, 25)
+  .addEdge(1, 2, 75)
+  .addVertex(9); // an isolated vertex: present, but unreachable (Infinity)
+
+const graph = new BMSSP(g);
+graph.calculateShortestPaths(0);
+console.log(graph.shortestPaths.get(2)); // 25
+console.log(graph.shortestPaths.get(9)); // Infinity
+```
+
+(Plain-object keys are strings in JavaScript, so the object form coerces them to numbers;
+use a `Map` or the `Graph` builder if you want to keep numeric keys explicit.)
 
 ### Optional: constant-degree transform
 
@@ -202,7 +232,7 @@ graphs in a few seconds), and set `FUZZ_XL=1` for an additional 2-million-node r
 | [`1.0.0`](https://github.com/Sirivasv/bmssp-js/milestones) | First end-to-end functional BMSSP (issues #40–#45) | ✅ done |
 | `1.1.0` | Correctness hardening — fuzz tests, edge cases, tie-breaking, input validation, constant-degree transform, API docs | ✅ done |
 | `1.2.0` | Performance & ergonomics — exact Lemma 3.3 asymptotics, BMSSP-vs-Dijkstra benchmarks, cliff investigation, relaxation micro-optimizations | ✅ done |
-| `2.0.0` | API generalization — dense-index engine (done), typed/flexible inputs, public multi-source/bounded entry point | 🔨 current |
+| `2.0.0` | API generalization — dense-index engine (done), typed/flexible inputs (done), public multi-source/bounded entry point | 🔨 current |
 
 ## Contributing (humans and AI agents welcome)
 

--- a/index.mjs
+++ b/index.mjs
@@ -1,22 +1,32 @@
-// Public API of the `bmssp` package (ESM-only). Exactly three exports:
-// the BMSSP class, the reference `dijkstra`, and the opt-in
-// `constantDegreeTransform`. Algorithm-internal modules (the block list,
-// the indexed heap, BaseCase, FindPivots, the tie-break helpers) are
-// deliberately NOT re-exported — they are implementation details of the
-// recursion, not supported public API.
+// Public API of the `bmssp` package (ESM-only). Four exports: the BMSSP
+// class, the reference `dijkstra`, the opt-in `constantDegreeTransform`, and
+// the `Graph` input builder. Algorithm-internal modules (the block list, the
+// indexed heap, BaseCase, FindPivots, the tie-break helpers) are deliberately
+// NOT re-exported — they are implementation details of the recursion, not
+// supported public API.
 
 /**
  * BMSSP — the paper's Algorithm 3 behind a small class API.
  *
- * `new BMSSP(graph)` takes an array of `[from, to, weight]` edges with
- * finite numeric node IDs and finite, non-negative weights (an empty array
- * is valid; malformed edges throw with the offending index).
+ * `new BMSSP(graph)` accepts any of the #172 input shapes: an array of
+ * `[from, to, weight]` edges, an adjacency `Map`/object
+ * (`{ from: [[to, weight], ...] }`), or a `Graph` builder instance. Node IDs
+ * must be finite numbers and weights finite and non-negative; an empty graph
+ * is valid and malformed edges throw with the offending index.
  * `calculateShortestPaths(source)` computes canonical distances into the
  * `shortestPaths` Map (`Infinity` for unreachable nodes), and
  * `reconstructPath(target)` returns the canonical shortest path as an
  * array of node IDs. Full JSDoc lives on the class in `src/bmssp.mjs`.
  */
 export { BMSSP } from "./src/bmssp.mjs";
+
+/**
+ * Graph — a small mutable input builder (#172). Declare vertices (including
+ * isolated ones via `addVertex`) and directed weighted edges (`addEdge`),
+ * then pass the instance to `new BMSSP(graph)`. Mutators chain
+ * (`new Graph().addEdge(0, 1, 50).addVertex(9)`). See `src/graph.mjs`.
+ */
+export { Graph } from "./src/graph.mjs";
 
 /**
  * Reference Dijkstra implementation — the oracle the BMSSP test suite is

--- a/src/bmssp.mjs
+++ b/src/bmssp.mjs
@@ -1,6 +1,7 @@
 import { baseCase } from "./baseCase.mjs";
 import { findPivots } from "./findPivots.mjs";
 import { BlockList } from "./blockList.mjs";
+import { normalizeGraphInput } from "./graph.mjs";
 import {
   compareKeys,
   compareKeyParts,
@@ -15,9 +16,14 @@ import {
 
 class BMSSP {
   constructor(inputGraph) {
-    if (!Array.isArray(inputGraph)) {
-      throw new Error("Input graph must be an array of edges");
-    }
+    // #172: accept several input shapes (edge array, adjacency map/object, or
+    // a Graph builder) and reduce them to a canonical { edges, vertices }.
+    // `vertices` is the EXPLICIT vertex universe — declared nodes, including
+    // isolated ones; edge endpoints are folded in below. An edge-array input
+    // yields an empty `vertices`, reproducing the pre-#172 "infer from edges"
+    // behavior exactly.
+    const { edges: inputEdges, vertices: declaredVertices } =
+      normalizeGraphInput(inputGraph);
 
     // Main graph represented as an array of edges
     this.graph = [];
@@ -38,7 +44,7 @@ class BMSSP {
     this.preds = new Map();
     this.ties = makeTies(this.hops, this.preds);
 
-    for (let [index, edge] of inputGraph.entries()) {
+    for (let [index, edge] of inputEdges.entries()) {
       if (!Array.isArray(edge) || edge.length !== 3) {
         throw new Error(`Edge at index ${index} must be [from, to, weight]`);
       }
@@ -59,6 +65,17 @@ class BMSSP {
       // Add node IDs to the set
       this.nodeIDs.add(edge[0]);
       this.nodeIDs.add(edge[1]);
+    }
+
+    // #172: fold in explicitly declared vertices (isolated nodes included).
+    // Same finiteness contract as edge endpoints; buildIndex/buildAdjacency
+    // then give every declared node an index, an empty CSR range and an
+    // empty neighbor list.
+    for (const id of declaredVertices) {
+      if (!Number.isFinite(id)) {
+        throw new Error("Declared vertex IDs must be finite numbers");
+      }
+      this.nodeIDs.add(id);
     }
 
     // Build the adjacency map from the copied edges

--- a/src/graph.mjs
+++ b/src/graph.mjs
@@ -1,0 +1,174 @@
+// #172 — typed / flexible graph inputs.
+//
+// A small builder (`Graph`) plus a normalizer (`normalizeGraphInput`) that
+// lets the BMSSP constructor accept several input shapes and reduce them to
+// one canonical internal form: `{ edges: [[from, to, weight], ...],
+// vertices: [id, ...] }`.
+//
+// `vertices` carries the EXPLICIT vertex universe — every node the caller
+// declared, including isolated ones with no incident edges. Edge endpoints
+// are still folded in by the BMSSP constructor, so an empty `vertices`
+// (the plain edge-list form) reproduces the pre-#172 "infer nodes from
+// edges" behavior exactly.
+//
+// Node-ID semantics are unchanged from earlier versions: IDs are finite
+// numbers. Value validation (finite IDs, finite non-negative weights) with
+// the "Edge at index N" messages stays in the BMSSP constructor so there is
+// a single source of truth; the pieces here validate only what they must to
+// build a well-formed normalized shape (and the builder validates eagerly at
+// the call site for a friendlier failure).
+
+/**
+ * A tiny mutable graph builder. Declare vertices (including isolated ones)
+ * and directed weighted edges, then hand the instance straight to
+ * `new BMSSP(graph)`.
+ *
+ * All mutators return `this`, so calls chain:
+ * `new Graph().addEdge(0, 1, 50).addEdge(1, 2, 75).addVertex(9)`.
+ *
+ * Node IDs must be finite numbers and weights finite and non-negative — the
+ * same contract the edge-array form has always enforced.
+ */
+class Graph {
+  constructor() {
+    // Declared vertex universe (numbers). addEdge folds in its endpoints too.
+    this._vertices = new Set();
+    // Declared directed edges as [from, to, weight] triples.
+    this._edges = [];
+  }
+
+  /**
+   * Declare a vertex. Safe to call for a node that already exists (idempotent)
+   * and the only way to introduce an isolated vertex (one with no edges).
+   * @param {number} id finite node ID
+   * @returns {Graph} this
+   */
+  addVertex(id) {
+    if (!Number.isFinite(id)) {
+      throw new Error("Graph.addVertex: node id must be a finite number");
+    }
+    this._vertices.add(id);
+    return this;
+  }
+
+  /**
+   * Add a directed edge `from -> to` of the given weight. Both endpoints are
+   * declared automatically.
+   * @param {number} from finite source node ID
+   * @param {number} to finite target node ID
+   * @param {number} weight finite, non-negative edge weight
+   * @returns {Graph} this
+   */
+  addEdge(from, to, weight) {
+    if (!Number.isFinite(from) || !Number.isFinite(to)) {
+      throw new Error("Graph.addEdge: node ids must be finite numbers");
+    }
+    if (!Number.isFinite(weight) || weight < 0) {
+      throw new Error(
+        "Graph.addEdge: weight must be a finite, non-negative number",
+      );
+    }
+    this._vertices.add(from);
+    this._vertices.add(to);
+    this._edges.push([from, to, weight]);
+    return this;
+  }
+
+  /** @param {number} id @returns {boolean} whether the vertex is declared */
+  hasVertex(id) {
+    return this._vertices.has(id);
+  }
+
+  /** @returns {number} number of declared vertices */
+  get vertexCount() {
+    return this._vertices.size;
+  }
+
+  /** @returns {number} number of declared edges */
+  get edgeCount() {
+    return this._edges.length;
+  }
+
+  /**
+   * The canonical normalized form the BMSSP constructor consumes. Returns
+   * fresh copies so later mutation of this builder cannot affect a graph
+   * already constructed from it.
+   * @returns {{ edges: number[][], vertices: number[] }}
+   */
+  toNormalized() {
+    return {
+      edges: this._edges.map((edge) => [...edge]),
+      vertices: [...this._vertices],
+    };
+  }
+}
+
+function isIterable(value) {
+  return value != null && typeof value[Symbol.iterator] === "function";
+}
+
+/**
+ * Reduce an adjacency form to `{ edges, vertices }`. Each entry maps a source
+ * node to an iterable of `[to, weight]` pairs; the source is always declared
+ * (so a node with an empty/absent neighbor list becomes an isolated vertex).
+ * When `coerceKeys` is set (plain-object form, whose keys are strings), the
+ * source key is converted to a number — finiteness is then checked by the
+ * BMSSP constructor's vertex validation.
+ */
+function adjacencyToNormalized(entries, coerceKeys) {
+  const edges = [];
+  const vertices = [];
+  for (const [rawFrom, neighbors] of entries) {
+    const from = coerceKeys ? Number(rawFrom) : rawFrom;
+    vertices.push(from);
+    if (neighbors == null) continue;
+    if (!isIterable(neighbors)) {
+      throw new Error(
+        `Adjacency list for node ${rawFrom} must be an iterable of [to, weight]`,
+      );
+    }
+    for (const pair of neighbors) {
+      if (!Array.isArray(pair) || pair.length !== 2) {
+        throw new Error(
+          `Adjacency entry for node ${rawFrom} must be [to, weight]`,
+        );
+      }
+      edges.push([from, pair[0], pair[1]]);
+    }
+  }
+  return { edges, vertices };
+}
+
+/**
+ * Normalize any accepted graph input into `{ edges, vertices }`:
+ * - a `Graph` builder instance,
+ * - an edge array `[[from, to, weight], ...]` (vertices inferred from edges),
+ * - an adjacency `Map<from, Iterable<[to, weight]>>`, or
+ * - a plain adjacency object `{ from: [[to, weight], ...] }` (numeric-string
+ *   keys, coerced to numbers).
+ *
+ * Only structural checks live here; per-edge value validation stays in the
+ * BMSSP constructor so its "Edge at index N" messages remain the single
+ * source of truth.
+ * @param {*} input
+ * @returns {{ edges: number[][], vertices: number[] }}
+ */
+function normalizeGraphInput(input) {
+  if (input instanceof Graph) {
+    return input.toNormalized();
+  }
+  if (Array.isArray(input)) {
+    return { edges: input, vertices: [] };
+  }
+  if (input instanceof Map) {
+    return adjacencyToNormalized(input.entries(), false);
+  }
+  if (input !== null && typeof input === "object") {
+    return adjacencyToNormalized(Object.entries(input), true);
+  }
+  throw new Error(
+    "Input graph must be an edge array, an adjacency map/object, or a Graph instance",
+  );
+}
+
+export { Graph, normalizeGraphInput };

--- a/test/graph.test.mjs
+++ b/test/graph.test.mjs
@@ -1,0 +1,213 @@
+import { describe, test, expect } from "@jest/globals";
+import { BMSSP, Graph, dijkstra } from "../index.mjs";
+import { sparseRandom } from "../benchmarks/generators.mjs";
+
+// #172 — typed / flexible graph inputs. The BMSSP constructor now accepts an
+// edge array (unchanged), an adjacency Map/object, or a Graph builder, and
+// callers can declare an explicit vertex universe including isolated nodes.
+// The correctness contract is unchanged: whatever the input shape, distances
+// must equal the Dijkstra oracle over the same logical graph.
+
+const EDGES = [
+  [0, 1, 7],
+  [0, 2, 9],
+  [0, 5, 14],
+  [1, 2, 10],
+  [1, 3, 15],
+  [2, 3, 11],
+  [2, 5, 2],
+  [3, 4, 6],
+  [5, 4, 9],
+];
+
+function distancesFromEdges(edges, source) {
+  const bmssp = new BMSSP(edges);
+  bmssp.calculateShortestPaths(source);
+  return new Map(bmssp.shortestPaths);
+}
+
+describe("Graph builder", () => {
+  test("addEdge / addVertex chain and count declared elements", () => {
+    const g = new Graph().addEdge(0, 1, 50).addEdge(1, 2, 75).addVertex(9);
+    expect(g.edgeCount).toBe(2);
+    expect(g.vertexCount).toBe(4); // 0, 1, 2, 9
+    expect(g.hasVertex(9)).toBe(true);
+    expect(g.hasVertex(7)).toBe(false);
+  });
+
+  test("addVertex is idempotent and addEdge auto-declares endpoints", () => {
+    const g = new Graph();
+    g.addVertex(3);
+    g.addVertex(3);
+    g.addEdge(3, 4, 1);
+    expect(g.vertexCount).toBe(2); // 3, 4
+    expect(g.hasVertex(4)).toBe(true);
+  });
+
+  test("toNormalized returns copies decoupled from later mutation", () => {
+    const g = new Graph().addEdge(0, 1, 5);
+    const snap = g.toNormalized();
+    g.addEdge(1, 2, 6);
+    g.addVertex(8);
+    expect(snap.edges).toEqual([[0, 1, 5]]);
+    expect(snap.vertices).toEqual([0, 1]);
+    // mutating the snapshot must not reach back into the builder
+    snap.edges[0][2] = 999;
+    expect(g.toNormalized().edges[0]).toEqual([0, 1, 5]);
+  });
+
+  test("validates node ids and weights eagerly at the call site", () => {
+    expect(() => new Graph().addVertex("x")).toThrow(/finite number/);
+    expect(() => new Graph().addVertex(Infinity)).toThrow(/finite number/);
+    expect(() => new Graph().addEdge(0, NaN, 1)).toThrow(/finite numbers/);
+    expect(() => new Graph().addEdge(0, 1, -1)).toThrow(/non-negative/);
+    expect(() => new Graph().addEdge(0, 1, Infinity)).toThrow(/non-negative/);
+  });
+
+  test("BMSSP accepts a Graph and matches the edge-array result", () => {
+    const g = new Graph();
+    for (const [from, to, weight] of EDGES) g.addEdge(from, to, weight);
+    const viaGraph = new BMSSP(g);
+    viaGraph.calculateShortestPaths(0);
+    expect(new Map(viaGraph.shortestPaths)).toEqual(
+      distancesFromEdges(EDGES, 0),
+    );
+  });
+});
+
+describe("adjacency inputs", () => {
+  test("adjacency object matches the edge-array result", () => {
+    const adjacency = {};
+    for (const [from, to, weight] of EDGES) {
+      (adjacency[from] ??= []).push([to, weight]);
+    }
+    const bmssp = new BMSSP(adjacency);
+    bmssp.calculateShortestPaths(0);
+    expect(new Map(bmssp.shortestPaths)).toEqual(distancesFromEdges(EDGES, 0));
+  });
+
+  test("adjacency Map matches the edge-array result", () => {
+    const adjacency = new Map();
+    for (const [from, to, weight] of EDGES) {
+      if (!adjacency.has(from)) adjacency.set(from, []);
+      adjacency.get(from).push([to, weight]);
+    }
+    const bmssp = new BMSSP(adjacency);
+    bmssp.calculateShortestPaths(0);
+    expect(new Map(bmssp.shortestPaths)).toEqual(distancesFromEdges(EDGES, 0));
+  });
+
+  test("object keys are coerced to numeric node ids", () => {
+    // Object keys are strings; they must normalize back to the numeric ids
+    // the rest of the API uses.
+    const bmssp = new BMSSP({ 0: [[1, 4]], 1: [[2, 6]] });
+    bmssp.calculateShortestPaths(0);
+    expect(bmssp.shortestPaths.get(2)).toBe(10);
+    expect([...bmssp.nodeIDs].sort((a, b) => a - b)).toEqual([0, 1, 2]);
+  });
+
+  test("a key with an empty neighbor list declares an isolated vertex", () => {
+    const bmssp = new BMSSP(
+      new Map([
+        [0, [[1, 3]]],
+        [5, []],
+      ]),
+    );
+    expect(bmssp.nodeIDs.has(5)).toBe(true);
+    bmssp.calculateShortestPaths(0);
+    expect(bmssp.shortestPaths.get(5)).toBe(Infinity);
+  });
+
+  test("a null/absent neighbor value declares an isolated vertex", () => {
+    const bmssp = new BMSSP({ 0: [[1, 3]], 5: null });
+    expect(bmssp.nodeIDs.has(5)).toBe(true);
+    bmssp.calculateShortestPaths(0);
+    expect(bmssp.shortestPaths.get(5)).toBe(Infinity);
+  });
+});
+
+describe("explicit vertex universe", () => {
+  test("a declared isolated vertex is unreachable but present", () => {
+    const g = new Graph().addEdge(0, 1, 3).addVertex(42);
+    const bmssp = new BMSSP(g);
+    expect(bmssp.nodeIDs.has(42)).toBe(true);
+    bmssp.calculateShortestPaths(0);
+    expect(bmssp.shortestPaths.get(42)).toBe(Infinity);
+    expect(bmssp.reconstructPath(42)).toEqual([]);
+  });
+
+  test("an isolated vertex is a valid source reaching only itself", () => {
+    const g = new Graph().addEdge(0, 1, 3).addVertex(42);
+    const bmssp = new BMSSP(g);
+    bmssp.calculateShortestPaths(42);
+    expect(bmssp.shortestPaths.get(42)).toBe(0);
+    expect(bmssp.shortestPaths.get(0)).toBe(Infinity);
+    expect(bmssp.shortestPaths.get(1)).toBe(Infinity);
+  });
+
+  test("declared vertices are validated for finiteness", () => {
+    // Graph guards addVertex, but the adjacency object path can smuggle a
+    // non-numeric key; the constructor must reject it.
+    expect(() => new BMSSP({ abc: [] })).toThrow(/finite numbers/);
+  });
+});
+
+describe("input validation across shapes", () => {
+  test("unrecognized top-level input types throw", () => {
+    expect(() => new BMSSP(42)).toThrow(/edge array, an adjacency/);
+    expect(() => new BMSSP("nope")).toThrow(/edge array, an adjacency/);
+    expect(() => new BMSSP(null)).toThrow(/edge array, an adjacency/);
+  });
+
+  test("malformed adjacency entries throw a clear message", () => {
+    expect(() => new BMSSP({ 0: [[1]] })).toThrow(/\[to, weight\]/);
+    expect(() => new BMSSP({ 0: 5 })).toThrow(/iterable of \[to, weight\]/);
+  });
+
+  test("edge-array validation is unchanged (indexed messages)", () => {
+    expect(
+      () =>
+        new BMSSP([
+          [0, 1, 5],
+          [0, 2],
+        ]),
+    ).toThrow(/Edge at index 1 must be \[from, to, weight\]/);
+    expect(() => new BMSSP([[0, 1, -5]])).toThrow(
+      /Edge at index 0 must have a non-negative numeric weight/,
+    );
+  });
+
+  test("empty graphs remain valid across shapes", () => {
+    expect(new BMSSP([]).nodeIDs.size).toBe(0);
+    expect(new BMSSP({}).nodeIDs.size).toBe(0);
+    expect(new BMSSP(new Map()).nodeIDs.size).toBe(0);
+    expect(new BMSSP(new Graph()).nodeIDs.size).toBe(0);
+  });
+});
+
+describe("cross-shape equivalence on seeded graphs (vs Dijkstra oracle)", () => {
+  test("edge array, adjacency map, and Graph agree with the oracle", () => {
+    const edges = sparseRandom(2_000, 3, 4242);
+    const source = 0;
+
+    const adjacencyMap = new Map();
+    const g = new Graph();
+    for (const [from, to, weight] of edges) {
+      if (!adjacencyMap.has(from)) adjacencyMap.set(from, []);
+      adjacencyMap.get(from).push([to, weight]);
+      g.addEdge(from, to, weight);
+    }
+
+    const fromArray = new BMSSP(edges);
+    fromArray.calculateShortestPaths(source);
+    const oracle = dijkstra(fromArray.graph, fromArray.nodeIDs, source);
+
+    for (const input of [adjacencyMap, g]) {
+      const bmssp = new BMSSP(input);
+      bmssp.calculateShortestPaths(source);
+      for (const node of bmssp.nodeIDs) {
+        expect(bmssp.shortestPaths.get(node)).toBe(oracle.get(node));
+      }
+    }
+  });
+});

--- a/test/main.test.mjs
+++ b/test/main.test.mjs
@@ -18,9 +18,11 @@ describe("BMSSP constructor", () => {
     expect(myBMSSP.graph).toEqual(mediumSparse);
   });
 
-  test("rejects a non-array input graph", () => {
+  test("rejects an unrecognized input graph type", () => {
+    // #172: arrays, adjacency maps/objects, and Graph builders are accepted;
+    // a bare string is none of those.
     expect(() => new BMSSP("not an edge array")).toThrow(
-      "Input graph must be an array of edges",
+      "Input graph must be an edge array, an adjacency map/object, or a Graph instance",
     );
   });
 


### PR DESCRIPTION
Closes #172. Milestone 2.0.0, mid-milestone → **no version bump** (the work reaches npm with the milestone-closing 2.0.0 release).

> 👋 @siddharth-diwakar — you'd offered to take this one, so apologies for the overlap: this was picked up in a maintainer working session. Very happy to hand off, incorporate your review, or collaborate on the follow-ups (#171/#173) — please shout.

## What changed

`new BMSSP(...)` now accepts several input shapes, all reduced by a new `normalizeGraphInput` to a canonical `{ edges, vertices }`:

- an **edge array** `[[from, to, weight], ...]` — unchanged;
- an **adjacency `Map`** `Map<from, Iterable<[to, weight]>>`;
- a **plain adjacency object** `{ from: [[to, weight], ...] }` (JS object keys are strings, so they're coerced to numbers);
- a new exported **`Graph` builder** — chainable `addVertex` / `addEdge`.

`vertices` is the **explicit, declarable vertex universe**: `Graph.addVertex` and adjacency keys with empty/`null` neighbor lists introduce **isolated** vertices, which flow through to `nodeIDs` and get an index, an empty CSR range, an `Infinity` estimate, and are valid as a `calculateShortestPaths` source (reaching only themselves). The plain edge list can't express an isolated vertex — this closes that gap.

```javascript
import { BMSSP, Graph } from "bmssp";

new BMSSP({ 0: [[1, 50], [2, 25]], 1: [[2, 75]] });      // adjacency object
new BMSSP(new Map([[0, [[1, 50]]], [5, []]]));            // Map; node 5 isolated

const g = new Graph().addEdge(0, 1, 50).addEdge(0, 2, 25).addVertex(9);
const graph = new BMSSP(g);
graph.calculateShortestPaths(0);
graph.shortestPaths.get(9); // Infinity (declared, isolated)
```

Node-ID semantics are unchanged (finite numbers, indices assigned in ascending-id order), so the canonical `[length, hops, id]` tie-break and **every oracle/determinism assertion are untouched** — this is a surface generalization, not an engine change.

## Scope boundary (please review)

Your engine-baseline comment on #206 asked #172 to *"construct straight into the index+CSR layout rather than round-tripping through the `[from,to,weight]` array."* This PR delivers the flexible-input **surface** but **keeps that round-trip**: `this.graph` and `this.adjacency` are public, tested fields (`main.test.mjs` asserts `bmssp.graph`), so the constructor must populate them regardless. Building CSR directly means deciding whether those public fields survive 2.0.0 — a breaking call I think belongs to **#173** (API stabilization). Deferred there as a roadmap proposal. Happy to fold it in here instead if you'd prefer.

## Tests / verification

- New `src/graph.mjs`; `Graph` re-exported from `index.mjs` (four public exports now).
- New **18-test** `test/graph.test.mjs`: builder semantics (chaining, idempotent `addVertex`, copy isolation, eager validation), adjacency Map/object inputs, object-key coercion, isolated vertices (empty/`null` lists, `addVertex`, as source), **cross-shape oracle equivalence on a seeded 2k sparse graph**, and every failure mode (unrecognized input, malformed adjacency entry, non-finite declared vertex, unchanged indexed edge-array messages).
- `npm test` → **208 passed, 1 XL skipped** (suite 209); `graph.mjs` / `bmssp.mjs` / `index.mjs` at 100% coverage; `npm run lint` clean.
- Updated `05` / `06` / `07` and `README.md` (new "Flexible graph inputs" usage section).

## Roadmap proposals (for Phase E, pending approval)

1. **Comment on #172 before closing** — record what shipped vs. deferred (the direct-CSR lever), so the history is honest.
2. **Comment on #173** — carry two decisions: whether `this.graph` / `this.adjacency` stay public (unblocks direct-CSR construction), and documenting the new `Graph`/adjacency surface + object-key coercion in the migration note, the `docs/index.html` API page (still lists three exports), and a `Graph` example in the gallery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)