### PR TITLE
feat(#171): public multi-source / bounded entrypoint — calculateShortestPathsFrom

### DIFF
--- a/.claude/knowledge/05-codebase-map.md
+++ b/.claude/knowledge/05-codebase-map.md
@@ -1,16 +1,18 @@
 # 05 — Codebase Map (current state)
 
-<!-- BOOKMARK-COMMIT: 50faa4a -->
-<!-- PENDING-PR-BRANCH: feat/172-typed-flexible-inputs -->
-<!-- Last validated: 2026-07-21 (Phase C of the #172 PR, branch
-     feat/172-typed-flexible-inputs, based on main 50faa4a). This PR adds typed/flexible
-     graph inputs (milestone 2.0.0, mid-milestone → no bump): new src/graph.mjs (`Graph`
-     builder + `normalizeGraphInput`), re-exported `Graph` from index.mjs, and a BMSSP
-     constructor that accepts an edge array (unchanged), an adjacency Map/object, or a
-     Graph — plus an explicit declarable vertex universe (isolated nodes). Node IDs stay
-     finite numbers; canonical [length, hops, id] tie-break order unchanged. Body describes
-     post-merge reality; markers fast-path on the next session's Phase A. Also folds in the
-     PR #207 marker flip (BOOKMARK 50faa4a) that had been left as a local bookkeeping edit. -->
+<!-- BOOKMARK-COMMIT: 6cab602 -->
+<!-- PENDING-PR-BRANCH: feat/171-multi-source-entrypoint -->
+<!-- Last validated: 2026-07-21 (Phase C of the #171 PR, branch
+     feat/171-multi-source-entrypoint, based on main 6cab602). This PR adds the public
+     multi-source / bounded entrypoint (milestone 2.0.0, mid-milestone → no bump):
+     BMSSP.calculateShortestPathsFrom(sources, { bound }) + the normalizeSources helper —
+     a thin, ergonomic surface over the existing bmssp(topLevel, B, S) wrapper that hides the
+     recursion level and the seed-the-Map ritual. Flexible `sources` (Map | object | [id,dist]
+     pairs | bare id array), bound defaults to Infinity, finite-bound runs prune the mirror to
+     the completed set U. Additive only — calculateShortestPaths / bmssp / reconstructPath
+     unchanged; node-ID + tie-break semantics untouched. Body describes post-merge reality;
+     markers fast-path on the next session's Phase A. Also folds in the #172-PR Phase E marker
+     flip (BOOKMARK 6cab602) that had been left as a local bookkeeping edit. -->
 
 
 Snapshot of what exists in `bmssp-js` today, so you know what to build on vs. what's missing.
@@ -88,6 +90,7 @@ test/
   constantDegree.test.mjs # #164: 11 tests — degree ≤ 2 on hand + seeded shapes (incl. star hub), distance preservation via oracle, BMSSP-on-transform, determinism, empty/validation
   graph.test.mjs          # #172: 18 tests — Graph builder (chain/idempotent/copies/eager validation), adjacency Map/object inputs, object-key coercion, isolated vertices (empty & null neighbor lists, declared, as source), cross-shape oracle equivalence (seeded 2k), unrecognized-input + malformed-adjacency throws
   pathReconstruction.test.mjs # #169: 3 public-API tests — Dijkstra path oracle, unreachable/pre-run/source switching, target validation
+  multiSource.test.mjs     # #171: 19 tests — calculateShortestPathsFrom: single-source equivalence, nearest-of-many + custom-d0 multi-source oracle, bounded pruning, all input shapes, reconstructPath/state-reset integration, validation
   blockList.test.mjs      # #42: 25 BlockList tests incl. seeded random stress, #182 many-chunk/M=1 regression tests + #167 machinery tests
   boundIndex.test.mjs     # #167: 8 BoundIndex tests — sequence ops, monotone findFirst, AVL invariants under seeded churn
   select.test.mjs         # #167: 9 partitionByRank tests — every-rank contract, worst-case orderings, duplicates, determinism
@@ -165,6 +168,11 @@ class BMSSP {
                                    //      space (S/U = indices, keys = [len,hops,index], CSR + labels)
   calculateShortestPaths(startNode)// #43: validates, sets labels.dist[startIdx] = 0, runs
                                    //      bmsspIndex(topLevel, ∞, {startIdx}), then syncLabelsOut
+  normalizeSources(sources)        // #171: flexible sources → Map<id, initialDistance>
+                                   //      (Map | {id:dist} | [id,dist][] | id[]; validated)
+  calculateShortestPathsFrom(sources, { bound }) // #171 PUBLIC multi-source/bounded entry:
+                                   //      seed shortestPaths, run bmssp(topLevel, bound, S),
+                                   //      prune the mirror to U under a finite bound
   reconstructPath(target)          // #169: source→target path from the public preds mirror
 }
 ```
@@ -214,6 +222,28 @@ result's indices/key are translated to id space (`keyToPublic`). `calculateShort
 skips the wrapper (runs `bmsspIndex` directly, then one `syncLabelsOut`). `reconstructPath`
 reads the public `preds` mirror as before. This is why #205 is **API-non-breaking** despite
 being in the 2.0.0 milestone: it re-engineers the interior, not the surface.
+
+**Public multi-source / bounded entrypoint (#171).**
+`calculateShortestPathsFrom(sources, { bound } = {})` exposes the paper's `BMSSP(l, B, S)`
+generalization (§04) as ergonomic public API — an additive surface over the existing
+`bmssp(topLevel, B, S)` wrapper, hiding both the recursion level and the "seed
+`this.shortestPaths` first" ritual the fuzz suite uses directly. `normalizeSources` reduces
+the flexible `sources` argument (`Map<id,dist>` | object `{id:dist}` (numeric-string keys
+coerced) | array of `[id,dist]` pairs | bare id array → distance 0) to a validated
+`Map<id, initialDistance>` (each id a known node, each distance finite ≥ 0; a repeated source
+keeps its smallest distance). The method seeds those distances into `this.shortestPaths`, runs
+`this.bmssp(this.topLevel, bound, new Set(ids))`, and — like `calculateShortestPaths` — writes
+results into the public Maps and returns nothing. **Bounded-run cleanup:** BMSSP relaxes some
+vertices at/above `B` without completing them, leaving over-estimates in the mirror, so under
+a **finite** bound the method prunes `shortestPaths`/`hops`/`preds` to the returned completed
+set `U` (exactly the vertices with `d(v) < B`); an unbounded run's `U` already equals the
+reachable set, so no pruning is needed. Single-source SSSP is the special case
+`calculateShortestPathsFrom([start])`. `bound` accepts a non-negative number or `Infinity`
+(default). The multi-source ground truth is `trueDist(v) = min_s(d0[s] + dist_s(v))`; initial
+distances are treated as the sources' true (complete) distances (the paper's precondition,
+trivially met by the common all-zero seeding). **Additive only** — `calculateShortestPaths`,
+`bmssp`, and `reconstructPath` are untouched, and node-ID / `[length, hops, id]` tie-break
+semantics are unchanged.
 
 **`bmsspIndex(l, boundKey, S)` (#43):** level 0 delegates to `baseCase`. At level ≥ 1:
 `findPivots` shrinks the frontier; pivots seed a `BlockList(M = 2^((l-1)·t), boundKey,
@@ -596,6 +626,19 @@ every accepted shape. See §"Flexible inputs (#172)" for the per-shape contract.
   checked against an independent Dijkstra path oracle, including competing paths, an
   unreachable vertex, calls before a run, source switching on one instance, and rejection
   of a target that is not in the graph.
+- `test/multiSource.test.mjs` (19, #171): the public `calculateShortestPathsFrom(sources,
+  { bound })` entrypoint. **Single-source equivalence** (`[s]` matches
+  `calculateShortestPaths(s)` and the Dijkstra oracle on a seeded 400-node sparse graph;
+  `[[s,0]]` == `[s]`); **multi-source semantics** against the `trueDist(v) =
+  min_s(d0[s]+dist_s(v))` oracle (nearest-of-many on a hand graph, custom initial distances
+  on a seeded 600-node graph, smallest-distance-wins for a repeated source); **bounded runs**
+  (a bound between two oracle distances completes exactly `d < B` and prunes the rest to ∞;
+  `bound = 0` completes nothing incl. the source; default `∞` is unbounded); **input shapes
+  agree** (Map / object / `[id,dist]` pairs / bare ids); **integration** (`reconstructPath`
+  and state-reset across `calculateShortestPaths`↔`calculateShortestPathsFrom` calls, isolated
+  declared vertex valid as a source); and **validation** (unknown source, negative/NaN/∞
+  initial distance, malformed pair, empty set, unrecognized shape, negative/NaN/non-number
+  bound, non-numeric object key).
 - `test/graph.test.mjs` (18, #172): the flexible-input surface. `Graph` builder
   (chaining, idempotent `addVertex`, endpoint auto-declare, `toNormalized` copy isolation,
   eager id/weight validation); `new BMSSP` from an adjacency **object** and **Map** and a
@@ -632,8 +675,9 @@ every accepted shape. See §"Flexible inputs (#172)" for the per-shape contract.
   (identical maps incl. Infinity → 0; wrong/missing entries counted); `runScenarioBenchmark`
   and `runComparisonCountBenchmark` on tiny injected scenarios return the expected columns
   with **zero mismatches**.
-- Current suite: **209 tests — 208 passing + 1 XL skipped by default** (#172 added the
-  18-test `graph.test.mjs`; `bmssp.mjs`, `index.mjs` and the new `graph.mjs` at 100%),
+- Current suite: **228 tests — 227 passing + 1 XL skipped by default** (#171 added the
+  19-test `multiSource.test.mjs`; #172 the 18-test `graph.test.mjs`; `bmssp.mjs`, `index.mjs`
+  and `graph.mjs` at 100%),
   ~100% statement coverage, ~7.5 s wall-clock (the #164 distance-preservation sweeps run
   BMSSP/Dijkstra from every source). No graph data files: every generated test graph comes
   from a seed; the #162 fixtures are hand-built and fully deterministic. The #205 dense-index
@@ -691,11 +735,13 @@ BMSSP-vs-Dijkstra head-to-head itself:
 | Exact Lemma 3.3 asymptotics (BST bound index + linear selection) | `src/boundIndex.mjs` + `src/select.mjs` + `src/blockList.mjs` | #167 | ✅ merged (PR #202, no bump) |
 | Relaxation micro-optimizations (allocation-free relaxEdge, unpacked routing, heap measurement) | `src/tieBreak.mjs` + `src/bmssp.mjs` + `src/baseCase.mjs` + `src/findPivots.mjs` | #168 | ✅ merged (PR #203, **minor → 1.2.0**, released 2026-07-21) |
 | Dense-index core: typed-array labels + CSR adjacency | `src/tieBreak.mjs` (makeLabels) + `src/bmssp.mjs` (buildIndex/CSR) + `src/baseCase.mjs` + `src/findPivots.mjs` | #205 | ✅ merged (PR #206, no bump — API-non-breaking) |
-| Typed / flexible graph inputs (Graph builder + adjacency Map/object + explicit vertex universe) | `src/graph.mjs` (new) + `src/bmssp.mjs` (constructor) + `index.mjs` (Graph export) + `test/graph.test.mjs` | #172 | ✅ done-pending-merge (this PR, no bump — mid-2.0.0) |
+| Typed / flexible graph inputs (Graph builder + adjacency Map/object + explicit vertex universe) | `src/graph.mjs` (new) + `src/bmssp.mjs` (constructor) + `index.mjs` (Graph export) + `test/graph.test.mjs` | #172 | ✅ merged (PR #208, no bump — mid-2.0.0) |
+| Public multi-source / bounded entrypoint (`calculateShortestPathsFrom`) | `src/bmssp.mjs` + `test/multiSource.test.mjs` | #171 | ✅ done-pending-merge (this PR, no bump — mid-2.0.0) |
 
 Milestones `1.1.0` (correctness hardening) and `1.2.0` (performance & ergonomics) are
 both **closed** — 1.2.0 released 2026-07-21 (npm + Docker Hub). Milestone `2.0.0`
-(API-breaking generalization) is current: **#205** (dense-index core) merged (PR #206) and
-**#172** (typed/flexible inputs) done-pending-merge (this PR, no bump), leaving
-**#171 → #173** (build order in `06`; #171 next, #173 closes the milestone with the
-**major → 2.0.0** bump). See [06-milestones-roadmap.md](06-milestones-roadmap.md).
+(API-breaking generalization) is current: **#205** (dense-index core, PR #206) and **#172**
+(typed/flexible inputs, PR #208) merged, and **#171** (public multi-source/bounded
+entrypoint) done-pending-merge (this PR, no bump), leaving **#173** — the last open issue,
+which closes the milestone with the **major → 2.0.0** bump (API stabilization + migration
+note + docs). See [06-milestones-roadmap.md](06-milestones-roadmap.md).

--- a/.claude/knowledge/06-milestones-roadmap.md
+++ b/.claude/knowledge/06-milestones-roadmap.md
@@ -1,8 +1,9 @@
 # 06 — Milestones Roadmap
 
-<!-- SYNCED-FROM-GITHUB: 2026-07-21 (RKB at start of the #172 session): 1.2.0 CLOSED; 2.0.0
-     open, 1 closed (#205) + 3 open (#171/#172/#173). #172 is done-pending-merge on branch
-     feat/172-typed-flexible-inputs (not yet closed on GitHub — Phase E) → #171 next -->
+<!-- SYNCED-FROM-GITHUB: 2026-07-21 (Phase C of the #171 PR, branch
+     feat/171-multi-source-entrypoint, based on main 6cab602): 1.2.0 CLOSED; 2.0.0 open,
+     2 closed (#205, #172) + 2 open (#171/#173). #171 done-pending-merge this PR (no bump,
+     mid-2.0.0), leaving #173 as the milestone-closing issue (major → 2.0.0). -->
 <!-- Current package version: 1.2.0 — released 2026-07-21 (tag + GitHub Release with
      Announcements discussion → npm + Docker Hub via publish.yml); tag matches -->
 <!-- Release-discussion convention (user-directed 2026-07-21): every GitHub Release also
@@ -43,28 +44,39 @@ it runs the same Phase C reconciliation directly on `main`.
 
 ## 📋 Roadmap proposals (pending user approval)
 
-**From the #172 PR (`feat/172-typed-flexible-inputs`, no issue-close beyond #172, no bump):**
+**#171 PR (this PR) — one proposal:**
 
-1. **Comment on #172 before closing it** — record what shipped vs. deferred: the flexible
-   input *surface* (`Graph` builder + adjacency Map/object + explicit vertex universe) is
-   done, but the #206-comment's "construct straight into index+CSR without the
-   `[from,to,weight]` round-trip" perf lever was **not** taken, because `this.graph` /
-   `this.adjacency` are public tested fields the constructor must populate anyway. That
-   construction-perf optimization is coupled to whether those fields stay public → carry it
-   into #173. _Rationale: keeps the issue's history honest about the scope call and prevents
-   a future reader assuming direct-CSR construction landed here._
+1. **Comment on #173** (API stabilization, the milestone-closing issue) recording the
+   #171-derived decisions it must resolve, now that the public multi-source surface exists:
+   - #171 shipped `calculateShortestPathsFrom` as **additive** (write-to-Map, returns nothing)
+     rather than taking the "may change existing signatures" latitude the #171 body mentioned —
+     so #173 owns every remaining breaking decision. Decide the **public/private split** for
+     the now-plain-method interior (`bmssp(l,B,S)`, `bmsspIndex`, `syncLabelsIn/Out`,
+     `boundToEngine`/`keyToPublic`, `normalizeSources`) — should the raw `bmssp` wrapper stay
+     public or move behind a private boundary?
+   - Document `calculateShortestPathsFrom` in the **migration note + `docs/index.html`** as a
+     public export alongside `Graph` (#172): its flexible `sources` shapes and the
+     **bounded-run pruning semantic** (finite `B` exposes only the completed set `U`).
+   - Consider whether to surface the richer `{ bound, vertices }` result #171 **discarded**
+     (write-to-Map was chosen for parallelism with `calculateShortestPaths`) — e.g. an
+     optional return or a companion method — as part of finalizing the 2.0 surface.
 
-2. **Comment on #173** (Stabilize the public API surface) — add two concrete decisions this
-   PR surfaces: (a) whether `this.graph` / `this.adjacency` stay public (if they go, the
-   constructor can build CSR directly from normalized input — the deferred #172 perf lever);
-   and (b) document the new `Graph` / adjacency-input surface + the numeric-string object-key
-   coercion rule in the 1.0→2.0 migration note, and mirror a `Graph`-builder example into the
-   `examples/` gallery (which #173 already owns per the PR #207 proposal). _Rationale: #173 is
-   the natural home for the public/private field decision the input work depends on._
+   _(No new issues and no milestone re-slicing: 2.0.0 is on track with **#173 the only issue
+   left**; #171's substrate is exactly what #173 stabilizes.)_
 
-_(No proposal on #171 beyond the existing build order: #172's normalization + explicit
-vertex-set API is exactly the substrate #171's public multi-source entrypoint will consume,
-which the current #171 notes already anticipate.)_
+_Previously executed proposals (kept for provenance):_
+
+_(The #172-PR proposals (PR #208) — scope-summary comment on closed **#172** (flexible-input
+surface shipped; direct-CSR construction perf lever deferred because `this.graph` /
+`this.adjacency` are public tested fields) and a carry-over comment on **#173** (decide the
+fate of those public fields → unblocks direct-CSR construction; document the `Graph` /
+adjacency surface + object-key coercion in the migration note, add `Graph` as the 4th export
+on `docs/index.html`, mirror a `Graph` example into the gallery) — were approved and executed
+2026-07-21: both comments posted.)_
+
+_(No #171 proposal was needed: #172's normalization + explicit vertex-set API is exactly the
+substrate #171's public multi-source entrypoint will consume, which the #171 notes already
+anticipate.)_
 
 _(The examples/Docker-PR proposal (PR #207) — comment on **#173** pointing its migration
 note / public-surface decision at the new `examples/` gallery as the canonical runnable
@@ -237,8 +249,8 @@ executed 2026-07-17.)_
   unit tests rewritten to drive the index API); 100% statement coverage, lint clean,
   FUZZ_ROUNDS=25 + FUZZ_XL green. Phase E: engine-baseline comment posted on #172; the
   build-order confirmation needed no GitHub write. **#172 is next.**
-- **#172 done-pending-merge (branch `feat/172-typed-flexible-inputs`, 2026-07-21; no
-  bump — mid-2.0.0):** typed / flexible graph inputs. New `src/graph.mjs` exports a
+- **#172 merged (PR #208, 2026-07-21, commit 6cab602; no bump — mid-2.0.0):** typed /
+  flexible graph inputs. New `src/graph.mjs` exports a
   chainable **`Graph`** builder (`addVertex`/`addEdge`, isolated-vertex declaration) and
   `normalizeGraphInput`; the BMSSP constructor now accepts an **edge array** (unchanged),
   an **adjacency `Map`**, a **plain adjacency object** (`{ from: [[to,weight]…] }`,
@@ -255,6 +267,22 @@ executed 2026-07-17.)_
   because `this.graph` (and `this.adjacency`) are public, tested fields that must be
   populated regardless; removing them to build CSR directly is a breaking change better
   owned by **#173** (API stabilization). See Roadmap proposals.
+- **#171 done-pending-merge (this PR, no bump — mid-2.0.0):** public multi-source /
+  bounded entrypoint. `BMSSP.calculateShortestPathsFrom(sources, { bound })` is a thin,
+  ergonomic surface over the existing `bmssp(topLevel, B, S)` wrapper — it hides the
+  recursion level and the "seed `this.shortestPaths` first" ritual the fuzz suite uses
+  directly. `sources` accepts a `Map<id,dist>`, object `{id:dist}`, array of `[id,dist]`
+  pairs, or bare id array (distance 0), reduced by the new `normalizeSources` helper;
+  `bound` defaults to `Infinity`. Results write into the public Maps (returns nothing, like
+  `calculateShortestPaths`); under a **finite** bound the mirror is pruned to the returned
+  completed set `U`, so only vertices with `d(v) < B` keep their exact distance (BMSSP's
+  above-`B` over-estimates are cleared). **Additive only** — `calculateShortestPaths`,
+  `bmssp`, `reconstructPath` and the `[length, hops, id]` tie-break are untouched; the
+  breaking-signature latitude the #171 body mentioned is deferred to #173. New 19-test
+  `multiSource.test.mjs` (single-source equivalence, nearest-of-many + custom-`d0`
+  multi-source oracle, bounded pruning, all input shapes, integration, validation); suite
+  228 (227 + 1 XL skip), `bmssp.mjs` 100%, lint clean. **#173 is the only 2.0.0 issue
+  left** (milestone-closing, major → 2.0.0). One Roadmap proposal (comment on #173).
 - **Examples + Docker refresh (PR #207 merged, 2026-07-21, commit 50faa4a;
   user-directed, no issue, no bump):** the stale single `examples/main.mjs` (it only
   printed the raw edge list — never ran the algorithm) is replaced by a standalone gallery
@@ -333,7 +361,8 @@ _Note:_ both #182 shapes stay as regression sentinels in every `npm run bench` (
 ## Milestone `2.0.0` (milestone #4) — API-breaking generalization — CURRENT
 
 Build order (derived 2026-07-21 at RKB, after 1.2.0 closed): ~~#205~~
-(merged, PR #206) → ~~#172~~ (done-pending-merge, this PR) → **#171 → #173**. Rationale:
+(merged, PR #206) → ~~#172~~ (merged, PR #208) → ~~#171~~ (done-pending-merge, this PR) →
+**#173**. Rationale:
 the dense-index engine (#205) decides the internal shapes every new API wraps, so it went
 first; typed/flexible inputs (#172) generalized the constructor surface over it; the public
 multi-source entrypoint (#171) is designed value-in/value-out over the finished engine and
@@ -343,9 +372,9 @@ the surface last and takes the **major → 2.0.0** bump as the milestone-closing
 | # | Issue | Labels | Notes |
 |---|---|---|---|
 | 205 | Dense-index core: typed-array labels + CSR adjacency | enhancement | ✅ merged (PR #206, no bump — API-non-breaking): sorted-id index + CSR + typed labels; wall-clock ~halved (sparse head-to-head 2.5× → 1.38×), counts unchanged |
-| 172 | Typed / flexible graph inputs | enhancement · help wanted | ✅ done-pending-merge (this PR, no bump): `Graph` builder + adjacency Map/object inputs + explicit declarable vertex universe, reduced via `normalizeGraphInput`; node-ID semantics unchanged. Deferred the direct-CSR construction perf lever to #173 (coupled to public `this.graph`) — see Roadmap proposals |
-| 171 | Public multi-source / bounded BMSSP entrypoint | enhancement · help wanted | **NEXT** — value-in/value-out API over the dense engine; #205 kept the id-based `bmssp(l,B,S)` wrapper and #172 added the input normalization + vertex-set substrate it consumes, so this is surface design |
-| 173 | Stabilize the public API surface for 1.0 → 2.0 | documentation · enhancement | milestone-closing: per-module public/private decision (incl. whether `this.graph`/`this.adjacency` stay public — the deferred #172 direct-CSR lever), migration note + `Graph` example, **major → 2.0.0** |
+| 172 | Typed / flexible graph inputs | enhancement · help wanted | ✅ merged (PR #208, no bump): `Graph` builder + adjacency Map/object inputs + explicit declarable vertex universe, reduced via `normalizeGraphInput`; node-ID semantics unchanged. Deferred the direct-CSR construction perf lever to #173 (coupled to public `this.graph`) |
+| 171 | Public multi-source / bounded BMSSP entrypoint | enhancement · help wanted | ✅ done-pending-merge (this PR, no bump): `calculateShortestPathsFrom(sources, { bound })` — additive surface over the `bmssp(l,B,S)` wrapper, flexible `sources` shapes + finite-bound pruning to the completed set `U`. Breaking-signature latitude deferred to #173 |
+| 173 | Stabilize the public API surface for 1.0 → 2.0 | documentation · enhancement | **NEXT / milestone-closing**: per-module public/private decision (incl. whether the raw `bmssp(l,B,S)` wrapper stays public, and whether `this.graph`/`this.adjacency` stay public — the deferred #172 direct-CSR lever), migration note + `Graph`/`calculateShortestPathsFrom` docs, **major → 2.0.0** |
 
 _Note after #43:_ `bmssp(l, B, S)` already **is** a bounded multi-source call internally —
 #171 is mostly about designing the public API around it (initial per-source distances,

--- a/.claude/knowledge/07-glossary.md
+++ b/.claude/knowledge/07-glossary.md
@@ -212,6 +212,18 @@ Quick lookup for the symbols and terms used across the paper, the notes, and the
   (`boundToEngine`), runs `bmsspIndex`, then mirrors labels back (`syncLabelsOut`) and
   translates the result to ids (`keyToPublic`). Returns `{ bound, boundKey, vertices }`
   (= the paper's `B'`, its composite key, `U`); scalar `B` in → scalar `bound` out.
+- **`calculateShortestPathsFrom(sources, { bound })`** (#171) — the PUBLIC multi-source /
+  bounded entrypoint: the ergonomic surface over `bmssp(topLevel, B, S)`. Normalizes
+  `sources` (a `Map<id,dist>`, object `{id:dist}`, array of `[id,dist]` pairs, or bare id
+  array → distance 0) via `normalizeSources`, seeds each into `this.shortestPaths`, and runs
+  `bmssp(this.topLevel, bound, …)` — hiding the recursion level and the seed-the-Map ritual.
+  Writes results into `shortestPaths`/`hops`/`preds` and returns nothing (read the Maps).
+  Under a **finite** bound it prunes the mirror to the returned completed set `U`, so only
+  the exact distances of vertices with `d(v) < B` remain (BMSSP's above-`B` over-estimates
+  are cleared); unbounded runs need no pruning. Single-source SSSP = `[start]`, `bound = ∞`.
+- **`normalizeSources(sources)`** (#171) — internal `BMSSP` helper reducing the flexible
+  `sources` argument to a validated `Map<id, initialDistance>` (every id a known node, every
+  distance finite ≥ 0; a repeated source keeps its smallest distance).
 - **`bmsspIndex(l, boundKey, S)`** (#43; dense engine #205) — the actual Algorithm 3
   recursion, **entirely in dense-index space**: `S`/`U` are index sets, keys are
   `[len, hops, index]`, the graph is `this.csr`, labels are `this.labels`. Level 0
@@ -366,6 +378,6 @@ Quick lookup for the symbols and terms used across the paper, the notes, and the
   exports — `BMSSP` (constructor contract, `calculateShortestPaths`, `reconstructPath`),
   `dijkstra`, `constantDegreeTransform` — and explicitly keeps algorithm internals out.
   Static, dependency-free HTML. **Note:** the #172 `Graph` export + flexible-input surface
-  is **not yet on this page** — it reaches npm only with the 2.0.0 release, and the docs
-  pass is folded into #173 (migration note + public-surface doc); tracked in the #172
-  Roadmap proposals.
+  and the #171 `calculateShortestPathsFrom` multi-source/bounded entrypoint are **not yet on
+  this page** — they reach npm only with the 2.0.0 release, and the docs pass is folded into
+  #173 (migration note + public-surface doc); tracked in the Roadmap proposals.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ with every building block shipped, tested, and released individually:
 | Relaxation micro-optimizations: allocation-free hot loops, −13–23% wall-clock ([#168](https://github.com/Sirivasv/bmssp-js/issues/168)) | `src/tieBreak.mjs` + the algorithm modules | ✅ done — **1.2.0** |
 | Dense-index core: typed-array labels + CSR adjacency, ~½ the wall-clock ([#205](https://github.com/Sirivasv/bmssp-js/issues/205)) | `src/bmssp.mjs` (CSR) + `src/tieBreak.mjs` (typed labels) | ✅ done |
 | Typed / flexible graph inputs: `Graph` builder + adjacency Map/object + explicit vertex universe ([#172](https://github.com/Sirivasv/bmssp-js/issues/172)) | `src/graph.mjs` + `BMSSP` constructor | ✅ done |
+| Public multi-source / bounded entrypoint ([#171](https://github.com/Sirivasv/bmssp-js/issues/171)) | `BMSSP.calculateShortestPathsFrom()` | ✅ done |
 
 > **Honest note:** the paper's win is asymptotic, and this repo optimizes for correctness
 > and readability first — but the constant factors have come down a lot. Measured
@@ -149,6 +150,45 @@ console.log(graph.shortestPaths.get(9)); // Infinity
 (Plain-object keys are strings in JavaScript, so the object form coerces them to numbers;
 use a `Map` or the `Graph` builder if you want to keep numeric keys explicit.)
 
+### Multi-source and bounded runs
+
+`calculateShortestPathsFrom(sources, { bound })` runs the paper's `BMSSP(l, B, S)`
+generalization directly: from a **set** of sources, each with an initial distance, optionally
+under a strict distance **bound `B`**. Results land in `shortestPaths` just like
+`calculateShortestPaths` — single-source SSSP is exactly the special case
+`calculateShortestPathsFrom([start])`.
+
+```javascript
+import { BMSSP } from "bmssp";
+
+const g = new BMSSP([
+  [0, 1, 2],
+  [1, 2, 3],
+  [5, 2, 1],
+]);
+
+// Nearest of several sources (each seeded at distance 0):
+g.calculateShortestPathsFrom([0, 5]);
+console.log(g.shortestPaths.get(2)); // 1  (via 5 -> 2, beating 0 -> 1 -> 2 = 5)
+
+// Sources with explicit initial distances, as pairs / a Map / an object:
+g.calculateShortestPathsFrom([
+  [0, 0],
+  [5, 10],
+]);
+console.log(g.shortestPaths.get(2)); // 5  (via 0 -> 1 -> 2; 5's head start no longer wins)
+
+// Bounded: only vertices with distance < B are completed; the rest stay Infinity.
+g.calculateShortestPathsFrom([0], { bound: 4 });
+console.log(g.shortestPaths.get(1)); // 2
+console.log(g.shortestPaths.get(2)); // Infinity  (distance 5 is not < 4)
+```
+
+Sources accept a `Map<id, dist>`, an object `{ id: dist }`, an array of `[id, dist]` pairs, or
+a bare array of ids (each seeded at distance 0). Initial distances are treated as the sources'
+true (complete) distances — with the common all-zero seeding this is automatic. `bound`
+defaults to `Infinity` (unbounded).
+
 ### Optional: constant-degree transform
 
 The paper's bound assumes every vertex has in-degree and out-degree ≤ 2. That preprocessing
@@ -232,7 +272,7 @@ graphs in a few seconds), and set `FUZZ_XL=1` for an additional 2-million-node r
 | [`1.0.0`](https://github.com/Sirivasv/bmssp-js/milestones) | First end-to-end functional BMSSP (issues #40–#45) | ✅ done |
 | `1.1.0` | Correctness hardening — fuzz tests, edge cases, tie-breaking, input validation, constant-degree transform, API docs | ✅ done |
 | `1.2.0` | Performance & ergonomics — exact Lemma 3.3 asymptotics, BMSSP-vs-Dijkstra benchmarks, cliff investigation, relaxation micro-optimizations | ✅ done |
-| `2.0.0` | API generalization — dense-index engine (done), typed/flexible inputs (done), public multi-source/bounded entry point | 🔨 current |
+| `2.0.0` | API generalization — dense-index engine (done), typed/flexible inputs (done), public multi-source/bounded entry point (done); API stabilization remaining | 🔨 current |
 
 ## Contributing (humans and AI agents welcome)
 

--- a/src/bmssp.mjs
+++ b/src/bmssp.mjs
@@ -429,6 +429,126 @@ class BMSSP {
     this.syncLabelsOut();
   }
 
+  // Internal (#171): reduce the flexible `sources` argument of
+  // calculateShortestPathsFrom to a Map<id, initialDistance>. Accepts a
+  // Map<id, dist>, a plain object { id: dist } (numeric-string keys coerced
+  // like #172's adjacency objects), an array of [id, dist] pairs, or a bare
+  // array of ids (each seeded at distance 0). Every id must be a known node
+  // and every initial distance a finite non-negative number; a repeated
+  // source keeps its smallest initial distance.
+  normalizeSources(sources) {
+    const out = new Map();
+    const add = (id, dist) => {
+      if (!this.nodeIDs.has(id)) {
+        throw new Error(`Source ${id} not found in the graph`);
+      }
+      if (!Number.isFinite(dist) || dist < 0) {
+        throw new Error(
+          `Source ${id} must have a non-negative finite initial distance`,
+        );
+      }
+      const prev = out.get(id);
+      out.set(id, prev === undefined ? dist : Math.min(prev, dist));
+    };
+
+    if (sources instanceof Map) {
+      for (const [id, dist] of sources) add(id, dist);
+    } else if (Array.isArray(sources)) {
+      for (const entry of sources) {
+        if (Array.isArray(entry)) {
+          if (entry.length !== 2) {
+            throw new Error("Each source pair must be [id, initialDistance]");
+          }
+          add(entry[0], entry[1]);
+        } else {
+          add(entry, 0);
+        }
+      }
+    } else if (sources && typeof sources === "object") {
+      for (const key of Object.keys(sources)) {
+        add(Number(key), sources[key]);
+      }
+    } else {
+      throw new Error(
+        "sources must be a Map, object, array of [id, dist] pairs, or array of ids",
+      );
+    }
+    return out;
+  }
+
+  /**
+   * Multi-source, optionally-bounded shortest paths — the public form of the
+   * paper's BMSSP(l, B, S) generalization (§04). Runs from a SET of sources,
+   * each with an initial distance, optionally under a strict distance bound B.
+   * Single-source SSSP is exactly the special case sources = [start],
+   * bound = Infinity — what calculateShortestPaths does.
+   *
+   * Results land in this.shortestPaths (and the hops/preds mirror), like
+   * calculateShortestPaths: every completed vertex holds its distance;
+   * vertices not reached — or, in a bounded run, not completed below B — keep
+   * Infinity. Read the answer from this.shortestPaths after the call. Under a
+   * finite bound only the completed set U is exposed: BMSSP may relax vertices
+   * above B without completing them, so those leftover estimates are pruned
+   * back to Infinity, leaving exactly the vertices with distance < B.
+   *
+   * The initial distances are treated as the sources' TRUE (complete)
+   * distances — the paper's precondition on S. With the common all-zero
+   * seeding this is trivially satisfied (nearest-of-many). Passing custom
+   * initial distances where one source's shortest path undercuts another's
+   * declared distance violates the precondition; the multi-source ground
+   * truth is trueDist(v) = min over sources s of (d0[s] + dist_s(v)).
+   *
+   * @param {Map<number,number>|Object<string,number>|Array<[number,number]>|number[]} sources
+   *   The source set. A Map<id, dist>, a plain object { id: dist } (numeric
+   *   string keys coerced), an array of [id, dist] pairs, or a bare array of
+   *   ids (each seeded at distance 0).
+   * @param {object} [options]
+   * @param {number} [options.bound=Infinity] - Strict distance upper bound B;
+   *   only vertices with distance < B are completed. Infinity runs unbounded.
+   * @throws {Error} If sources is empty or an unrecognized shape, a source id
+   *   is not in the graph, an initial distance is not a non-negative finite
+   *   number, or bound is not a non-negative number / Infinity.
+   */
+  calculateShortestPathsFrom(sources, { bound = Infinity } = {}) {
+    this.initializeShortestPaths();
+
+    const seeded = this.normalizeSources(sources);
+    if (seeded.size === 0) {
+      throw new Error("At least one source is required");
+    }
+    if (typeof bound !== "number" || Number.isNaN(bound) || bound < 0) {
+      throw new Error("bound must be a non-negative number or Infinity");
+    }
+
+    // Seed each source's initial distance into the public estimate; the
+    // bmssp() wrapper's syncLabelsIn snapshots these finite distances into the
+    // engine as complete roots (hop 0, no predecessor).
+    for (const [id, dist] of seeded) {
+      this.shortestPaths.set(id, dist);
+    }
+    const { vertices } = this.bmssp(
+      this.topLevel,
+      bound,
+      new Set(seeded.keys()),
+    );
+
+    // Under a finite bound the top-level call is a successful execution whose
+    // returned set U is exactly the vertices completed below B. BMSSP relaxes
+    // (but does not complete) some vertices at or above B, leaving over-
+    // estimates in the mirror; prune everything outside U so the public Maps
+    // report only the exact in-bound distances (matching an unbounded run,
+    // whose U already equals the reachable set — no pruning needed there).
+    if (bound !== Infinity) {
+      for (const id of this.nodeIDs) {
+        if (!vertices.has(id)) {
+          this.shortestPaths.set(id, Infinity);
+          this.hops.delete(id);
+          this.preds.delete(id);
+        }
+      }
+    }
+  }
+
   /**
    * Reconstruct the canonical shortest path from the most recent source to
    * target. Returns an empty array when target is unreachable or no shortest

--- a/test/multiSource.test.mjs
+++ b/test/multiSource.test.mjs
@@ -1,0 +1,302 @@
+import { describe, test, expect } from "@jest/globals";
+import { BMSSP, dijkstra } from "../index.mjs";
+import { sparseRandom } from "../benchmarks/generators.mjs";
+
+// #171 — public multi-source / bounded BMSSP entrypoint.
+// calculateShortestPathsFrom(sources, { bound }) runs the paper's
+// BMSSP(l, B, S) generalization from a public surface: a set of sources with
+// initial distances, optionally under a strict bound B. Results land in
+// this.shortestPaths, like calculateShortestPaths. Single-source SSSP is the
+// special case sources = [start], bound = Infinity.
+//
+// Ground truth for a multi-source run with initial distances d0[s]:
+//   trueDist(v) = min over sources s of (d0[s] + dist_s(v))
+// where dist_s is the single-source Dijkstra distance from s.
+
+// Small hand graph with competing paths from two sources.
+const HAND = [
+  [0, 1, 2],
+  [1, 2, 3],
+  [2, 3, 1],
+  [3, 4, 4],
+  [5, 4, 1],
+  [5, 3, 6],
+  [4, 6, 2],
+];
+
+// Multi-source oracle: min over sources of (initial distance + Dijkstra dist).
+function multiSourceOracle(graph, nodeIDs, initial) {
+  const oracles = new Map();
+  for (const s of initial.keys()) {
+    oracles.set(s, dijkstra(graph, nodeIDs, s));
+  }
+  const trueDist = new Map();
+  for (const v of nodeIDs) {
+    let best = Infinity;
+    for (const [s, d0] of initial) {
+      best = Math.min(best, d0 + oracles.get(s).get(v));
+    }
+    trueDist.set(v, best);
+  }
+  return trueDist;
+}
+
+describe("#171 calculateShortestPathsFrom — single-source equivalence", () => {
+  test("sources = [s] matches calculateShortestPaths(s) and the oracle", () => {
+    const edges = sparseRandom(400, 3, 7101);
+    const nodeIDs = new BMSSP(edges).nodeIDs;
+    for (const s of [...nodeIDs].slice(0, 5)) {
+      const a = new BMSSP(edges);
+      a.calculateShortestPaths(s);
+      const b = new BMSSP(edges);
+      b.calculateShortestPathsFrom([s]);
+      const oracle = dijkstra(edges, nodeIDs, s);
+      for (const v of nodeIDs) {
+        expect(b.shortestPaths.get(v)).toBe(a.shortestPaths.get(v));
+        expect(b.shortestPaths.get(v)).toBe(oracle.get(v));
+      }
+    }
+  });
+
+  test("[[s, 0]] pair form equals the bare-id form", () => {
+    const g1 = new BMSSP(HAND);
+    g1.calculateShortestPathsFrom([0]);
+    const g2 = new BMSSP(HAND);
+    g2.calculateShortestPathsFrom([[0, 0]]);
+    for (const v of g1.nodeIDs) {
+      expect(g2.shortestPaths.get(v)).toBe(g1.shortestPaths.get(v));
+    }
+  });
+});
+
+describe("#171 calculateShortestPathsFrom — multi-source semantics", () => {
+  test("nearest-of-many (all sources at distance 0) on the hand graph", () => {
+    const g = new BMSSP(HAND);
+    const initial = new Map([
+      [0, 0],
+      [5, 0],
+    ]);
+    g.calculateShortestPathsFrom([0, 5]);
+    const trueDist = multiSourceOracle(HAND, g.nodeIDs, initial);
+    for (const v of g.nodeIDs) {
+      expect(g.shortestPaths.get(v)).toBe(trueDist.get(v));
+    }
+    // node 4 is reached at 1 via 5->4 (beats 0->1->2->3->4 = 10)
+    expect(g.shortestPaths.get(4)).toBe(1);
+    // node 6 = 4 -> 6 (2) on top of the nearest 4
+    expect(g.shortestPaths.get(6)).toBe(3);
+  });
+
+  test("custom initial distances match the multi-source oracle (seeded)", () => {
+    const edges = sparseRandom(600, 3, 7202);
+    const nodeIDs = new BMSSP(edges).nodeIDs;
+    const nodes = [...nodeIDs].sort((a, b) => a - b);
+    const initial = new Map([
+      [nodes[0], 0],
+      [nodes[10], 25],
+      [nodes[100], 5],
+    ]);
+    const g = new BMSSP(edges);
+    g.calculateShortestPathsFrom(initial);
+    const trueDist = multiSourceOracle(edges, nodeIDs, initial);
+    for (const v of nodeIDs) {
+      expect(g.shortestPaths.get(v)).toBe(trueDist.get(v));
+    }
+  });
+
+  test("a repeated source keeps its smallest initial distance", () => {
+    const g = new BMSSP(HAND);
+    g.calculateShortestPathsFrom([
+      [0, 40],
+      [0, 5],
+      [0, 12],
+    ]);
+    // effective d0[0] = 5, so d(1) = 5 + 2 = 7
+    expect(g.shortestPaths.get(0)).toBe(5);
+    expect(g.shortestPaths.get(1)).toBe(7);
+  });
+});
+
+describe("#171 calculateShortestPathsFrom — bounded runs", () => {
+  test("bound B completes exactly the vertices with distance < B (seeded)", () => {
+    const edges = sparseRandom(500, 3, 7303);
+    const nodeIDs = new BMSSP(edges).nodeIDs;
+    const nodes = [...nodeIDs].sort((a, b) => a - b);
+    const source = nodes[0];
+    const oracle = dijkstra(edges, nodeIDs, source);
+    const finite = [...oracle.values()]
+      .filter((d) => d < Infinity)
+      .sort((a, b) => a - b);
+    // Bound between two existing distances so no vertex ties it.
+    const B =
+      (finite[Math.floor(finite.length * 0.5)] +
+        finite[Math.floor(finite.length * 0.5) + 1]) /
+      2;
+
+    const g = new BMSSP(edges);
+    g.calculateShortestPathsFrom([source], { bound: B });
+    for (const v of nodeIDs) {
+      const trueD = oracle.get(v);
+      if (trueD < B) {
+        expect(g.shortestPaths.get(v)).toBe(trueD);
+      } else {
+        expect(g.shortestPaths.get(v)).toBe(Infinity);
+      }
+    }
+  });
+
+  test("bound = 0 completes nothing (even the source, at distance 0, is not < 0)", () => {
+    const g = new BMSSP(HAND);
+    g.calculateShortestPathsFrom([0], { bound: 0 });
+    for (const v of g.nodeIDs) {
+      expect(g.shortestPaths.get(v)).toBe(Infinity);
+    }
+  });
+
+  test("default bound is Infinity (unbounded)", () => {
+    const g = new BMSSP(HAND);
+    g.calculateShortestPathsFrom([0]);
+    // node 4 reachable from 0 via 0->1->2->3->4 = 10
+    expect(g.shortestPaths.get(4)).toBe(10);
+  });
+});
+
+describe("#171 calculateShortestPathsFrom — input shapes agree", () => {
+  test("Map, object, [id,dist] pairs, and bare ids give identical results", () => {
+    const initialPairs = [
+      [0, 0],
+      [5, 3],
+    ];
+    const asMap = new BMSSP(HAND);
+    asMap.calculateShortestPathsFrom(new Map(initialPairs));
+
+    const asObject = new BMSSP(HAND);
+    asObject.calculateShortestPathsFrom({ 0: 0, 5: 3 });
+
+    const asPairs = new BMSSP(HAND);
+    asPairs.calculateShortestPathsFrom(initialPairs);
+
+    for (const v of asMap.nodeIDs) {
+      expect(asObject.shortestPaths.get(v)).toBe(asMap.shortestPaths.get(v));
+      expect(asPairs.shortestPaths.get(v)).toBe(asMap.shortestPaths.get(v));
+    }
+
+    // Bare-id form (all distance 0) matches a pairs form with explicit zeros.
+    const bareIds = new BMSSP(HAND);
+    bareIds.calculateShortestPathsFrom([0, 5]);
+    const zeros = new BMSSP(HAND);
+    zeros.calculateShortestPathsFrom([
+      [0, 0],
+      [5, 0],
+    ]);
+    for (const v of bareIds.nodeIDs) {
+      expect(bareIds.shortestPaths.get(v)).toBe(zeros.shortestPaths.get(v));
+    }
+  });
+});
+
+describe("#171 calculateShortestPathsFrom — integration", () => {
+  test("reconstructPath works after a multi-source run", () => {
+    const g = new BMSSP(HAND);
+    g.calculateShortestPathsFrom([0, 5]);
+    // 4 is reached from source 5 (5->4, dist 1)
+    expect(g.reconstructPath(4)).toEqual([5, 4]);
+    // 6 hangs off 4
+    expect(g.reconstructPath(6)).toEqual([5, 4, 6]);
+    // 1 is reached from source 0
+    expect(g.reconstructPath(1)).toEqual([0, 1]);
+  });
+
+  test("state resets between calls and after calculateShortestPaths", () => {
+    const g = new BMSSP(HAND);
+    g.calculateShortestPaths(0);
+    expect(g.shortestPaths.get(4)).toBe(10);
+    // Switch to the other source only.
+    g.calculateShortestPathsFrom([5]);
+    expect(g.shortestPaths.get(4)).toBe(1);
+    // node 1 is unreachable from 5 alone.
+    expect(g.shortestPaths.get(1)).toBe(Infinity);
+    // Back to single-source via the new entrypoint.
+    g.calculateShortestPathsFrom([0]);
+    expect(g.shortestPaths.get(4)).toBe(10);
+    expect(g.shortestPaths.get(1)).toBe(2);
+  });
+
+  test("isolated declared vertex is valid as a source (reaches only itself)", () => {
+    const g = new BMSSP(
+      new Map([
+        [0, [[1, 5]]],
+        [9, []],
+      ]),
+    );
+    g.calculateShortestPathsFrom([9]);
+    expect(g.shortestPaths.get(9)).toBe(0);
+    expect(g.shortestPaths.get(0)).toBe(Infinity);
+    expect(g.shortestPaths.get(1)).toBe(Infinity);
+  });
+});
+
+describe("#171 calculateShortestPathsFrom — validation", () => {
+  test("unknown source id throws", () => {
+    const g = new BMSSP(HAND);
+    expect(() => g.calculateShortestPathsFrom([999])).toThrow(
+      /Source 999 not found/,
+    );
+  });
+
+  test("negative, NaN, and non-finite initial distances throw", () => {
+    const g = new BMSSP(HAND);
+    expect(() => g.calculateShortestPathsFrom([[0, -1]])).toThrow(
+      /non-negative finite/,
+    );
+    expect(() => g.calculateShortestPathsFrom([[0, NaN]])).toThrow(
+      /non-negative finite/,
+    );
+    expect(() => g.calculateShortestPathsFrom([[0, Infinity]])).toThrow(
+      /non-negative finite/,
+    );
+  });
+
+  test("malformed source pair throws", () => {
+    const g = new BMSSP(HAND);
+    expect(() => g.calculateShortestPathsFrom([[0, 1, 2]])).toThrow(
+      /Each source pair/,
+    );
+  });
+
+  test("empty source set throws", () => {
+    const g = new BMSSP(HAND);
+    expect(() => g.calculateShortestPathsFrom([])).toThrow(
+      /At least one source/,
+    );
+    expect(() => g.calculateShortestPathsFrom(new Map())).toThrow(
+      /At least one source/,
+    );
+  });
+
+  test("unrecognized sources shape throws", () => {
+    const g = new BMSSP(HAND);
+    expect(() => g.calculateShortestPathsFrom(42)).toThrow(/sources must be/);
+    expect(() => g.calculateShortestPathsFrom(null)).toThrow(/sources must be/);
+  });
+
+  test("negative or NaN bound throws", () => {
+    const g = new BMSSP(HAND);
+    expect(() => g.calculateShortestPathsFrom([0], { bound: -5 })).toThrow(
+      /bound must be/,
+    );
+    expect(() => g.calculateShortestPathsFrom([0], { bound: NaN })).toThrow(
+      /bound must be/,
+    );
+    expect(() => g.calculateShortestPathsFrom([0], { bound: "10" })).toThrow(
+      /bound must be/,
+    );
+  });
+
+  test("object with a non-numeric key throws (coerces to NaN, unknown source)", () => {
+    const g = new BMSSP(HAND);
+    expect(() => g.calculateShortestPathsFrom({ notANode: 0 })).toThrow(
+      /Source NaN not found/,
+    );
+  });
+});


### PR DESCRIPTION
Closes #171.

## Summary

Exposes the paper's `BMSSP(l, B, S)` generalization (§04) as ergonomic public API:
**`BMSSP.calculateShortestPathsFrom(sources, { bound })`** — an **additive** surface over the
existing `bmssp(topLevel, B, S)` wrapper that hides the recursion level and the "seed
`this.shortestPaths` first" ritual the fuzz suite drives directly.

- **Flexible `sources`** (new `normalizeSources` helper): a `Map<id, dist>`, an object
  `{ id: dist }` (numeric-string keys coerced), an array of `[id, dist]` pairs, or a bare array
  of ids (each seeded at distance 0). Validated: each id a known node, each distance finite ≥ 0;
  a repeated source keeps its smallest distance.
- **`bound`** defaults to `Infinity` (unbounded). Accepts a non-negative number or `Infinity`.
- **Write-to-Map, returns nothing** — like `calculateShortestPaths`; read `this.shortestPaths`.
- **Bounded-run cleanup:** BMSSP relaxes some vertices at/above `B` without completing them, so
  under a finite bound the mirror is pruned to the returned completed set `U` — only vertices
  with `d(v) < B` keep their exact distance (above-`B` over-estimates cleared).
- **Single-source SSSP** is the special case `calculateShortestPathsFrom([start])`.

**Additive only** — `calculateShortestPaths`, `bmssp`, `reconstructPath`, and the
`[length, hops, id]` tie-break are untouched. The "may change existing signatures" latitude in
the #171 body is deliberately deferred to **#173** (API stabilization / milestone-closing).

**No version bump** (mid-2.0.0, per the semver convention).

## Tests / lint

- New **19-test `test/multiSource.test.mjs`**: single-source + Dijkstra-oracle equivalence,
  nearest-of-many and custom-`d0` multi-source oracle (`trueDist(v) = min_s(d0[s]+dist_s(v))`),
  bounded pruning, input-shape agreement (Map/object/pairs/bare ids), `reconstructPath` +
  state-reset integration, and full validation coverage.
- Full suite **228 (227 passing + 1 XL skip)**; `src/bmssp.mjs` at **100%**; `npm run lint` clean.

## Docs

Refreshed `.claude/knowledge/05`/`06`/`07` and `README.md` (new "Multi-source and bounded runs"
usage section, status table + roadmap rows). `docs/index.html` is intentionally **not** touched
here — it reaches npm only with the 2.0.0 release and the docs pass is folded into #173.

## Roadmap proposals

1. **Comment on #173** (the milestone-closing API-stabilization issue) recording the
   #171-derived decisions it must now resolve:
   - #171 shipped additive, so #173 owns every remaining breaking decision — the **public/private
     split** for the now-plain-method interior (`bmssp(l,B,S)`, `bmsspIndex`, `syncLabelsIn/Out`,
     `boundToEngine`/`keyToPublic`, `normalizeSources`); does the raw `bmssp` wrapper stay public?
   - Document `calculateShortestPathsFrom` in the **migration note + `docs/index.html`** alongside
     `Graph` (#172): flexible `sources` shapes + the **bounded-run pruning semantic**.
   - Consider surfacing the richer `{ bound, vertices }` result #171 **discarded** (write-to-Map was
     chosen for parallelism with `calculateShortestPaths`) as part of finalizing the 2.0 surface.

   _No new issues and no milestone re-slicing — 2.0.0 is on track with **#173 the only issue left**._

🤖 Generated with [Claude Code](https://claude.com/claude-code)