### PR TITLE
feat(#173): stabilize public API surface — docs, contract test, migration note (major → 2.0.0)

### DIFF
--- a/.claude/knowledge/05-codebase-map.md
+++ b/.claude/knowledge/05-codebase-map.md
@@ -1,18 +1,19 @@
 # 05 — Codebase Map (current state)
 
-<!-- BOOKMARK-COMMIT: 6cab602 -->
-<!-- PENDING-PR-BRANCH: feat/171-multi-source-entrypoint -->
-<!-- Last validated: 2026-07-21 (Phase C of the #171 PR, branch
-     feat/171-multi-source-entrypoint, based on main 6cab602). This PR adds the public
-     multi-source / bounded entrypoint (milestone 2.0.0, mid-milestone → no bump):
-     BMSSP.calculateShortestPathsFrom(sources, { bound }) + the normalizeSources helper —
-     a thin, ergonomic surface over the existing bmssp(topLevel, B, S) wrapper that hides the
-     recursion level and the seed-the-Map ritual. Flexible `sources` (Map | object | [id,dist]
-     pairs | bare id array), bound defaults to Infinity, finite-bound runs prune the mirror to
-     the completed set U. Additive only — calculateShortestPaths / bmssp / reconstructPath
-     unchanged; node-ID + tie-break semantics untouched. Body describes post-merge reality;
-     markers fast-path on the next session's Phase A. Also folds in the #172-PR Phase E marker
-     flip (BOOKMARK 6cab602) that had been left as a local bookkeeping edit. -->
+<!-- BOOKMARK-COMMIT: d56bc86 -->
+<!-- PENDING-PR-BRANCH: feat/173-stabilize-public-api -->
+<!-- Last validated: 2026-07-21 (Phase C of the #173 PR, branch feat/173-stabilize-public-api,
+     based on main d56bc86). This PR is the milestone-closing 2.0.0 work: public-API
+     STABILIZATION (documentation + contract lockdown, no behavior change). Adds @public/
+     @internal JSDoc across the BMSSP class, a contract test (test/publicApi.test.mjs) pinning
+     the 4 exports + supported members, MIGRATION.md (1.0→2.0, no breaking changes), two new
+     examples (05-flexible-inputs, 06-multi-source), and a rewritten docs/index.html (4 exports
+     + calculateShortestPathsFrom + advanced bmssp). User-confirmed decisions: document-only
+     boundary (no #-privatization), keep this.graph/this.adjacency public (direct-CSR perf
+     lever deferred to a new post-2.0 issue), keep raw bmssp(l,B,S) as advanced public API.
+     **major → 2.0.0** (npm version major applied). Body describes post-merge reality; markers
+     fast-path on the next session's Phase A. Also folds in the #171-PR RKB marker flip
+     (BOOKMARK d56bc86) that had been left as a local bookkeeping edit. -->
 
 
 Snapshot of what exists in `bmssp-js` today, so you know what to build on vs. what's missing.
@@ -91,6 +92,7 @@ test/
   graph.test.mjs          # #172: 18 tests — Graph builder (chain/idempotent/copies/eager validation), adjacency Map/object inputs, object-key coercion, isolated vertices (empty & null neighbor lists, declared, as source), cross-shape oracle equivalence (seeded 2k), unrecognized-input + malformed-adjacency throws
   pathReconstruction.test.mjs # #169: 3 public-API tests — Dijkstra path oracle, unreachable/pre-run/source switching, target validation
   multiSource.test.mjs     # #171: 19 tests — calculateShortestPathsFrom: single-source equivalence, nearest-of-many + custom-d0 multi-source oracle, bounded pruning, all input shapes, reconstructPath/state-reset integration, validation
+  publicApi.test.mjs       # #173: 9 CONTRACT tests — pins the 4 exports + BMSSP/Graph supported members + constantDegreeTransform/dijkstra shapes; export/rename drift fails CI
   blockList.test.mjs      # #42: 25 BlockList tests incl. seeded random stress, #182 many-chunk/M=1 regression tests + #167 machinery tests
   boundIndex.test.mjs     # #167: 8 BoundIndex tests — sequence ops, monotone findFirst, AVL invariants under seeded churn
   select.test.mjs         # #167: 9 partitionByRank tests — every-rank contract, worst-case orderings, duplicates, determinism
@@ -117,11 +119,15 @@ examples/                 # standalone, copy-pasteable gallery — each file imp
   02-dijkstra-oracle.mjs  #   validate BMSSP against the exported `dijkstra` oracle (per-node table)
   03-constant-degree.mjs  #   the opt-in constantDegreeTransform (sourceCopy/collapse)
   04-larger-graph.mjs     #   a generated 40×40 grid — timing + oracle spot-check
-  run-all.mjs             #   runs all four in order (the Docker image's default CMD)
+  05-flexible-inputs.mjs  #   #172 surface: edge array / adjacency Map / object / Graph all equal + isolated vertex
+  06-multi-source.mjs     #   #171 surface: calculateShortestPathsFrom — nearest-of-many, custom d0, bounded pruning
+  run-all.mjs             #   runs all six in order (the Docker image's default CMD)
   README.md               #   gallery index + Docker run/override/mount recipes
-docs/index.html           # public-API reference (GitHub Pages via static.yml) — rewritten in
-                          # #166 from a stale landing page (wrong repo link, stray </svg>);
-                          # documents the three exports only, internals explicitly excluded
+docs/index.html           # public-API reference (GitHub Pages via static.yml); since #173
+                          # documents all FOUR exports (BMSSP, Graph, dijkstra,
+                          # constantDegreeTransform) + calculateShortestPathsFrom + advanced bmssp
+MIGRATION.md              # #173: 1.0 → 2.0 migration note (no breaking changes; the locked
+                          # public surface + what's now explicitly @internal), linked from README
 ```
 
 Tooling: Jest (`npm test`, needs `--experimental-vm-modules`, already in the `test` script),
@@ -244,6 +250,24 @@ distances are treated as the sources' true (complete) distances (the paper's pre
 trivially met by the common all-zero seeding). **Additive only** — `calculateShortestPaths`,
 `bmssp`, and `reconstructPath` are untouched, and node-ID / `[length, hops, id]` tie-break
 semantics are unchanged.
+
+**Public-API stabilization (#173, milestone-closing → 2.0.0).** A **documentation + contract
+lockdown**, no behavior change (user-confirmed: document-only boundary, no `#`-privatization).
+The class carries a class-level JSDoc enumerating the **supported public surface** — the
+constructor, `calculateShortestPaths`, `calculateShortestPathsFrom`, `bmssp(l,B,S)` (advanced
+primitive), `reconstructPath`, `getEdges`, and the public fields `shortestPaths` / `nodeIDs`
+/ `hops` / `preds` / `adjacency` / `graph` — with `@public`/`@internal` tags on the method
+JSDoc. Everything else (the dense-index engine: `csr`, `labels`, `ids`, `indexOf`,
+`bmsspIndex`, `syncLabelsIn/Out`, `boundToEngine`/`keyToPublic`, `normalizeSources`,
+`buildIndex`, `deriveParameters`, `k`/`t`/`topLevel`/`ties`) is `@internal` — may change in a
+minor. `index.mjs` exports exactly four names (`BMSSP`, `Graph`, `dijkstra`,
+`constantDegreeTransform`); the algorithm-internal modules stay unexported. `MIGRATION.md`
+records the 1.0→2.0 story (**no breaking changes** — #205/#172/#171 all landed additively, so
+2.0.0 is a stability commitment + feature consolidation), and `test/publicApi.test.mjs` pins
+the surface so export/rename drift fails CI. **Deferred (user-directed):** `this.graph` /
+`this.adjacency` stay public, so the #172/#206 direct-CSR construction perf lever is deferred
+to a new post-2.0 issue (Roadmap proposal); the raw `bmssp(l,B,S)` wrapper stays a documented
+advanced entrypoint.
 
 **`bmsspIndex(l, boundKey, S)` (#43):** level 0 delegates to `baseCase`. At level ≥ 1:
 `findPivots` shrinks the frontier; pivots seed a `BlockList(M = 2^((l-1)·t), boundKey,
@@ -647,6 +671,15 @@ every accepted shape. See §"Flexible inputs (#172)" for the per-shape contract.
   valid as a source reaching only itself); cross-shape **oracle equivalence** on a seeded
   2k sparse graph; and the failure modes — unrecognized top-level input, malformed
   adjacency entry, non-finite declared vertex, and the unchanged indexed edge-array messages.
+- `test/publicApi.test.mjs` (9, #173): the **CONTRACT test** locking the 2.0.0 public
+  surface. Asserts `index.mjs` exports exactly `{ BMSSP, Graph, constantDegreeTransform,
+  dijkstra }` and their kinds; the `BMSSP` prototype has every documented public method
+  (`calculateShortestPaths`, `calculateShortestPathsFrom`, `bmssp`, `reconstructPath`,
+  `getEdges`) and an instance carries the public fields (`shortestPaths`/`nodeIDs`/`hops`/
+  `preds`/`adjacency`/`graph`), with an end-to-end behavior smoke check; the `Graph` builder's
+  public methods + chaining/`toNormalized` shape; `constantDegreeTransform`'s locked return
+  keys; and `dijkstra`'s signature. Adding/removing/renaming any of these fails CI — the teeth
+  behind the document-only boundary.
 - `test/edgeCases.test.mjs` (9, #162): deterministic hand-built disconnection fixtures,
   each checked against a hand-computed full distance map **and** the Dijkstra oracle
   (Infinity entries included): self-loop-only source, sink source (adjacency keeps an
@@ -675,9 +708,9 @@ every accepted shape. See §"Flexible inputs (#172)" for the per-shape contract.
   (identical maps incl. Infinity → 0; wrong/missing entries counted); `runScenarioBenchmark`
   and `runComparisonCountBenchmark` on tiny injected scenarios return the expected columns
   with **zero mismatches**.
-- Current suite: **228 tests — 227 passing + 1 XL skipped by default** (#171 added the
-  19-test `multiSource.test.mjs`; #172 the 18-test `graph.test.mjs`; `bmssp.mjs`, `index.mjs`
-  and `graph.mjs` at 100%),
+- Current suite: **237 tests — 236 passing + 1 XL skipped by default** (#173 added the
+  9-test contract `publicApi.test.mjs`; #171 the 19-test `multiSource.test.mjs`; #172 the
+  18-test `graph.test.mjs`; `bmssp.mjs`, `index.mjs` and `graph.mjs` at 100%),
   ~100% statement coverage, ~7.5 s wall-clock (the #164 distance-preservation sweeps run
   BMSSP/Dijkstra from every source). No graph data files: every generated test graph comes
   from a seed; the #162 fixtures are hand-built and fully deterministic. The #205 dense-index
@@ -736,12 +769,14 @@ BMSSP-vs-Dijkstra head-to-head itself:
 | Relaxation micro-optimizations (allocation-free relaxEdge, unpacked routing, heap measurement) | `src/tieBreak.mjs` + `src/bmssp.mjs` + `src/baseCase.mjs` + `src/findPivots.mjs` | #168 | ✅ merged (PR #203, **minor → 1.2.0**, released 2026-07-21) |
 | Dense-index core: typed-array labels + CSR adjacency | `src/tieBreak.mjs` (makeLabels) + `src/bmssp.mjs` (buildIndex/CSR) + `src/baseCase.mjs` + `src/findPivots.mjs` | #205 | ✅ merged (PR #206, no bump — API-non-breaking) |
 | Typed / flexible graph inputs (Graph builder + adjacency Map/object + explicit vertex universe) | `src/graph.mjs` (new) + `src/bmssp.mjs` (constructor) + `index.mjs` (Graph export) + `test/graph.test.mjs` | #172 | ✅ merged (PR #208, no bump — mid-2.0.0) |
-| Public multi-source / bounded entrypoint (`calculateShortestPathsFrom`) | `src/bmssp.mjs` + `test/multiSource.test.mjs` | #171 | ✅ done-pending-merge (this PR, no bump — mid-2.0.0) |
+| Public multi-source / bounded entrypoint (`calculateShortestPathsFrom`) | `src/bmssp.mjs` + `test/multiSource.test.mjs` | #171 | ✅ merged (PR #209, no bump — mid-2.0.0) |
+| Public-API stabilization + 1.0→2.0 migration note | `src/bmssp.mjs` (JSDoc) + `MIGRATION.md` + `docs/index.html` + `examples/` + `test/publicApi.test.mjs` | #173 | ✅ done-pending-merge (this PR, **major → 2.0.0** — milestone-closing) |
 
 Milestones `1.1.0` (correctness hardening) and `1.2.0` (performance & ergonomics) are
 both **closed** — 1.2.0 released 2026-07-21 (npm + Docker Hub). Milestone `2.0.0`
-(API-breaking generalization) is current: **#205** (dense-index core, PR #206) and **#172**
-(typed/flexible inputs, PR #208) merged, and **#171** (public multi-source/bounded
-entrypoint) done-pending-merge (this PR, no bump), leaving **#173** — the last open issue,
-which closes the milestone with the **major → 2.0.0** bump (API stabilization + migration
-note + docs). See [06-milestones-roadmap.md](06-milestones-roadmap.md).
+(API-breaking generalization) is being closed by **this PR**: **#205** (dense-index core,
+PR #206), **#172** (typed/flexible inputs, PR #208), and **#171** (public multi-source/bounded
+entrypoint, PR #209) all merged (no bumps), and **#173** (this PR) stabilizes the public API
+surface and takes the **major → 2.0.0** bump. In practice the three generalizations landed
+additively, so 2.0.0 has **no breaking changes** on the documented surface — it is a stability
+commitment (see `MIGRATION.md`). See [06-milestones-roadmap.md](06-milestones-roadmap.md).

--- a/.claude/knowledge/06-milestones-roadmap.md
+++ b/.claude/knowledge/06-milestones-roadmap.md
@@ -1,11 +1,13 @@
 # 06 — Milestones Roadmap
 
-<!-- SYNCED-FROM-GITHUB: 2026-07-21 (Phase C of the #171 PR, branch
-     feat/171-multi-source-entrypoint, based on main 6cab602): 1.2.0 CLOSED; 2.0.0 open,
-     2 closed (#205, #172) + 2 open (#171/#173). #171 done-pending-merge this PR (no bump,
-     mid-2.0.0), leaving #173 as the milestone-closing issue (major → 2.0.0). -->
-<!-- Current package version: 1.2.0 — released 2026-07-21 (tag + GitHub Release with
-     Announcements discussion → npm + Docker Hub via publish.yml); tag matches -->
+<!-- SYNCED-FROM-GITHUB: 2026-07-21 (Phase C of the #173 PR, branch feat/173-stabilize-public-api,
+     based on main d56bc86): 1.2.0 CLOSED; 2.0.0 open, 3 closed (#205, #172, #171) + 1 open
+     (#173). #173 done-pending-merge this PR (public-API stabilization, **major → 2.0.0**) —
+     the milestone-closing issue; on merge + release, milestone 2.0.0 closes. -->
+<!-- Current package version: 2.0.0 — BUMPED in the #173 PR (npm version major), NOT yet
+     released. Latest tag is 1.2.0. On merge, Phase 2 tags 2.0.0 + GitHub Release (with
+     Announcements discussion) → npm + Docker Hub via publish.yml. Until then this is a
+     bumped-but-untagged version (Phase A step 5 surfaces it). -->
 <!-- Release-discussion convention (user-directed 2026-07-21): every GitHub Release also
      creates a linked discussion — pass --discussion-category "Announcements" to
      gh release create (the UI's "Create a discussion for this release" checkbox) -->
@@ -44,27 +46,40 @@ it runs the same Phase C reconciliation directly on `main`.
 
 ## 📋 Roadmap proposals (pending user approval)
 
-**#171 PR (this PR) — one proposal:**
+**#173 PR (this PR, milestone-closing) — proposals:**
 
-1. **Comment on #173** (API stabilization, the milestone-closing issue) recording the
-   #171-derived decisions it must resolve, now that the public multi-source surface exists:
-   - #171 shipped `calculateShortestPathsFrom` as **additive** (write-to-Map, returns nothing)
-     rather than taking the "may change existing signatures" latitude the #171 body mentioned —
-     so #173 owns every remaining breaking decision. Decide the **public/private split** for
-     the now-plain-method interior (`bmssp(l,B,S)`, `bmsspIndex`, `syncLabelsIn/Out`,
-     `boundToEngine`/`keyToPublic`, `normalizeSources`) — should the raw `bmssp` wrapper stay
-     public or move behind a private boundary?
-   - Document `calculateShortestPathsFrom` in the **migration note + `docs/index.html`** as a
-     public export alongside `Graph` (#172): its flexible `sources` shapes and the
-     **bounded-run pruning semantic** (finite `B` exposes only the completed set `U`).
-   - Consider whether to surface the richer `{ bound, vertices }` result #171 **discarded**
-     (write-to-Map was chosen for parallelism with `calculateShortestPaths`) — e.g. an
-     optional return or a companion method — as part of finalizing the 2.0 surface.
+1. **Close milestone `2.0.0`** — #173 is its last open issue; on this PR's merge + the 2.0.0
+   release, the milestone is complete (4/4: #205, #172, #171, #173).
+2. **Create a new issue: "Direct-CSR construction — skip the edge-list round-trip."** The
+   #172/#206 perf lever, deferred again by #173's user-confirmed decision to keep
+   `this.graph` / `this.adjacency` public (tests + `main.test.mjs` depend on them). Building
+   the index/CSR straight from the input — bypassing the `[from,to,weight]` copy — needs those
+   fields to become lazy/derived or private, i.e. a breaking change. So it is a **3.0 / future-
+   major** candidate (or a carefully non-breaking lazy-getter approach in a minor). Needs a
+   home milestone — see proposal 4.
+3. **(Optional) Create a small enhancement issue: "Richer multi-source return."** #171 chose
+   write-to-Map / returns-nothing for `calculateShortestPathsFrom`; the internal wrapper still
+   produces `{ bound, vertices }`. Surfacing it (an optional return or companion method) is a
+   purely additive future enhancement — file only if the user wants it tracked.
+4. **Decide the next milestone direction with the user.** 2.0.0 is the last defined milestone;
+   the core algorithm is feature-complete. Natural next buckets: a **performance** milestone
+   (direct-CSR construction + further engine work) and/or an **ergonomics/polish** one. Propose
+   creating one milestone (name/number TBD with the user) to host proposals 2–3, rather than
+   leaving them unmilestoned.
 
-   _(No new issues and no milestone re-slicing: 2.0.0 is on track with **#173 the only issue
-   left**; #171's substrate is exactly what #173 stabilizes.)_
+_These are Phase E gated GitHub writes — execute only after the user confirms the merge, one
+confirmation per edit._
 
 _Previously executed proposals (kept for provenance):_
+
+_(The #171-PR proposal (PR #209) — a single comment on **#173** recording the #171-derived
+decisions it must resolve now that the public multi-source surface exists (the public/private
+split for the now-plain-method interior incl. whether the raw `bmssp(l,B,S)` wrapper stays
+public; documenting `calculateShortestPathsFrom` + its flexible `sources` shapes and
+bounded-run pruning semantic in the migration note / `docs/index.html` alongside `Graph`; and
+whether to surface the richer `{ bound, vertices }` result #171 discarded) — was approved and
+executed 2026-07-21: comment posted on #173. No new issues and no milestone re-slicing —
+2.0.0 is on track with **#173 the only issue left**.)_
 
 _(The #172-PR proposals (PR #208) — scope-summary comment on closed **#172** (flexible-input
 surface shipped; direct-CSR construction perf lever deferred because `this.graph` /
@@ -267,8 +282,8 @@ executed 2026-07-17.)_
   because `this.graph` (and `this.adjacency`) are public, tested fields that must be
   populated regardless; removing them to build CSR directly is a breaking change better
   owned by **#173** (API stabilization). See Roadmap proposals.
-- **#171 done-pending-merge (this PR, no bump — mid-2.0.0):** public multi-source /
-  bounded entrypoint. `BMSSP.calculateShortestPathsFrom(sources, { bound })` is a thin,
+- **#171 merged (PR #209, 2026-07-21, commit d56bc86; no bump — mid-2.0.0):** public
+  multi-source / bounded entrypoint. `BMSSP.calculateShortestPathsFrom(sources, { bound })` is a thin,
   ergonomic surface over the existing `bmssp(topLevel, B, S)` wrapper — it hides the
   recursion level and the "seed `this.shortestPaths` first" ritual the fuzz suite uses
   directly. `sources` accepts a `Map<id,dist>`, object `{id:dist}`, array of `[id,dist]`
@@ -282,7 +297,23 @@ executed 2026-07-17.)_
   `multiSource.test.mjs` (single-source equivalence, nearest-of-many + custom-`d0`
   multi-source oracle, bounded pruning, all input shapes, integration, validation); suite
   228 (227 + 1 XL skip), `bmssp.mjs` 100%, lint clean. **#173 is the only 2.0.0 issue
-  left** (milestone-closing, major → 2.0.0). One Roadmap proposal (comment on #173).
+  left** (milestone-closing, major → 2.0.0). Roadmap proposal (comment on #173 recording the
+  API-stabilization decisions #171 hands off) was approved and posted 2026-07-21.
+- **#173 done-pending-merge (this PR, major → 2.0.0 — milestone-closing):** public-API
+  stabilization, a **documentation + contract lockdown** with no behavior change.
+  User-confirmed decisions (2026-07-21): **document-only** boundary (JSDoc `@public`/
+  `@internal`, no `#`-privatization — the fuzz/baseCase/findPivots/tieBreak suites drive
+  internals); **keep `this.graph`/`this.adjacency` public** (direct-CSR construction perf
+  lever deferred to a new post-2.0 issue — Roadmap proposal 2); **keep raw `bmssp(l,B,S)`**
+  as a documented *advanced* public entrypoint. Deliverables: class-level JSDoc enumerating
+  the supported surface + `@public`/`@internal` tags; `MIGRATION.md` (1.0→2.0, **no breaking
+  changes** — #205/#172/#171 were additive, so 2.0.0 is a stability commitment + feature
+  consolidation); rewritten `docs/index.html` (all four exports + `calculateShortestPathsFrom`
+  + advanced `bmssp`; stale ~1M crossover claim corrected to <50k); two new examples
+  (`05-flexible-inputs`, `06-multi-source`) wired into `run-all`; and `test/publicApi.test.mjs`
+  (9 contract tests pinning the surface). **major → 2.0.0** (`npm version major`). Suite 237
+  (236 + 1 XL skip), lint clean. Roadmap proposals: close milestone 2.0.0, file the deferred
+  direct-CSR perf issue, and decide the next-milestone direction with the user (Phase E).
 - **Examples + Docker refresh (PR #207 merged, 2026-07-21, commit 50faa4a;
   user-directed, no issue, no bump):** the stale single `examples/main.mjs` (it only
   printed the raw edge list — never ran the algorithm) is replaced by a standalone gallery
@@ -361,8 +392,8 @@ _Note:_ both #182 shapes stay as regression sentinels in every `npm run bench` (
 ## Milestone `2.0.0` (milestone #4) — API-breaking generalization — CURRENT
 
 Build order (derived 2026-07-21 at RKB, after 1.2.0 closed): ~~#205~~
-(merged, PR #206) → ~~#172~~ (merged, PR #208) → ~~#171~~ (done-pending-merge, this PR) →
-**#173**. Rationale:
+(merged, PR #206) → ~~#172~~ (merged, PR #208) → ~~#171~~ (merged, PR #209) →
+~~#173~~ (done-pending-merge, this PR, **major → 2.0.0**). Rationale:
 the dense-index engine (#205) decides the internal shapes every new API wraps, so it went
 first; typed/flexible inputs (#172) generalized the constructor surface over it; the public
 multi-source entrypoint (#171) is designed value-in/value-out over the finished engine and
@@ -373,8 +404,8 @@ the surface last and takes the **major → 2.0.0** bump as the milestone-closing
 |---|---|---|---|
 | 205 | Dense-index core: typed-array labels + CSR adjacency | enhancement | ✅ merged (PR #206, no bump — API-non-breaking): sorted-id index + CSR + typed labels; wall-clock ~halved (sparse head-to-head 2.5× → 1.38×), counts unchanged |
 | 172 | Typed / flexible graph inputs | enhancement · help wanted | ✅ merged (PR #208, no bump): `Graph` builder + adjacency Map/object inputs + explicit declarable vertex universe, reduced via `normalizeGraphInput`; node-ID semantics unchanged. Deferred the direct-CSR construction perf lever to #173 (coupled to public `this.graph`) |
-| 171 | Public multi-source / bounded BMSSP entrypoint | enhancement · help wanted | ✅ done-pending-merge (this PR, no bump): `calculateShortestPathsFrom(sources, { bound })` — additive surface over the `bmssp(l,B,S)` wrapper, flexible `sources` shapes + finite-bound pruning to the completed set `U`. Breaking-signature latitude deferred to #173 |
-| 173 | Stabilize the public API surface for 1.0 → 2.0 | documentation · enhancement | **NEXT / milestone-closing**: per-module public/private decision (incl. whether the raw `bmssp(l,B,S)` wrapper stays public, and whether `this.graph`/`this.adjacency` stay public — the deferred #172 direct-CSR lever), migration note + `Graph`/`calculateShortestPathsFrom` docs, **major → 2.0.0** |
+| 171 | Public multi-source / bounded BMSSP entrypoint | enhancement · help wanted | ✅ merged (PR #209, no bump): `calculateShortestPathsFrom(sources, { bound })` — additive surface over the `bmssp(l,B,S)` wrapper, flexible `sources` shapes + finite-bound pruning to the completed set `U`. Breaking-signature latitude deferred to #173 |
+| 173 | Stabilize the public API surface for 1.0 → 2.0 | documentation · enhancement | ✅ done-pending-merge (this PR, **major → 2.0.0** — milestone-closing): document-only boundary (`@public`/`@internal` JSDoc + `test/publicApi.test.mjs` contract test), `MIGRATION.md` (no breaking changes), rewritten `docs/index.html`, `05-flexible-inputs`/`06-multi-source` examples. Kept `this.graph`/`this.adjacency` + raw `bmssp` public; direct-CSR perf lever deferred to a new post-2.0 issue |
 
 _Note after #43:_ `bmssp(l, B, S)` already **is** a bounded multi-source call internally —
 #171 is mostly about designing the public API around it (initial per-source distances,

--- a/.claude/knowledge/07-glossary.md
+++ b/.claude/knowledge/07-glossary.md
@@ -375,9 +375,21 @@ Quick lookup for the symbols and terms used across the paper, the notes, and the
   sentinels in every `npm run bench` (`star`, `sparse-random-l4`).
 - **Docs page (#166)** — `docs/index.html`, the GitHub-Pages-published public-API reference
   (deployed by `static.yml` on `docs/**` changes). Documents the `index.mjs`
-  exports — `BMSSP` (constructor contract, `calculateShortestPaths`, `reconstructPath`),
-  `dijkstra`, `constantDegreeTransform` — and explicitly keeps algorithm internals out.
-  Static, dependency-free HTML. **Note:** the #172 `Graph` export + flexible-input surface
-  and the #171 `calculateShortestPathsFrom` multi-source/bounded entrypoint are **not yet on
-  this page** — they reach npm only with the 2.0.0 release, and the docs pass is folded into
-  #173 (migration note + public-surface doc); tracked in the Roadmap proposals.
+  exports. **Rewritten in #173** to document all **four** exports — `BMSSP` (flexible-input
+  constructor, `calculateShortestPaths`, `calculateShortestPathsFrom`, advanced `bmssp`,
+  `reconstructPath`, `getEdges`), `Graph`, `dijkstra`, `constantDegreeTransform` — with the
+  supported-surface contract stated up front (links to `MIGRATION.md` + the `examples/`
+  gallery) and algorithm internals + the dense-index engine members explicitly excluded.
+  Static, dependency-free HTML; the stale "~1M comparison crossover" line was corrected to
+  <50k.
+- **`MIGRATION.md` (#173)** — the 1.0 → 2.0 migration note at the repo root, linked from
+  `README.md`. Records that 2.0.0 has **no breaking changes** on the documented public surface
+  (#205/#172/#171 all landed additively → 2.0.0 is a stability commitment + feature
+  consolidation), lists the locked public API (4 exports + the supported `BMSSP` members), and
+  enumerates what is now explicitly `@internal` (the engine members + unexported modules).
+- **Public-API contract (#173)** — the 2.0.0 supported surface, enforced two ways: JSDoc
+  `@public`/`@internal` tags on the `BMSSP` class (documentation) and `test/publicApi.test.mjs`
+  (a contract test pinning the 4 exports + supported members, so export/rename drift fails CI).
+  User-confirmed **document-only** enforcement — no `#`-privatization (tests drive internals),
+  `this.graph`/`this.adjacency` kept public (direct-CSR perf lever deferred), raw `bmssp(l,B,S)`
+  kept as an advanced public entrypoint.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,76 @@
+# Migrating from 1.x to 2.0
+
+**TL;DR — there are no breaking changes to the documented public API.** Every program
+written against the 1.x public surface keeps working unchanged on 2.0.0. The major version
+marks a **stability commitment**: the public API below is now locked and covered by a
+contract test (`test/publicApi.test.mjs`), so it can't drift by accident. The 2.0.0
+milestone also consolidates the capabilities that landed additively across 1.1.x / 1.2.x
+and the 2.0.0 pre-work.
+
+The runnable, always-green reference for everything here is the
+[`examples/` gallery](examples/) — each file imports from the published `bmssp` package and
+exercises exactly the public surface.
+
+## What's new since 1.0
+
+All of these are **additive** — nothing you relied on was removed or changed shape:
+
+- **Flexible graph inputs** (#172). `new BMSSP(input)` now accepts an edge array (as before),
+  an adjacency `Map` (`Map<from, [[to, weight], …]>`), a plain adjacency object
+  (`{ from: [[to, weight], …] }`, numeric-string keys coerced to numbers), or a new **`Graph`**
+  builder. `Graph` is the only way to declare an **isolated vertex**
+  (`new Graph().addEdge(0, 1, 50).addVertex(9)`). See
+  [`examples/05-flexible-inputs.mjs`](examples/05-flexible-inputs.mjs).
+- **Multi-source / bounded entrypoint** (#171). `calculateShortestPathsFrom(sources, { bound })`
+  runs the paper's `BMSSP(l, B, S)` generalization from a set of sources with initial
+  distances, optionally under a strict distance bound. See
+  [`examples/06-multi-source.mjs`](examples/06-multi-source.mjs).
+- **Dense-index engine** (#205). The interior was re-engineered onto typed-array labels and a
+  CSR adjacency, roughly halving wall-clock — **no API change**.
+- Earlier 1.x additions, now part of the locked surface: shortest-path reconstruction
+  (`reconstructPath`, #169), the opt-in `constantDegreeTransform` (#164), constructor input
+  validation (#165), deterministic tie-breaking (#163).
+
+## The supported public API (locked as of 2.0.0)
+
+`index.mjs` exports exactly four names:
+
+| Export | What it is |
+| --- | --- |
+| `BMSSP` | The algorithm class (see its methods below). |
+| `Graph` | Mutable input builder — `addVertex`, `addEdge`, `hasVertex`, `toNormalized`; mutators chain. |
+| `dijkstra` | `dijkstra(graph, nodeIDs, source) → Map<id, distance>` — the reference oracle. |
+| `constantDegreeTransform` | Opt-in degree-≤2 rewrite → `{ edges, copiesOf, originalOf, sourceCopy, collapse }`. |
+
+Supported members of a `BMSSP` instance:
+
+- **Methods:** `calculateShortestPaths(source)`, `calculateShortestPathsFrom(sources, { bound })`,
+  `bmssp(l, B, S)` (advanced — the low-level bounded multi-source primitive, returns
+  `{ bound, boundKey, vertices }`), `reconstructPath(target)`, `getEdges(nodeId)`.
+- **Fields:** `shortestPaths` (`Map<id, distance>`), `nodeIDs` (`Set`), `hops` / `preds`
+  (canonical tie-break mirror), `adjacency` (`Map<id, [[to, weight], …]>`), `graph` (the
+  copied edge array).
+
+## What is explicitly internal
+
+Everything not listed above is an **implementation detail** and may change in a **minor**
+release — using it was never a supported contract:
+
+- The algorithm-internal modules, which are **not** re-exported from `index.mjs`: the Lemma 3.3
+  block list, the indexed min-heap, `BaseCase`, `FindPivots`, the balanced-BST bound index, the
+  linear-time selection, and the tie-break helpers.
+- The `BMSSP` class's dense-index engine members: `csr`, `labels`, `ids`, `indexOf`,
+  `bmsspIndex`, `syncLabelsIn`/`syncLabelsOut`, `boundToEngine`/`keyToPublic`, `normalizeSources`,
+  `buildIndex`, `buildAdjacency`, `deriveParameters`, `initializeShortestPaths`, and the derived
+  parameters `k` / `t` / `topLevel` / `ties`.
+
+These carry `@internal` in their JSDoc. If you depended on any of them, pin to the exact
+version you tested against and open an issue describing the use case — some may be worth
+promoting to the public surface deliberately in a future minor.
+
+## Version cadence
+
+Since 2.0.0 the project follows [semver](https://semver.org/): a released version bumps on a
+bug fix (patch) or a milestone-closing feature set (minor, or major for a milestone named after
+a major version). Most merged PRs ship no release; their work reaches npm with the next
+milestone-closing release.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ with every building block shipped, tested, and released individually:
 | Dense-index core: typed-array labels + CSR adjacency, ~½ the wall-clock ([#205](https://github.com/Sirivasv/bmssp-js/issues/205)) | `src/bmssp.mjs` (CSR) + `src/tieBreak.mjs` (typed labels) | ✅ done |
 | Typed / flexible graph inputs: `Graph` builder + adjacency Map/object + explicit vertex universe ([#172](https://github.com/Sirivasv/bmssp-js/issues/172)) | `src/graph.mjs` + `BMSSP` constructor | ✅ done |
 | Public multi-source / bounded entrypoint ([#171](https://github.com/Sirivasv/bmssp-js/issues/171)) | `BMSSP.calculateShortestPathsFrom()` | ✅ done |
+| Public API stabilization + 1.0→2.0 migration note ([#173](https://github.com/Sirivasv/bmssp-js/issues/173)) | `MIGRATION.md` + `docs/index.html` + contract test | ✅ done — **2.0.0** |
 
 > **Honest note:** the paper's win is asymptotic, and this repo optimizes for correctness
 > and readability first — but the constant factors have come down a lot. Measured
@@ -119,7 +120,9 @@ when the target is unreachable (or before any run) and throws for a node outside
 
 A reference `dijkstra` implementation is also exported. See the `examples/` directory for
 more, or the [public API reference](https://sirivasv.github.io/bmssp-js/) for the complete
-documented surface.
+documented surface. The public API is **stable as of 2.0.0** — see
+[MIGRATION.md](MIGRATION.md) for the 1.0 → 2.0 note (no breaking changes) and the locked
+surface.
 
 ### Flexible graph inputs
 
@@ -272,7 +275,7 @@ graphs in a few seconds), and set `FUZZ_XL=1` for an additional 2-million-node r
 | [`1.0.0`](https://github.com/Sirivasv/bmssp-js/milestones) | First end-to-end functional BMSSP (issues #40–#45) | ✅ done |
 | `1.1.0` | Correctness hardening — fuzz tests, edge cases, tie-breaking, input validation, constant-degree transform, API docs | ✅ done |
 | `1.2.0` | Performance & ergonomics — exact Lemma 3.3 asymptotics, BMSSP-vs-Dijkstra benchmarks, cliff investigation, relaxation micro-optimizations | ✅ done |
-| `2.0.0` | API generalization — dense-index engine (done), typed/flexible inputs (done), public multi-source/bounded entry point (done); API stabilization remaining | 🔨 current |
+| `2.0.0` | API generalization — dense-index engine, typed/flexible inputs, public multi-source/bounded entry point, and public-API stabilization (migration note + locked surface) | ✅ done |
 
 ## Contributing (humans and AI agents welcome)
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,9 @@
         <pre><code>npm install bmssp</code></pre>
         <p>
             The package is ESM-only. Graphs are arrays of <code>[from, to, weight]</code>
-            edges with finite numeric node IDs and finite, non-negative weights.
+            edges with finite numeric node IDs and finite, non-negative weights — or,
+            equivalently, an adjacency <code>Map</code>/object or a <code>Graph</code> builder
+            (see below).
         </p>
 
         <h2>Quick start</h2>
@@ -158,17 +160,47 @@ graph.shortestPaths;      // Map(3) { 0 => 0, 1 => 50, 2 => 25 }
 graph.reconstructPath(1); // [0, 1]</code></pre>
 
         <h2>Public API</h2>
-        <p>The package has exactly three exports: <code>BMSSP</code>, <code>dijkstra</code>,
-           and <code>constantDegreeTransform</code>.</p>
+        <p>The package has exactly four exports: <code>BMSSP</code>, <code>Graph</code>,
+           <code>dijkstra</code>, and <code>constantDegreeTransform</code>. This surface is
+           <strong>stable as of 2.0.0</strong> — see the
+           <a href="https://github.com/Sirivasv/bmssp-js/blob/main/MIGRATION.md"
+              target="_blank" rel="noopener">1.0&nbsp;→&nbsp;2.0 migration note</a> and the
+           runnable <a href="https://github.com/Sirivasv/bmssp-js/tree/main/examples"
+              target="_blank" rel="noopener">examples gallery</a>. Anything not listed here
+           (the block list, the indexed heap, <code>BaseCase</code>/<code>FindPivots</code>,
+           and the <code>BMSSP</code> class's dense-index engine members) is internal and may
+           change in a minor release.</p>
 
-        <h3><code>new BMSSP(graph)</code></h3>
+        <h3><code>new BMSSP(input)</code></h3>
         <p>
-            Validates and stores the edge list. Every entry must be an exact three-element
-            <code>[from, to, weight]</code> array; node IDs must be finite numbers and weights
-            finite and non-negative. Malformed input throws an <code>Error</code> identifying
-            the offending edge index. An empty edge array is valid (the graph then has no
-            nodes, so any start node is rejected later).
+            Accepts any of four input shapes and reduces them to a canonical graph: an array of
+            <code>[from, to, weight]</code> edges, an adjacency <code>Map</code>
+            (<code>Map&lt;from, [[to, weight], …]&gt;</code>), a plain adjacency object
+            (<code>{ from: [[to, weight], …] }</code>, numeric-string keys coerced to numbers),
+            or a <code>Graph</code> builder instance. Node IDs must be finite numbers and
+            weights finite and non-negative; malformed edges throw an <code>Error</code>
+            identifying the offending index. An empty graph in any shape is valid (it then has
+            no nodes, so any start node is rejected later).
         </p>
+
+        <h3><code>new Graph()</code></h3>
+        <p>
+            A small mutable input builder. <code>addVertex(id)</code> declares a vertex —
+            including an <strong>isolated</strong> one (present but with no incident edges),
+            which a bare edge list can't express — and <code>addEdge(from, to, weight)</code>
+            adds a directed weighted edge, auto-declaring its endpoints. Both validate eagerly
+            and chain; pass the instance to <code>new BMSSP(graph)</code>.
+        </p>
+<pre><code>import { BMSSP, Graph } from "bmssp";
+
+const g = new Graph()
+  .addEdge(0, 1, 50)
+  .addEdge(0, 2, 25)
+  .addVertex(9); // an isolated vertex — present, but unreachable
+
+const graph = new BMSSP(g);
+graph.calculateShortestPaths(0);
+graph.shortestPaths.get(9); // Infinity</code></pre>
 
         <h3><code>graph.calculateShortestPaths(source)</code></h3>
         <p>
@@ -182,6 +214,37 @@ graph.reconstructPath(1); // [0, 1]</code></pre>
             zero-weight edges. Calling it again with a different source resets state and
             recomputes.
         </p>
+
+        <h3><code>graph.calculateShortestPathsFrom(sources, { bound })</code></h3>
+        <p>
+            The paper's multi-source, bounded generalization as public API: runs from a
+            <strong>set</strong> of sources, each with an initial distance, optionally under a
+            strict distance <code>bound</code> <em>B</em>. <code>sources</code> accepts a
+            <code>Map&lt;id, dist&gt;</code>, an object <code>{ id: dist }</code>, an array of
+            <code>[id, dist]</code> pairs, or a bare array of ids (each seeded at distance 0).
+            Single-source SSSP is the special case
+            <code>calculateShortestPathsFrom([start])</code>. Results land in
+            <code>shortestPaths</code> exactly like <code>calculateShortestPaths</code>. Under a
+            <strong>finite</strong> <code>bound</code>, only the completed set — vertices with
+            distance <em>&lt; B</em> — is exposed; BMSSP's above-<em>B</em> over-estimates are
+            pruned to <code>Infinity</code>. <code>bound</code> defaults to <code>Infinity</code>.
+        </p>
+<pre><code>const g = new BMSSP([[0, 1, 2], [1, 2, 3], [5, 2, 1]]);
+
+g.calculateShortestPathsFrom([0, 5]);          // nearest of two sources
+g.shortestPaths.get(2);                         // 1  (via 5 -> 2)
+
+g.calculateShortestPathsFrom([0], { bound: 4 }); // bounded
+g.shortestPaths.get(2);                         // Infinity  (distance 5 ≥ 4)</code></pre>
+
+        <div class="note">
+            <strong>Advanced:</strong> <code>graph.bmssp(l, B, S)</code> is the low-level
+            bounded multi-source primitive that <code>calculateShortestPathsFrom</code> wraps.
+            It works in composite <code>[length, hops, id]</code> key space and returns
+            <code>{ bound, boundKey, vertices }</code> (the paper's <em>B′</em>, its key, and
+            the completed set <em>U</em>). Most callers want
+            <code>calculateShortestPathsFrom</code> instead.
+        </div>
 
         <h3><code>graph.reconstructPath(target)</code></h3>
         <p>
@@ -221,18 +284,22 @@ t.collapse(g.shortestPaths);               // Map(3) { 0 => 0, 1 => 50, 2 => 25 
 
         <div class="note">
             Algorithm internals — the Lemma 3.3 block list, the indexed min-heap,
-            <code>BaseCase</code>, <code>FindPivots</code>, and the tie-break helpers — are
-            deliberately <em>not</em> exported. They are implementation details, documented
-            in-source for contributors.
+            <code>BaseCase</code>, <code>FindPivots</code>, the linear-time selection and
+            balanced-BST bound index, the tie-break helpers, and the <code>BMSSP</code> class's
+            dense-index engine members (<code>csr</code>, <code>labels</code>,
+            <code>bmsspIndex</code>, the <code>syncLabels…</code> bridge, …) — are deliberately
+            <em>not</em> part of the public surface. They are implementation details, documented
+            in-source for contributors, and may change in a minor release.
         </div>
 
         <h2>Correctness &amp; performance</h2>
         <p>
             Every release is validated node-by-node against the Dijkstra oracle on thousands
             of seeded graphs (up to 2 million nodes). The paper's win is asymptotic: measured
-            head-to-head, Dijkstra still wins wall-clock at practical sizes, but in the
-            paper's own metric — comparisons between path lengths — this implementation does
-            fewer comparisons than Dijkstra from about n&nbsp;=&nbsp;1M on sparse graphs. See
+            head-to-head, Dijkstra still wins wall-clock at practical sizes (the dense-index
+            engine narrowed the sparse gap to ~1.4×), but in the paper's own metric —
+            comparisons between path lengths — this implementation does fewer comparisons than
+            Dijkstra from well under n&nbsp;=&nbsp;50k on sparse graphs. See
             <a href="https://github.com/Sirivasv/bmssp-js/blob/main/benchmarks/HEAD-TO-HEAD.md"
                target="_blank" rel="noopener">benchmarks/HEAD-TO-HEAD.md</a> for the data and
             methodology.

--- a/examples/05-flexible-inputs.mjs
+++ b/examples/05-flexible-inputs.mjs
@@ -1,0 +1,77 @@
+// Example 5 — flexible graph inputs (#172).
+//
+// Standalone: after `npm install bmssp` run `node 05-flexible-inputs.mjs`.
+// The BMSSP constructor accepts four input shapes, all equivalent: an edge
+// array, an adjacency `Map`, a plain adjacency object, and the `Graph`
+// builder. The builder is also the only way to declare an ISOLATED vertex
+// (one with no incident edges), which a bare edge list can't express.
+
+import { BMSSP, Graph } from "bmssp";
+
+export function run() {
+  // The same logical graph, four ways.
+  const edgeArray = [
+    [0, 1, 7],
+    [0, 2, 9],
+    [1, 2, 10],
+    [2, 3, 11],
+  ];
+
+  const asMap = new Map([
+    [
+      0,
+      [
+        [1, 7],
+        [2, 9],
+      ],
+    ],
+    [1, [[2, 10]]],
+    [2, [[3, 11]]],
+  ]);
+
+  // Plain-object keys are strings in JS, so they are coerced to numbers.
+  const asObject = {
+    0: [
+      [1, 7],
+      [2, 9],
+    ],
+    1: [[2, 10]],
+    2: [[3, 11]],
+  };
+
+  const asBuilder = new Graph()
+    .addEdge(0, 1, 7)
+    .addEdge(0, 2, 9)
+    .addEdge(1, 2, 10)
+    .addEdge(2, 3, 11);
+
+  console.log(
+    "Distances from node 0 — identical across all four input shapes:",
+  );
+  for (const [label, input] of [
+    ["edge array", edgeArray],
+    ["adjacency Map", asMap],
+    ["adjacency object", asObject],
+    ["Graph builder", asBuilder],
+  ]) {
+    const g = new BMSSP(input);
+    g.calculateShortestPaths(0);
+    const row = [...g.nodeIDs]
+      .sort((a, b) => a - b)
+      .map((n) => `${n}:${g.shortestPaths.get(n)}`)
+      .join("  ");
+    console.log(`  ${label.padEnd(18)} ${row}`);
+  }
+
+  // Isolated vertex: declared via addVertex, present but unreachable.
+  const withIsolated = new Graph().addEdge(0, 1, 7).addVertex(42);
+  const g = new BMSSP(withIsolated);
+  g.calculateShortestPaths(0);
+  console.log(
+    `\nIsolated vertex 42 is present but unreachable: ` +
+      `${g.shortestPaths.get(42)}`,
+  );
+}
+
+import { fileURLToPath } from "node:url";
+if (process.argv[1] === fileURLToPath(import.meta.url)) run();

--- a/examples/06-multi-source.mjs
+++ b/examples/06-multi-source.mjs
@@ -1,0 +1,53 @@
+// Example 6 — multi-source and bounded runs (#171).
+//
+// Standalone: after `npm install bmssp` run `node 06-multi-source.mjs`.
+// `calculateShortestPathsFrom(sources, { bound })` runs the paper's
+// BMSSP(l, B, S) generalization directly: from a SET of sources, each with an
+// initial distance, optionally under a strict distance bound B. Results land
+// in `shortestPaths`, exactly like `calculateShortestPaths`.
+
+import { BMSSP } from "bmssp";
+
+export function run() {
+  const g = new BMSSP([
+    [0, 1, 2],
+    [1, 2, 3],
+    [5, 2, 1],
+    [2, 3, 4],
+  ]);
+
+  const show = (label) => {
+    const row = [...g.nodeIDs]
+      .sort((a, b) => a - b)
+      .map((n) => `${n}:${g.shortestPaths.get(n)}`)
+      .join("  ");
+    console.log(`  ${label.padEnd(34)} ${row}`);
+  };
+
+  // Nearest of several sources (each seeded at distance 0). Node 2 is reached
+  // at 1 via 5->2, beating 0->1->2 = 5.
+  g.calculateShortestPathsFrom([0, 5]);
+  show("nearest-of-many [0, 5]");
+
+  // Sources with explicit initial distances. Giving source 5 a head start of
+  // 10 flips node 2 to the 0->1->2 route (5) instead.
+  g.calculateShortestPathsFrom([
+    [0, 0],
+    [5, 10],
+  ]);
+  show("with initial distances 0:0, 5:10");
+
+  // Bounded run: only vertices with distance < B are completed; everything
+  // else (including BMSSP's above-B over-estimates) is reported as Infinity.
+  g.calculateShortestPathsFrom([0], { bound: 4 });
+  show("from [0] under bound B = 4");
+
+  console.log(
+    "\nSources accept a Map, an object { id: dist }, [id, dist] pairs, " +
+      "or a\nbare array of ids (each seeded at distance 0). bound defaults " +
+      "to Infinity.",
+  );
+}
+
+import { fileURLToPath } from "node:url";
+if (process.argv[1] === fileURLToPath(import.meta.url)) run();

--- a/examples/README.md
+++ b/examples/README.md
@@ -20,6 +20,8 @@ node run-all.mjs
 | [`02-dijkstra-oracle.mjs`](02-dijkstra-oracle.mjs) | Validating BMSSP against the exported reference `dijkstra` oracle |
 | [`03-constant-degree.mjs`](03-constant-degree.mjs) | The opt-in, distance-preserving `constantDegreeTransform` |
 | [`04-larger-graph.mjs`](04-larger-graph.mjs) | Building a larger grid graph programmatically and timing a run |
+| [`05-flexible-inputs.mjs`](05-flexible-inputs.mjs) | The four accepted input shapes (edge array / adjacency `Map` / object / `Graph` builder) and isolated vertices |
+| [`06-multi-source.mjs`](06-multi-source.mjs) | `calculateShortestPathsFrom()` — nearest-of-many, custom initial distances, and bounded runs |
 | [`run-all.mjs`](run-all.mjs) | Runs every example above in order |
 
 ## Running without installing (Docker)

--- a/examples/run-all.mjs
+++ b/examples/run-all.mjs
@@ -6,12 +6,16 @@ import { run as basic } from "./01-basic.mjs";
 import { run as oracle } from "./02-dijkstra-oracle.mjs";
 import { run as constantDegree } from "./03-constant-degree.mjs";
 import { run as largerGraph } from "./04-larger-graph.mjs";
+import { run as flexibleInputs } from "./05-flexible-inputs.mjs";
+import { run as multiSource } from "./06-multi-source.mjs";
 
 const examples = [
   ["01 · Basic shortest paths & path reconstruction", basic],
   ["02 · Validate against the Dijkstra oracle", oracle],
   ["03 · Opt-in constant-degree transform", constantDegree],
   ["04 · A larger generated grid graph", largerGraph],
+  ["05 · Flexible graph inputs (Graph builder / adjacency)", flexibleInputs],
+  ["06 · Multi-source & bounded runs", multiSource],
 ];
 
 const rule = "─".repeat(64);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bmssp",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bmssp",
-      "version": "1.2.0",
+      "version": "2.0.0",
       "license": "MPL-2.0",
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bmssp",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "Javascript package implementation of the bmssp algorithm.",
   "main": "index.mjs",
   "keywords": [

--- a/src/bmssp.mjs
+++ b/src/bmssp.mjs
@@ -14,7 +14,38 @@ import {
   RELAX_LOST,
 } from "./tieBreak.mjs";
 
+/**
+ * BMSSP — the paper's Algorithm 3 behind a small class API.
+ *
+ * **Supported public API (stable as of 2.0.0 — see `MIGRATION.md`):**
+ * - `new BMSSP(input)` — construct from an edge array, an adjacency `Map`/object,
+ *   or a {@link Graph} builder (see the constructor).
+ * - {@link BMSSP#calculateShortestPaths} — single-source SSSP.
+ * - {@link BMSSP#calculateShortestPathsFrom} — multi-source / bounded run (the
+ *   ergonomic front door to the paper's `BMSSP(l, B, S)` generalization).
+ * - {@link BMSSP#bmssp} — the low-level bounded multi-source primitive (advanced;
+ *   composite keys, returns `{ bound, boundKey, vertices }`).
+ * - {@link BMSSP#reconstructPath} — canonical path for the latest run.
+ * - {@link BMSSP#getEdges} — O(1) outgoing-edge lookup.
+ * - Public fields: `shortestPaths`, `nodeIDs`, `hops`, `preds`, `adjacency`,
+ *   `graph` (all documented in the constructor).
+ *
+ * **Everything else on this class is `@internal`** — the dense-index engine
+ * (`csr`, `labels`, `ids`, `indexOf`, `bmsspIndex`, `syncLabelsIn/Out`,
+ * `boundToEngine`, `keyToPublic`, `buildIndex`, …) and the derived parameters
+ * (`k`, `t`, `topLevel`, `ties`). It is not part of the public contract and may
+ * change in a minor release. The algorithm-internal modules (`BlockList`,
+ * `MinHeap`, `baseCase`, `findPivots`, `BoundIndex`, `select`, `tieBreak`) are
+ * likewise not re-exported from `index.mjs`.
+ *
+ * @public
+ */
 class BMSSP {
+  /**
+   * @public
+   * @param {Array<[number,number,number]>|Map|Object|Graph} inputGraph - Any
+   *   #172 input shape: an edge array, an adjacency `Map`/object, or a `Graph`.
+   */
   constructor(inputGraph) {
     // #172: accept several input shapes (edge array, adjacency map/object, or
     // a Graph builder) and reduce them to a canonical { edges, vertices }.
@@ -118,6 +149,8 @@ class BMSSP {
    * same canonical labels the id-keyed engine did — and, because the
    * assignment depends only on the node-ID set, results stay invariant
    * under edge-list permutation.
+   *
+   * @internal
    */
   buildIndex() {
     const sorted = [...this.nodeIDs].sort((a, b) => a - b);
@@ -182,6 +215,8 @@ class BMSSP {
    * - topLevel = max(1, ⌈log₂ n / t⌉) — level of the top BMSSP call.
    * Everything is clamped to >= 1 so tiny graphs stay out of degenerate
    * regimes: correctness never depends on the asymptotics.
+   *
+   * @internal
    */
   deriveParameters() {
     const logn = Math.log2(Math.max(2, this.nodeIDs.size));
@@ -267,6 +302,7 @@ class BMSSP {
    *   the returned bound's length (never exceed it).
    *   Every returned vertex is complete either way.
    *
+   * @public
    * @param {number} l - Recursion level; 0 delegates to baseCase
    * @param {number|[number, number, *]} B - Strict upper bound on the keys
    *   in scope: a number (Infinity is allowed) or a composite bound
@@ -498,6 +534,7 @@ class BMSSP {
    * declared distance violates the precondition; the multi-source ground
    * truth is trueDist(v) = min over sources s of (d0[s] + dist_s(v)).
    *
+   * @public
    * @param {Map<number,number>|Object<string,number>|Array<[number,number]>|number[]} sources
    *   The source set. A Map<id, dist>, a plain object { id: dist } (numeric
    *   string keys coerced), an array of [id, dist] pairs, or a bare array of
@@ -554,6 +591,7 @@ class BMSSP {
    * target. Returns an empty array when target is unreachable or no shortest
    * path run has completed yet.
    *
+   * @public
    * @param {number} target - A node in the graph
    * @returns {number[]} Node IDs from the source through target
    * @throws {Error} If target is not in the graph

--- a/test/publicApi.test.mjs
+++ b/test/publicApi.test.mjs
@@ -1,0 +1,141 @@
+import { describe, test, expect } from "@jest/globals";
+import * as api from "../index.mjs";
+import { BMSSP, Graph, dijkstra, constantDegreeTransform } from "../index.mjs";
+
+// #173 — public API surface, locked for 2.0.0. This is the CONTRACT test: it
+// pins exactly which names `index.mjs` exports and which members make up the
+// supported public surface of each. The internal/public boundary is
+// documented (JSDoc @public/@internal + docs/index.html + MIGRATION.md); this
+// test gives it teeth — adding, removing, or renaming a public export or a
+// supported method here fails CI, so the surface can't drift by accident.
+//
+// Algorithm internals (BlockList, MinHeap, baseCase, findPivots, BoundIndex,
+// select, tieBreak, and the BMSSP dense-index engine members) are deliberately
+// NOT asserted as public — they may change in a minor release.
+
+describe("#173 index.mjs exports exactly the supported surface", () => {
+  test("exports precisely { BMSSP, Graph, constantDegreeTransform, dijkstra }", () => {
+    expect(Object.keys(api).sort()).toEqual([
+      "BMSSP",
+      "Graph",
+      "constantDegreeTransform",
+      "dijkstra",
+    ]);
+  });
+
+  test("each export has the expected kind", () => {
+    expect(typeof BMSSP).toBe("function"); // class
+    expect(typeof Graph).toBe("function"); // class
+    expect(typeof dijkstra).toBe("function");
+    expect(typeof constantDegreeTransform).toBe("function");
+  });
+});
+
+describe("#173 BMSSP supported public methods and fields", () => {
+  const PUBLIC_METHODS = [
+    "calculateShortestPaths",
+    "calculateShortestPathsFrom",
+    "bmssp",
+    "reconstructPath",
+    "getEdges",
+  ];
+  const PUBLIC_FIELDS = [
+    "shortestPaths",
+    "nodeIDs",
+    "hops",
+    "preds",
+    "adjacency",
+    "graph",
+  ];
+
+  test("every documented public method exists on the prototype", () => {
+    for (const name of PUBLIC_METHODS) {
+      expect(typeof BMSSP.prototype[name]).toBe("function");
+    }
+  });
+
+  test("every documented public field is present on an instance", () => {
+    const g = new BMSSP([[0, 1, 5]]);
+    for (const name of PUBLIC_FIELDS) {
+      expect(g[name]).toBeDefined();
+    }
+    expect(g.shortestPaths instanceof Map).toBe(true);
+    expect(g.nodeIDs instanceof Set).toBe(true);
+    expect(g.adjacency instanceof Map).toBe(true);
+    expect(Array.isArray(g.graph)).toBe(true);
+  });
+
+  test("the documented public methods behave as specified end-to-end", () => {
+    const g = new BMSSP([
+      [0, 1, 5],
+      [1, 2, 3],
+    ]);
+    g.calculateShortestPaths(0);
+    expect(g.shortestPaths.get(2)).toBe(8);
+    expect(g.reconstructPath(2)).toEqual([0, 1, 2]);
+    expect(g.getEdges(0)).toEqual([[1, 5]]);
+
+    g.calculateShortestPathsFrom([2], { bound: Infinity });
+    expect(g.shortestPaths.get(2)).toBe(0);
+
+    // The advanced primitive returns the composite-key result object.
+    g.initializeShortestPaths?.();
+    g.shortestPaths.set(0, 0);
+    const result = g.bmssp(g.topLevel, Infinity, new Set([0]));
+    expect(result).toHaveProperty("bound");
+    expect(result).toHaveProperty("boundKey");
+    expect(result.vertices instanceof Set).toBe(true);
+  });
+});
+
+describe("#173 Graph builder public surface", () => {
+  const PUBLIC = ["addVertex", "addEdge", "hasVertex", "toNormalized"];
+
+  test("builder exposes its documented methods", () => {
+    for (const name of PUBLIC) {
+      expect(typeof Graph.prototype[name]).toBe("function");
+    }
+  });
+
+  test("mutators chain and produce a normalized shape", () => {
+    const g = new Graph().addEdge(0, 1, 50).addVertex(9);
+    expect(g).toBeInstanceOf(Graph);
+    const { edges, vertices } = g.toNormalized();
+    expect(edges).toEqual([[0, 1, 50]]);
+    expect(vertices).toContain(9);
+  });
+});
+
+describe("#173 constantDegreeTransform return shape is locked", () => {
+  test("returns { edges, copiesOf, originalOf, sourceCopy, collapse }", () => {
+    const t = constantDegreeTransform([
+      [0, 1, 5],
+      [0, 2, 3],
+    ]);
+    expect(Object.keys(t).sort()).toEqual([
+      "collapse",
+      "copiesOf",
+      "edges",
+      "originalOf",
+      "sourceCopy",
+    ]);
+    expect(Array.isArray(t.edges)).toBe(true);
+    expect(t.copiesOf instanceof Map).toBe(true);
+    expect(t.originalOf instanceof Map).toBe(true);
+    expect(typeof t.sourceCopy).toBe("function");
+    expect(typeof t.collapse).toBe("function");
+  });
+});
+
+describe("#173 dijkstra oracle signature is locked", () => {
+  test("dijkstra(graph, nodeIDs, source) → Map<id, distance>", () => {
+    const graph = [
+      [0, 1, 5],
+      [1, 2, 3],
+    ];
+    const nodeIDs = new Set([0, 1, 2]);
+    const dist = dijkstra(graph, nodeIDs, 0);
+    expect(dist instanceof Map).toBe(true);
+    expect(dist.get(2)).toBe(8);
+  });
+});


### PR DESCRIPTION
Closes #173. **Milestone-closing PR for 2.0.0.**

## Summary

A **documentation + contract lockdown** of the public API — **no behavior change, no breaking changes** on the documented surface. #205 (dense-index engine), #172 (flexible inputs), and #171 (multi-source entrypoint) all landed additively, so 2.0.0 is a **stability commitment + feature consolidation**, not a breaking release.

### User-confirmed decisions
- **Document-only boundary** (JSDoc `@public`/`@internal`), **no `#`-privatization** — the fuzz / baseCase / findPivots / tieBreak suites drive internals directly, and hard-privatizing would mean rewriting them and losing internal unit-test access.
- **Keep `this.graph` / `this.adjacency` public** — the #172/#206 direct-CSR construction perf lever is deferred to a new post-2.0 issue.
- **Keep the raw `bmssp(l, B, S)` wrapper** as a documented *advanced* public entrypoint (the low-level bounded multi-source primitive), with `calculateShortestPathsFrom` as the ergonomic front door.

## Deliverables

- **`src/bmssp.mjs`** — class-level JSDoc enumerating the supported public surface + `@public`/`@internal` tags on the method JSDoc. No code behavior change.
- **`test/publicApi.test.mjs`** — 9 **contract tests** pinning the four exports (`BMSSP`, `Graph`, `dijkstra`, `constantDegreeTransform`), the `BMSSP`/`Graph` supported members, and the `constantDegreeTransform`/`dijkstra` shapes. Any export/rename drift now fails CI — the teeth behind the document-only boundary.
- **`MIGRATION.md`** — the 1.0 → 2.0 note: no breaking changes, the locked public surface, and what is now explicitly `@internal`. Linked from `README.md`.
- **`docs/index.html`** — rewritten to document all four exports + `calculateShortestPathsFrom` + the advanced `bmssp`; the stale "~1M comparison crossover" line corrected to <50k.
- **`examples/`** — new `05-flexible-inputs.mjs` (the four input shapes + isolated vertex) and `06-multi-source.mjs` (`calculateShortestPathsFrom`: nearest-of-many, custom `d0`, bounded), wired into `run-all.mjs` and the gallery README. Verified end-to-end via a temporary self-symlink (`node_modules/bmssp` → repo), then cleaned up.

## Version / tests / lint

- **major → 2.0.0** (`npm version major`; `package.json` + lockfile in sync).
- Suite **237 (236 passing + 1 XL skip)**; lint clean. New contract tests + two examples; no behavior change means every pre-existing oracle/determinism/fuzz assertion passes untouched.

## Roadmap proposals (Phase E — gated)

1. **Close milestone `2.0.0`** — #173 is its last open issue (4/4 with #205/#172/#171).
2. **Create a new issue** for the deferred **direct-CSR construction** perf lever (build the index/CSR without the `[from,to,weight]` round-trip) — requires `this.graph`/`this.adjacency` to become lazy/derived, so a 3.0 / future-major candidate.
3. *(Optional)* file a small enhancement issue for a **richer multi-source return** (`{ bound, vertices }`), if you want it tracked.
4. **Decide the next-milestone direction** — 2.0.0 is the last defined milestone; propose creating one (performance and/or ergonomics) to host proposals 2–3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)