### PR TITLE
feat(#212): direct-CSR construction — remove public graph/adjacency (major → 3.0.0)

### DIFF
--- a/.claude/knowledge/05-codebase-map.md
+++ b/.claude/knowledge/05-codebase-map.md
@@ -1,19 +1,21 @@
 # 05 — Codebase Map (current state)
 
-<!-- BOOKMARK-COMMIT: d56bc86 -->
-<!-- PENDING-PR-BRANCH: feat/173-stabilize-public-api -->
-<!-- Last validated: 2026-07-21 (Phase C of the #173 PR, branch feat/173-stabilize-public-api,
-     based on main d56bc86). This PR is the milestone-closing 2.0.0 work: public-API
-     STABILIZATION (documentation + contract lockdown, no behavior change). Adds @public/
-     @internal JSDoc across the BMSSP class, a contract test (test/publicApi.test.mjs) pinning
-     the 4 exports + supported members, MIGRATION.md (1.0→2.0, no breaking changes), two new
-     examples (05-flexible-inputs, 06-multi-source), and a rewritten docs/index.html (4 exports
-     + calculateShortestPathsFrom + advanced bmssp). User-confirmed decisions: document-only
-     boundary (no #-privatization), keep this.graph/this.adjacency public (direct-CSR perf
-     lever deferred to a new post-2.0 issue), keep raw bmssp(l,B,S) as advanced public API.
-     **major → 2.0.0** (npm version major applied). Body describes post-merge reality; markers
-     fast-path on the next session's Phase A. Also folds in the #171-PR RKB marker flip
-     (BOOKMARK d56bc86) that had been left as a local bookkeeping edit. -->
+<!-- BOOKMARK-COMMIT: 47fae54 -->
+<!-- PENDING-PR-BRANCH: feat/212-direct-csr-construction -->
+<!-- Last validated: 2026-07-22 (Phase C of the #212 PR, branch feat/212-direct-csr-construction,
+     based on main 47fae54). This PR is the milestone-closing 3.0.0 work: DIRECT-CSR
+     CONSTRUCTION — the constructor builds the dense index + CSR + typed labels straight from
+     the validated input edges, removing the intermediate this.graph deep-copy and the
+     this.adjacency Map (and buildAdjacency). Purely construction-side + label-preserving (CSR
+     byte-identical), so every oracle/determinism assertion is unchanged; roughly HALVES
+     construction time (n=500k/m=1.5M: ~510 → ~240 ms median, clean A/B vs main 2.0.0).
+     BREAKING: the public this.graph / this.adjacency fields are gone → getEdges materializes
+     the edge view from CSR on demand. User-confirmed decision (2026-07-22): remove the fields
+     (not lazy getters). Test/bench migration: new test/helpers.mjs edgesOf() + bench-util
+     adjacencyOf() rebuild oracle inputs from getEdges; publicApi.test pins the fields as GONE.
+     **major → 3.0.0** (npm version major applied). Body describes post-merge reality; markers
+     fast-path on the next session's Phase A. Also carries the #173-PR Phase-E 06 reconciliation
+     that branch protection had stranded as a local bookkeeping edit. -->
 
 
 Snapshot of what exists in `bmssp-js` today, so you know what to build on vs. what's missing.
@@ -68,6 +70,8 @@ index.mjs                 # re-exports { BMSSP }, { dijkstra }, { constantDegree
 src/
   bmssp.mjs               # BMSSP class — full Algorithm 3 recursion (#43); wires the pieces below.
                           #      Constructor accepts flexible inputs via normalizeGraphInput (#172)
+                          #      and builds the index/CSR DIRECTLY from them (#212) — no this.graph
+                          #      deep-copy, no this.adjacency Map; getEdges reads the CSR on demand
   graph.mjs               # #172: public `Graph` input builder (addVertex/addEdge, chainable) +
                           #      normalizeGraphInput — edge array | adjacency Map/object | Graph →
                           #      canonical { edges, vertices }; `vertices` = explicit vertex universe
@@ -92,7 +96,8 @@ test/
   graph.test.mjs          # #172: 18 tests — Graph builder (chain/idempotent/copies/eager validation), adjacency Map/object inputs, object-key coercion, isolated vertices (empty & null neighbor lists, declared, as source), cross-shape oracle equivalence (seeded 2k), unrecognized-input + malformed-adjacency throws
   pathReconstruction.test.mjs # #169: 3 public-API tests — Dijkstra path oracle, unreachable/pre-run/source switching, target validation
   multiSource.test.mjs     # #171: 19 tests — calculateShortestPathsFrom: single-source equivalence, nearest-of-many + custom-d0 multi-source oracle, bounded pruning, all input shapes, reconstructPath/state-reset integration, validation
-  publicApi.test.mjs       # #173: 9 CONTRACT tests — pins the 4 exports + BMSSP/Graph supported members + constantDegreeTransform/dijkstra shapes; export/rename drift fails CI
+  publicApi.test.mjs       # #173: CONTRACT tests — pins the 4 exports + BMSSP/Graph supported members + constantDegreeTransform/dijkstra shapes; export/rename drift fails CI. #212: +1 test pinning graph/adjacency as REMOVED (10 total)
+  helpers.mjs              # #212: shared test helper edgesOf(instance) — rebuilds a [from,to,weight][] edge array from the public getEdges() view (the removed this.graph), to feed the dijkstra oracle
   blockList.test.mjs      # #42: 25 BlockList tests incl. seeded random stress, #182 many-chunk/M=1 regression tests + #167 machinery tests
   boundIndex.test.mjs     # #167: 8 BoundIndex tests — sequence ops, monotone findFirst, AVL invariants under seeded churn
   select.test.mjs         # #167: 9 partitionByRank tests — every-rank contract, worst-case orderings, duplicates, determinism
@@ -103,7 +108,8 @@ test/
   README.md               # test-suite principles (everything seeded, no data files) + file map
 benchmarks/               # dependency-free benchmark harness, `npm run bench` / `npm run bench:counts`
   generators.mjs          #   seeded graph builders + SCENARIOS registry (sparse/dense/grid/chain/star/sparse-l4)
-  bench-util.mjs          #   timing (timeMany), markdown-table + countMismatches helpers
+  bench-util.mjs          #   timing (timeMany), markdown-table + countMismatches helpers;
+                          #     #212 adjacencyOf(instance) — Map view rebuilt from getEdges for the fair Dijkstra baseline (built once, outside timing)
   adjacency.bench.mjs     #   adjacency map (#45) vs. linear edge scan
   scenarios.bench.mjs     #   #170: head-to-head per shape — construct + dijkstra + bmssp timings, verified outputs
   dijkstra-adj.mjs        #   #170: algorithm-only Dijkstra over prebuilt adjacency + comparison counter (fair baseline)
@@ -147,10 +153,10 @@ class BMSSP {
                                    // vertices }; validates edges (finite numeric node IDs,
                                    // finite non-negative weights) + folds in declared
                                    // vertices (isolated OK); [] / {} / empty Graph remain valid
-  //   this.graph          : deep-copied edge array
   //   this.nodeIDs        : Set of all node IDs (from both endpoints)
   //   this.shortestPaths  : Map<nodeId, distance>, initialized to Infinity  ← public d̂[·]
-  //   this.adjacency      : Map<nodeId, Array<[to, weight]>>  ← #45 public edge view (getEdges)
+  //   (#212 REMOVED this.graph + this.adjacency — CSR is the single source of truth;
+  //    getEdges() materializes a node's [to,weight] edges from the CSR on demand)
   //   this.hops, this.preds : Map — #163 canonical labels, public mirror refreshed after a run
   //   this.ties           : { hops, preds } bundle (public boundary compatibility)
   //   --- #205 dense engine (indices assigned in ascending-id order) ---
@@ -160,9 +166,10 @@ class BMSSP {
   //   this.labels         : { dist:Float64Array, hops:Uint32Array, preds:Int32Array } ← engine d̂
   //   this.k, this.t, this.topLevel : paper parameters, derived in the constructor
   initializeShortestPaths()        // reset public Maps AND engine label arrays to ∞ / 0 / NO_PRED
-  buildAdjacency()                 // #45: (re)build the public adjacency Map from this.graph
-  buildIndex()                     // #205: sorted-id index + CSR + typed labels (called in ctor)
-  getEdges(nodeId)                 // #45: O(1) outgoing-edge lookup; [] for unknown nodes
+  buildIndex(edges)                // #205/#212: sorted-id index + CSR + typed labels built
+                                   //      DIRECTLY from the validated input edges (called in ctor)
+  getEdges(nodeId)                 // #45/#212: node's [to,weight] edges materialized from the
+                                   //      CSR (input edge order); [] for unknown nodes
   deriveParameters()               // #43: k = max(1,⌊(log₂n)^⅓⌋), t = max(1,⌊(log₂n)^⅔⌋),
                                    //      topLevel = max(1,⌈log₂n / t⌉) — from this.nodeIDs.size
   syncLabelsIn() / syncLabelsOut() // #205: snapshot public shortestPaths → engine arrays before a
@@ -192,6 +199,22 @@ offending edge index (unchanged messages). Declared `vertices` (the explicit uni
 (`[]` / `{}` / `new Map()` / `new Graph()`) remains valid and preserves the #162 contract:
 construction succeeds, then `calculateShortestPaths()` rejects any start node because the
 graph has no nodes.
+
+**Direct-CSR construction (#212, milestone-closing → 3.0.0).** The constructor builds the
+dense index + CSR + typed labels **directly** from the validated input edges — there is no
+longer an intermediate `this.graph` deep-copy or an eager `this.adjacency` Map (`buildAdjacency`
+is gone). `buildIndex(edges)` takes the normalized edge array as a parameter: it validates
+node membership, counts per-node out-degrees, prefix-sums the `offsets`, and fills
+`targets`/`weights` straight from `edges`. **BREAKING:** the public `this.graph` and
+`this.adjacency` fields are removed (user-confirmed 2026-07-22 — remove, not lazy getters), so
+`getEdges(nodeId)` now materializes a node's `[to,weight]` edges from the CSR on demand
+(`[]` for unknown / isolated nodes). Because the CSR is built from the same edges in the same
+order, it is **byte-identical** to the pre-#212 round-trip, so every canonical label / oracle /
+determinism assertion is unchanged — this is a construction-side change, not an engine change.
+Measured payoff: construction time **roughly halved** (n=500k / m=1.5M: ~510 → ~240 ms median,
+clean A/B vs `main` 2.0.0). Test/bench code that fed the removed fields to the Dijkstra oracles
+rebuilds them from `getEdges` via `edgesOf` (`test/helpers.mjs`) / `adjacencyOf`
+(`benchmarks/bench-util.mjs`); `test/publicApi.test.mjs` pins the two fields as **removed**.
 
 **Flexible inputs (#172, `src/graph.mjs`).** `normalizeGraphInput(input)` recognizes four
 shapes and always yields `{ edges: [[from,to,weight]…], vertices: [id…] }`:
@@ -256,7 +279,8 @@ lockdown**, no behavior change (user-confirmed: document-only boundary, no `#`-p
 The class carries a class-level JSDoc enumerating the **supported public surface** — the
 constructor, `calculateShortestPaths`, `calculateShortestPathsFrom`, `bmssp(l,B,S)` (advanced
 primitive), `reconstructPath`, `getEdges`, and the public fields `shortestPaths` / `nodeIDs`
-/ `hops` / `preds` / `adjacency` / `graph` — with `@public`/`@internal` tags on the method
+/ `hops` / `preds` (in 2.0.0 also `adjacency` / `graph`, **removed by #212**) — with
+`@public`/`@internal` tags on the method
 JSDoc. Everything else (the dense-index engine: `csr`, `labels`, `ids`, `indexOf`,
 `bmsspIndex`, `syncLabelsIn/Out`, `boundToEngine`/`keyToPublic`, `normalizeSources`,
 `buildIndex`, `deriveParameters`, `k`/`t`/`topLevel`/`ties`) is `@internal` — may change in a
@@ -264,10 +288,11 @@ minor. `index.mjs` exports exactly four names (`BMSSP`, `Graph`, `dijkstra`,
 `constantDegreeTransform`); the algorithm-internal modules stay unexported. `MIGRATION.md`
 records the 1.0→2.0 story (**no breaking changes** — #205/#172/#171 all landed additively, so
 2.0.0 is a stability commitment + feature consolidation), and `test/publicApi.test.mjs` pins
-the surface so export/rename drift fails CI. **Deferred (user-directed):** `this.graph` /
-`this.adjacency` stay public, so the #172/#206 direct-CSR construction perf lever is deferred
-to a new post-2.0 issue (Roadmap proposal); the raw `bmssp(l,B,S)` wrapper stays a documented
-advanced entrypoint.
+the surface so export/rename drift fails CI. In 2.0.0 the raw `bmssp(l,B,S)` wrapper stayed a
+documented advanced entrypoint and `this.graph` / `this.adjacency` stayed public (the #172/#206
+direct-CSR construction perf lever deferred to #212). **#212 (3.0.0) then removed those two
+fields** and did the direct-CSR construction — see the "Direct-CSR construction (#212)"
+paragraph above; the contract test now pins them as gone.
 
 **`bmsspIndex(l, boundKey, S)` (#43):** level 0 delegates to `baseCase`. At level ≥ 1:
 `findPivots` shrinks the frontier; pivots seed a `BlockList(M = 2^((l-1)·t), boundKey,
@@ -531,7 +556,7 @@ into `{ hops, preds }` Maps for `reconstructPath` and external inspection.
 
 `dijkstra(graph, nodeIDs, source) → Map<nodeId, distance>`. Standard array binary min-heap
 with lazy stale-entry skipping (no `DecreaseKey`). Builds its own adjacency list from the edge
-array (independent of the class's `this.adjacency`). This is the **ground truth** the BMSSP
+array (independent of the class's CSR / `getEdges`). This is the **ground truth** the BMSSP
 implementation is tested against — and, since #43, no longer part of the BMSSP code path.
 
 ## `src/constantDegree.mjs` — constant-degree transform (#164)
@@ -587,7 +612,9 @@ every accepted shape. See §"Flexible inputs (#172)" for the per-shape contract.
 ## Tests — the contract
 
 - `test/main.test.mjs` (16): constructor input-validation failures (#165), nodeIDs,
-  adjacency, and shortestPaths contracts, plus the
+  `getEdges` (CSR edge view; #212-repurposed from the old adjacency-Map assertions —
+  ingests every input edge, sink → `[]`, edge count preserved), and shortestPaths
+  contracts, plus the
   **key one** — "BMSSP vs Dijkstra" on a **seeded 10k-node sparse graph** (`sparseRandom(10_000,
   3, 1601)`, already `topLevel` 3): for a fixed source, `myBMSSP.shortestPaths` must equal
   `dijkstra(...)` for every node. (Until 2026-07-17 this ran on `roadNet-CA.txt`, an 87 MB
@@ -676,7 +703,8 @@ every accepted shape. See §"Flexible inputs (#172)" for the per-shape contract.
   dijkstra }` and their kinds; the `BMSSP` prototype has every documented public method
   (`calculateShortestPaths`, `calculateShortestPathsFrom`, `bmssp`, `reconstructPath`,
   `getEdges`) and an instance carries the public fields (`shortestPaths`/`nodeIDs`/`hops`/
-  `preds`/`adjacency`/`graph`), with an end-to-end behavior smoke check; the `Graph` builder's
+  `preds`) — and, since #212, that the removed `adjacency`/`graph` fields are **absent** —
+  with an end-to-end behavior smoke check; the `Graph` builder's
   public methods + chaining/`toNormalized` shape; `constantDegreeTransform`'s locked return
   keys; and `dijkstra`'s signature. Adding/removing/renaming any of these fails CI — the teeth
   behind the document-only boundary.
@@ -708,16 +736,17 @@ every accepted shape. See §"Flexible inputs (#172)" for the per-shape contract.
   (identical maps incl. Infinity → 0; wrong/missing entries counted); `runScenarioBenchmark`
   and `runComparisonCountBenchmark` on tiny injected scenarios return the expected columns
   with **zero mismatches**.
-- Current suite: **237 tests — 236 passing + 1 XL skipped by default** (#173 added the
-  9-test contract `publicApi.test.mjs`; #171 the 19-test `multiSource.test.mjs`; #172 the
-  18-test `graph.test.mjs`; `bmssp.mjs`, `index.mjs` and `graph.mjs` at 100%),
-  ~100% statement coverage, ~7.5 s wall-clock (the #164 distance-preservation sweeps run
+- Current suite: **238 tests — 237 passing + 1 XL skipped by default** (#212 added a
+  contract test pinning `graph`/`adjacency` as removed, taking `publicApi.test.mjs` to 10;
+  #171 the 19-test `multiSource.test.mjs`; #172 the 18-test `graph.test.mjs`; `bmssp.mjs`,
+  `index.mjs`, `graph.mjs` and `test/helpers.mjs` at 100%),
+  ~100% statement coverage, ~7 s wall-clock (the #164 distance-preservation sweeps run
   BMSSP/Dijkstra from every source). No graph data files: every generated test graph comes
-  from a seed; the #162 fixtures are hand-built and fully deterministic. The #205 dense-index
-  engine changed the internal function signatures (`baseCase`/`findPivots` take
-  `labels`/`csr` + index sets) but not a single oracle/determinism assertion — the fuzz,
-  edge-case, tie-break-determinism and constant-degree suites pass unchanged, which is
-  the correctness proof that the id→index refactor preserved every canonical label.
+  from a seed; the #162 fixtures are hand-built and fully deterministic. Like #205, the #212
+  direct-CSR change touched construction and the test/bench oracle plumbing (`edgesOf`/
+  `adjacencyOf` rebuild the removed fields from `getEdges`) but not a single oracle/determinism
+  assertion — the fuzz (incl. FUZZ_ROUNDS=25 + FUZZ_XL 2M), edge-case, tie-break-determinism
+  and constant-degree suites pass unchanged, the correctness proof that the CSR is identical.
 
 ## Benchmarks (`benchmarks/`, `npm run bench` / `npm run bench:counts`)
 
@@ -726,8 +755,10 @@ BMSSP-vs-Dijkstra head-to-head itself:
 
 - `adjacency.bench.mjs`: the #45 map is ~thousands× faster per-node than a linear scan.
 - `scenarios.bench.mjs`: per shape, algorithm-only `dijkstra ms` / `bmssp ms` / `ratio`
-  columns — both sides consume the BMSSP instance's prebuilt adjacency (`dijkstra-adj.mjs`
-  is the fair baseline) and outputs are verified node-by-node (`mismatches` must be 0).
+  columns — both sides consume an adjacency Map built once from the BMSSP instance via
+  `adjacencyOf` (getEdges → Map; since #212 the class no longer stores one) outside the timed
+  region (`dijkstra-adj.mjs` is the fair baseline) and outputs are verified node-by-node
+  (`mismatches` must be 0).
   Scenario registry adds `sparse-random-l4` (n = 300k, degree 3): `topLevel` steps 3→4 at
   exactly n = 2^18 + 1 and stays 4 until t reaches 7 (~n = 376k), so 300k sits inside the
   #182 level-transition window (the step itself measures ~+24% at the exact straddle).
@@ -770,13 +801,14 @@ BMSSP-vs-Dijkstra head-to-head itself:
 | Dense-index core: typed-array labels + CSR adjacency | `src/tieBreak.mjs` (makeLabels) + `src/bmssp.mjs` (buildIndex/CSR) + `src/baseCase.mjs` + `src/findPivots.mjs` | #205 | ✅ merged (PR #206, no bump — API-non-breaking) |
 | Typed / flexible graph inputs (Graph builder + adjacency Map/object + explicit vertex universe) | `src/graph.mjs` (new) + `src/bmssp.mjs` (constructor) + `index.mjs` (Graph export) + `test/graph.test.mjs` | #172 | ✅ merged (PR #208, no bump — mid-2.0.0) |
 | Public multi-source / bounded entrypoint (`calculateShortestPathsFrom`) | `src/bmssp.mjs` + `test/multiSource.test.mjs` | #171 | ✅ merged (PR #209, no bump — mid-2.0.0) |
-| Public-API stabilization + 1.0→2.0 migration note | `src/bmssp.mjs` (JSDoc) + `MIGRATION.md` + `docs/index.html` + `examples/` + `test/publicApi.test.mjs` | #173 | ✅ done-pending-merge (this PR, **major → 2.0.0** — milestone-closing) |
+| Public-API stabilization + 1.0→2.0 migration note | `src/bmssp.mjs` (JSDoc) + `MIGRATION.md` + `docs/index.html` + `examples/` + `test/publicApi.test.mjs` | #173 | ✅ merged (PR #210, **major → 2.0.0**, released 2026-07-21 — milestone-closing) |
+| Direct-CSR construction: build index/CSR from the input, remove public `graph`/`adjacency` | `src/bmssp.mjs` (constructor/buildIndex/getEdges) + `test/helpers.mjs` + `benchmarks/bench-util.mjs` + test/docs migration | #212 | ✅ done-pending-merge (this PR, **major → 3.0.0** — milestone-closing) |
 
-Milestones `1.1.0` (correctness hardening) and `1.2.0` (performance & ergonomics) are
-both **closed** — 1.2.0 released 2026-07-21 (npm + Docker Hub). Milestone `2.0.0`
-(API-breaking generalization) is being closed by **this PR**: **#205** (dense-index core,
-PR #206), **#172** (typed/flexible inputs, PR #208), and **#171** (public multi-source/bounded
-entrypoint, PR #209) all merged (no bumps), and **#173** (this PR) stabilizes the public API
-surface and takes the **major → 2.0.0** bump. In practice the three generalizations landed
-additively, so 2.0.0 has **no breaking changes** on the documented surface — it is a stability
-commitment (see `MIGRATION.md`). See [06-milestones-roadmap.md](06-milestones-roadmap.md).
+Milestones `1.1.0` (correctness hardening), `1.2.0` (performance & ergonomics) and `2.0.0`
+(API-breaking generalization — #205/#172/#171/#173) are all **closed and released**
+(2.0.0 on 2026-07-21, npm + Docker Hub; landed additively, so 2.0.0 had **no breaking
+changes** — see `MIGRATION.md`). Milestone `3.0.0` (performance) is being closed by **this
+PR**: **#212** (direct-CSR construction) is its only issue — it builds the index/CSR straight
+from the input and removes the public `this.graph` / `this.adjacency` fields (the one breaking
+change, hence **major → 3.0.0**), roughly halving construction time. See
+[06-milestones-roadmap.md](06-milestones-roadmap.md).

--- a/.claude/knowledge/06-milestones-roadmap.md
+++ b/.claude/knowledge/06-milestones-roadmap.md
@@ -1,11 +1,14 @@
 # 06 — Milestones Roadmap
 
-<!-- SYNCED-FROM-GITHUB: 2026-07-21 (Phase C of the #173 PR, branch feat/173-stabilize-public-api,
-     based on main d56bc86): 1.2.0 CLOSED; 2.0.0 open, 3 closed (#205, #172, #171) + 1 open
-     (#173). #173 done-pending-merge this PR (public-API stabilization, **major → 2.0.0**) —
-     the milestone-closing issue; on merge + release, milestone 2.0.0 closes. -->
-<!-- Current package version: 2.0.0 — BUMPED in the #173 PR (npm version major), NOT yet
-     released. Latest tag is 1.2.0. On merge, Phase 2 tags 2.0.0 + GitHub Release (with
+<!-- SYNCED-FROM-GITHUB: 2026-07-22 (Phase C of the #212 PR, branch feat/212-direct-csr-construction,
+     based on main 47fae54). 1.1.0/1.2.0/2.0.0 CLOSED + RELEASED. Milestone **3.0.0 —
+     performance** (number 5) has its only issue #212 (direct-CSR construction) done-pending-
+     merge in this PR (**major → 3.0.0** — milestone-closing). On merge + release, 3.0.0
+     closes. This file also still carries the #173-PR Phase E reconciliation (2.0.0 closed,
+     3.0.0 + #212 created) that branch protection had stranded as a local edit — it rides this
+     PR branch. -->
+<!-- Current package version: 3.0.0 — BUMPED in the #212 PR (npm version major), NOT yet
+     released. Latest tag is 2.0.0. On merge, Phase 2 tags 3.0.0 + GitHub Release (with
      Announcements discussion) → npm + Docker Hub via publish.yml. Until then this is a
      bumped-but-untagged version (Phase A step 5 surfaces it). -->
 <!-- Release-discussion convention (user-directed 2026-07-21): every GitHub Release also
@@ -46,31 +49,35 @@ it runs the same Phase C reconciliation directly on `main`.
 
 ## 📋 Roadmap proposals (pending user approval)
 
-**#173 PR (this PR, milestone-closing) — proposals:**
+**#212 PR (this PR, milestone-closing → 3.0.0) — proposals:**
 
-1. **Close milestone `2.0.0`** — #173 is its last open issue; on this PR's merge + the 2.0.0
-   release, the milestone is complete (4/4: #205, #172, #171, #173).
-2. **Create a new issue: "Direct-CSR construction — skip the edge-list round-trip."** The
-   #172/#206 perf lever, deferred again by #173's user-confirmed decision to keep
-   `this.graph` / `this.adjacency` public (tests + `main.test.mjs` depend on them). Building
-   the index/CSR straight from the input — bypassing the `[from,to,weight]` copy — needs those
-   fields to become lazy/derived or private, i.e. a breaking change. So it is a **3.0 / future-
-   major** candidate (or a carefully non-breaking lazy-getter approach in a minor). Needs a
-   home milestone — see proposal 4.
-3. **(Optional) Create a small enhancement issue: "Richer multi-source return."** #171 chose
-   write-to-Map / returns-nothing for `calculateShortestPathsFrom`; the internal wrapper still
-   produces `{ bound, vertices }`. Surfacing it (an optional return or companion method) is a
-   purely additive future enhancement — file only if the user wants it tracked.
-4. **Decide the next milestone direction with the user.** 2.0.0 is the last defined milestone;
-   the core algorithm is feature-complete. Natural next buckets: a **performance** milestone
-   (direct-CSR construction + further engine work) and/or an **ergonomics/polish** one. Propose
-   creating one milestone (name/number TBD with the user) to host proposals 2–3, rather than
-   leaving them unmilestoned.
+1. **Close milestone `3.0.0`** — #212 is its only issue; on this PR's merge + the 3.0.0
+   release, the milestone is complete (1/1).
+2. **Decide the next milestone direction with the user.** With 3.0.0 the core algorithm is
+   feature-complete *and* the big construction/engine perf levers (#205 dense-index, #212
+   direct-CSR) are spent. There is no defined next milestone. Options to weigh with the user:
+   (a) a **further-performance** milestone (see proposal 3 for a concrete candidate), (b) an
+   **ergonomics/interop** milestone (e.g. TypeScript type declarations, a streaming/large-graph
+   ingestion path), or (c) declare the project **feature-complete / maintenance-mode** and open
+   no new milestone. Recommend deciding (a/b/c) before filing anything.
+3. **(Optional) File a follow-up perf issue: "Skip the id sort for already-dense inputs."**
+   `buildIndex` still sorts the node-ID set (`O(n log n)`) to assign ascending-id indices; when
+   the input ids are already the dense range `0..n-1` (a common case, e.g. generated grids),
+   the sort is avoidable with a fast-path (detect contiguous ids, or a counting/radix pass).
+   Purely a construction micro-opt, label-preserving. File only if the user wants a further-perf
+   milestone (proposal 2a).
 
 _These are Phase E gated GitHub writes — execute only after the user confirms the merge, one
 confirmation per edit._
 
 _Previously executed proposals (kept for provenance):_
+
+_(The #173-PR proposals (PR #210) were approved and executed 2026-07-21 in Phase E:
+(1) milestone **2.0.0 closed** (4/4 done); (2) new issue **#212** "Direct-CSR construction —
+build the index/CSR without the edge-list round-trip" created — the deferred #172/#206 perf
+lever, breaking because it needs public `this.graph`/`this.adjacency` to become lazy/private;
+(3) new milestone **3.0.0 — performance** (number 5) created to host #212. The optional
+"richer multi-source return" enhancement was **not** filed (offered; not requested).)_
 
 _(The #171-PR proposal (PR #209) — a single comment on **#173** recording the #171-derived
 decisions it must resolve now that the public multi-source surface exists (the public/private
@@ -299,7 +306,8 @@ executed 2026-07-17.)_
   228 (227 + 1 XL skip), `bmssp.mjs` 100%, lint clean. **#173 is the only 2.0.0 issue
   left** (milestone-closing, major → 2.0.0). Roadmap proposal (comment on #173 recording the
   API-stabilization decisions #171 hands off) was approved and posted 2026-07-21.
-- **#173 done-pending-merge (this PR, major → 2.0.0 — milestone-closing):** public-API
+- **#173 merged (PR #210, 2026-07-21, commit 47fae54; major → 2.0.0, RELEASED + milestone
+  closed same day):** public-API
   stabilization, a **documentation + contract lockdown** with no behavior change.
   User-confirmed decisions (2026-07-21): **document-only** boundary (JSDoc `@public`/
   `@internal`, no `#`-privatization — the fuzz/baseCase/findPivots/tieBreak suites drive
@@ -312,8 +320,28 @@ executed 2026-07-17.)_
   + advanced `bmssp`; stale ~1M crossover claim corrected to <50k); two new examples
   (`05-flexible-inputs`, `06-multi-source`) wired into `run-all`; and `test/publicApi.test.mjs`
   (9 contract tests pinning the surface). **major → 2.0.0** (`npm version major`). Suite 237
-  (236 + 1 XL skip), lint clean. Roadmap proposals: close milestone 2.0.0, file the deferred
-  direct-CSR perf issue, and decide the next-milestone direction with the user (Phase E).
+  (236 + 1 XL skip), lint clean. **Released 2026-07-21** (tag 2.0.0 + GitHub Release with
+  Announcements discussion → npm 2.0.0 + Docker Hub, publish.yml succeeded). Phase E executed:
+  milestone **2.0.0 closed** (4/4), issue **#212** (direct-CSR construction) filed under a new
+  **3.0.0 — performance** milestone.
+- **#212 done-pending-merge (this PR, major → 3.0.0 — milestone-closing):** direct-CSR
+  construction, the only issue in milestone 3.0.0. The constructor now builds the dense index
+  + CSR + typed labels **directly** from the normalized input edges (`buildIndex(edges)`),
+  removing the intermediate `this.graph` deep-copy and the eager `this.adjacency` Map
+  (`buildAdjacency` gone). **BREAKING:** the public `this.graph`/`this.adjacency` fields are
+  **removed** — user-confirmed 2026-07-22 to remove them outright rather than keep a
+  non-breaking lazy getter — so `getEdges(nodeId)` now materializes a node's `[to,weight]`
+  edges from the CSR on demand. Because the CSR is built from the same edges in the same order
+  it is **byte-identical** to the pre-#212 round-trip: every oracle/determinism assertion is
+  unchanged (default suite + FUZZ_ROUNDS=25 + FUZZ_XL 2M all green). **Measured payoff:
+  construction ~halved** — clean A/B vs `main` 2.0.0 at n=500k/m=1.5M: ~510 → ~240 ms median.
+  Test/bench migration: `test/helpers.mjs` `edgesOf()` + `benchmarks/bench-util.mjs`
+  `adjacencyOf()` rebuild the oracle inputs from `getEdges`; `test/publicApi.test.mjs` pins the
+  two fields as **removed** (10 contract tests). Docs: `MIGRATION.md` 2→3 section,
+  `docs/index.html` + `README` note the removal. Suite 238 (237 + 1 XL skip), lint clean.
+  **major → 3.0.0** (`npm version major`). Roadmap proposals: close milestone 3.0.0, decide the
+  next-milestone direction with the user, optionally file the id-sort fast-path perf issue
+  (Phase E).
 - **Examples + Docker refresh (PR #207 merged, 2026-07-21, commit 50faa4a;
   user-directed, no issue, no bump):** the stale single `examples/main.mjs` (it only
   printed the raw edge list — never ran the algorithm) is replaced by a standalone gallery
@@ -389,11 +417,11 @@ _Note:_ both #182 shapes stay as regression sentinels in every `npm run bench` (
 `sparse-random-l4`), and `npm run bench:counts` reproduces the comparison-count crossover
 (below 1.0 before n = 50k since #167; ~n = 1M in the 1.0.0/1.1.1 records).
 
-## Milestone `2.0.0` (milestone #4) — API-breaking generalization — CURRENT
+## Milestone `2.0.0` (milestone #4) — API-breaking generalization — ✅ CLOSED (released 2026-07-21)
 
 Build order (derived 2026-07-21 at RKB, after 1.2.0 closed): ~~#205~~
 (merged, PR #206) → ~~#172~~ (merged, PR #208) → ~~#171~~ (merged, PR #209) →
-~~#173~~ (done-pending-merge, this PR, **major → 2.0.0**). Rationale:
+~~#173~~ (merged, PR #210, **major → 2.0.0**, released — milestone closed). Rationale:
 the dense-index engine (#205) decides the internal shapes every new API wraps, so it went
 first; typed/flexible inputs (#172) generalized the constructor surface over it; the public
 multi-source entrypoint (#171) is designed value-in/value-out over the finished engine and
@@ -405,11 +433,25 @@ the surface last and takes the **major → 2.0.0** bump as the milestone-closing
 | 205 | Dense-index core: typed-array labels + CSR adjacency | enhancement | ✅ merged (PR #206, no bump — API-non-breaking): sorted-id index + CSR + typed labels; wall-clock ~halved (sparse head-to-head 2.5× → 1.38×), counts unchanged |
 | 172 | Typed / flexible graph inputs | enhancement · help wanted | ✅ merged (PR #208, no bump): `Graph` builder + adjacency Map/object inputs + explicit declarable vertex universe, reduced via `normalizeGraphInput`; node-ID semantics unchanged. Deferred the direct-CSR construction perf lever to #173 (coupled to public `this.graph`) |
 | 171 | Public multi-source / bounded BMSSP entrypoint | enhancement · help wanted | ✅ merged (PR #209, no bump): `calculateShortestPathsFrom(sources, { bound })` — additive surface over the `bmssp(l,B,S)` wrapper, flexible `sources` shapes + finite-bound pruning to the completed set `U`. Breaking-signature latitude deferred to #173 |
-| 173 | Stabilize the public API surface for 1.0 → 2.0 | documentation · enhancement | ✅ done-pending-merge (this PR, **major → 2.0.0** — milestone-closing): document-only boundary (`@public`/`@internal` JSDoc + `test/publicApi.test.mjs` contract test), `MIGRATION.md` (no breaking changes), rewritten `docs/index.html`, `05-flexible-inputs`/`06-multi-source` examples. Kept `this.graph`/`this.adjacency` + raw `bmssp` public; direct-CSR perf lever deferred to a new post-2.0 issue |
+| 173 | Stabilize the public API surface for 1.0 → 2.0 | documentation · enhancement | ✅ merged (PR #210, **major → 2.0.0**, released 2026-07-21 — milestone-closing): document-only boundary (`@public`/`@internal` JSDoc + `test/publicApi.test.mjs` contract test), `MIGRATION.md` (no breaking changes), rewritten `docs/index.html`, `05-flexible-inputs`/`06-multi-source` examples. Kept `this.graph`/`this.adjacency` + raw `bmssp` public; direct-CSR perf lever deferred to #212 (3.0.0) |
 
 _Note after #43:_ `bmssp(l, B, S)` already **is** a bounded multi-source call internally —
-#171 is mostly about designing the public API around it (initial per-source distances,
-returning `{ bound, vertices }` sensibly) rather than new algorithm work.
+#171 designed the public API around it (`calculateShortestPathsFrom`), rather than new
+algorithm work.
+
+## Milestone `3.0.0` (milestone #5) — performance — being closed by this PR
+
+Opened 2026-07-21 (Phase E of the #173 PR) to host post-2.0 engine work. The core algorithm is
+feature-complete; this milestone is about speed. Its only issue, #212, is done-pending-merge in
+this PR (**major → 3.0.0**), so on merge + release the milestone closes.
+
+| # | Issue | Labels | Notes |
+|---|---|---|---|
+| 212 | Direct-CSR construction — build the index/CSR without the edge-list round-trip | enhancement | ✅ done-pending-merge (this PR, **major → 3.0.0** — milestone-closing): the constructor builds the dense index + CSR + typed labels straight from the normalized input; **removed** the public `this.graph`/`this.adjacency` fields (user-confirmed breaking approach, not lazy getters) → `getEdges` serves the edge view from CSR. Construction ~halved (n=500k/m=1.5M: ~510 → ~240 ms). CSR byte-identical → every oracle/determinism assertion unchanged |
+
+_Decision (user-confirmed 2026-07-22):_ took the **breaking** approach — remove `graph`/
+`adjacency` outright (not a non-breaking lazy-getter), so this PR is the **major → 3.0.0**
+milestone-closer rather than a pre-3.0 minor.
 
 ---
 

--- a/.claude/knowledge/07-glossary.md
+++ b/.claude/knowledge/07-glossary.md
@@ -1,8 +1,11 @@
 # 07 — Glossary
 
-<!-- Updated on: 2026-07-21 (#172 PR: flexible inputs — Graph builder, normalizeGraphInput,
-     explicit vertex universe; four public exports now. Previous update the same day:
-     #205 PR dense-index engine — makeLabels, labelKey, CSR, dense index, buildIndex,
+<!-- Updated on: 2026-07-22 (#212 PR: direct-CSR construction — removed the public
+     this.graph / this.adjacency fields + buildAdjacency; buildIndex(edges); getEdges
+     served from CSR; edgesOf/adjacencyOf test-bench helpers; breaking → 3.0.0.
+     Previous update 2026-07-21 (#172 PR): flexible inputs — Graph builder,
+     normalizeGraphInput, explicit vertex universe; four public exports. Same day:
+     #205 dense-index engine — makeLabels, labelKey, CSR, dense index, buildIndex,
      syncLabelsIn/Out, boundToEngine/keyToPublic, bmsspIndex; NO_PRED now -1;
      relaxEdge/baseCase/findPivots typed-array signatures; #168 compareKeyParts + RELAX_*) -->
 
@@ -111,17 +114,24 @@ Quick lookup for the symbols and terms used across the paper, the notes, and the
   the set *inferred* from edge endpoints. Before #172 the vertex set was always inferred; a
   `Graph` (`addVertex`) or an adjacency form (a key with no neighbors) can now declare
   **isolated** vertices, which flow through to `nodeIDs` and get an index, an empty CSR
-  range, an empty adjacency list, an ∞ estimate, and are valid as a `calculateShortestPaths`
+  range (`getEdges` → `[]`), an ∞ estimate, and are valid as a `calculateShortestPaths`
   source (reaching only themselves).
-- **`adjacency`** (#45) — `Map<nodeId, Array<[to, weight]>>` field on the `BMSSP` class:
-  a node's outgoing edges. Since #205 this is the **public edge view** behind `getEdges`
-  (and the fair-baseline Dijkstra in the benchmarks); the algorithm's hot path uses the
-  CSR arrays instead. Every known node has an entry (empty array for sinks). Built in the
-  constructor.
-- **`buildAdjacency()`** (#45) — class method that (re)builds `this.adjacency` from
-  `this.graph`. Called by the constructor.
-- **`getEdges(nodeId)`** (#45) — class method returning a node's outgoing edges as
-  `[to, weight]` pairs; returns `[]` for unknown nodes.
+- **`adjacency` / `buildAdjacency()` / `this.graph` (removed by #212)** — until #212 the
+  `BMSSP` class kept a deep-copied edge array (`this.graph`) and a
+  `Map<nodeId, Array<[to,weight]>>` (`this.adjacency`, built by `buildAdjacency()`) as
+  public fields. #212 (**breaking, 3.0.0**) removed all three: the CSR is the single source
+  of truth, built directly from the input (see "Direct-CSR construction"). `getEdges`
+  materializes the edge view on demand instead.
+- **`getEdges(nodeId)`** (#45; CSR-served since #212) — public class method returning a
+  node's outgoing edges as fresh `[to, weight]` pairs, materialized from `this.csr` (edge
+  order follows the construction input); returns `[]` for unknown nodes.
+- **Direct-CSR construction** (#212) — the constructor builds the dense index + CSR + typed
+  labels straight from the validated input edges, with no intermediate `this.graph` deep copy
+  or `this.adjacency` Map. `buildIndex(edges)` consumes the normalized edge array directly.
+  Purely construction-side and label-preserving (the CSR is byte-identical to the pre-#212
+  round-trip), so every oracle/determinism assertion is unchanged; it roughly **halves
+  construction time** (n = 500k / m = 1.5M: ~510 → ~240 ms median). **Breaking** only in that
+  the public `graph`/`adjacency` fields are gone — hence the 3.0.0 major.
 - **Dense index** (#205) — the `BMSSP` class maps every original node id to a contiguous
   integer `0..n-1`, assigned in **ascending numeric id order** (`buildIndex`). `this.ids`
   (`Float64Array`) is index → id, `this.indexOf` (`Map`) is the inverse. Index order
@@ -131,10 +141,18 @@ Quick lookup for the symbols and terms used across the paper, the notes, and the
   targets:Uint32Array, weights:Float64Array }`. Node `u`'s outgoing edges are
   `targets/weights[offsets[u] .. offsets[u+1])`. Replaces per-edge `adjacency.get` +
   iterator/destructuring in the hot loops.
-- **`buildIndex()`** (#205) — constructor step building the dense index (`ids`/`indexOf`),
-  the CSR arrays (`this.csr`), and the typed label state (`this.labels`).
+- **`buildIndex(edges)`** (#205; takes `edges` since #212) — constructor step building the
+  dense index (`ids`/`indexOf`), the CSR arrays (`this.csr`), and the typed label state
+  (`this.labels`) directly from the validated input edges (no `this.graph` copy).
 - **Adjacency list (oracle)** — the *local* adjacency `Map` that `src/dijkstra.mjs` builds
-  internally per call; distinct from the class's persistent `this.adjacency`.
+  internally per call. Since #212 the class no longer keeps a persistent adjacency Map; the
+  benchmark's fair baseline builds one once via `adjacencyOf` (below) from `getEdges`.
+- **`edgesOf` / `adjacencyOf` (test/bench helpers, #212)** — since #212 removed the public
+  `graph`/`adjacency` fields, tests rebuild what the oracles need from `getEdges`:
+  `edgesOf(instance)` (`test/helpers.mjs`) → a `[from,to,weight][]` array for the
+  `dijkstra(edges, …)` oracle; `adjacencyOf(instance)` (`benchmarks/bench-util.mjs`) → a
+  `Map<from,[to,weight][]>` for the benchmark `dijkstraAdjacency` baseline (built once,
+  outside the timed region).
 - **`BlockList`** (#42) — `src/blockList.mjs`, the Lemma 3.3 structure `D`. API:
   `insert(key, value)` / `batchPrepend(pairs)` / `pull() → { keys, bound }`, plus
   `size` / `isEmpty()`. `pull()`'s `{ keys, bound }` is Algorithm 3's `Si, Bi`. Values must
@@ -339,8 +357,9 @@ Quick lookup for the symbols and terms used across the paper, the notes, and the
   for #182's transition cliff.
 - **Head-to-head** — the measured BMSSP-vs-Dijkstra comparison. **Algorithm-only
   timing**: construction and adjacency building are excluded for both sides; the Dijkstra
-  baseline consumes the BMSSP instance's own prebuilt `adjacency` Map (the exported
-  `dijkstra()` builds its own per call — that's loading, not algorithm). Since #170 the
+  baseline consumes an adjacency Map built once from the BMSSP instance via `adjacencyOf`
+  (since #212 the class no longer stores one — the exported `dijkstra()` builds its own per
+  call, which is loading, not algorithm). Since #170 the
   harness runs it per shape with node-by-node output verification (`mismatches` column);
   `benchmarks/HEAD-TO-HEAD.md` is the frozen 1.0.0 record (2026-07-16, up to n = 4M),
   `benchmarks/RESULTS.md` the latest capture.
@@ -391,5 +410,6 @@ Quick lookup for the symbols and terms used across the paper, the notes, and the
   `@public`/`@internal` tags on the `BMSSP` class (documentation) and `test/publicApi.test.mjs`
   (a contract test pinning the 4 exports + supported members, so export/rename drift fails CI).
   User-confirmed **document-only** enforcement — no `#`-privatization (tests drive internals),
-  `this.graph`/`this.adjacency` kept public (direct-CSR perf lever deferred), raw `bmssp(l,B,S)`
-  kept as an advanced public entrypoint.
+  raw `bmssp(l,B,S)` kept as an advanced public entrypoint. (The `this.graph`/`this.adjacency`
+  fields, kept public in 2.0.0 with the direct-CSR perf lever deferred, were **removed in #212**
+  → 3.0.0; `test/publicApi.test.mjs` now pins that they are gone.)

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,4 +1,41 @@
-# Migrating from 1.x to 2.0
+# Migration guide
+
+The runnable, always-green reference for everything here is the
+[`examples/` gallery](examples/) — each file imports from the published `bmssp` package and
+exercises exactly the public surface.
+
+---
+
+## Migrating from 2.x to 3.0
+
+**TL;DR — one small breaking change: two public fields were removed.** 3.0.0 is a
+**performance** release. Its single change to the public surface is the removal of two
+`BMSSP` instance fields that were rarely used directly:
+
+| Removed field (2.x) | Replacement (3.0) |
+| --- | --- |
+| `instance.graph` (copied `[from, to, weight][]` edge array) | Rebuild on demand from `instance.getEdges(id)` over `instance.nodeIDs`, or just keep the array you constructed the instance with. |
+| `instance.adjacency` (`Map<id, [[to, weight], …]>`) | `instance.getEdges(id)` returns a node's `[to, weight]` edges (materialized from the CSR); build a Map yourself if you need one. |
+
+**Why:** since 2.0's dense-index engine, the graph already lives as a CSR (compressed-sparse-row
+typed arrays) — the single source of truth the algorithm actually runs on. The `graph` and
+`adjacency` fields were an extra edge-array deep copy plus an adjacency `Map` built eagerly in
+the constructor on top of it. Building the CSR **directly** from the input (#212) skips that
+round-trip and **roughly halves construction time** (n = 500k / m = 1.5M: ~510 → ~240 ms
+median). Everything else is unchanged — same distances, hops, predecessors, tie-break, and
+every other public method and field.
+
+**If you used `getEdges` already** (the supported edge accessor), nothing changes — it still
+returns `[to, weight]` pairs and `[]` for unknown nodes; it just builds the array from the CSR
+now. **If you fed `instance.graph` to the `dijkstra` oracle**, pass the edge array you built the
+instance from instead (or `[...instance.nodeIDs].flatMap(f => instance.getEdges(f).map(([t, w]) => [f, t, w]))`).
+
+The rest of the public surface — the four exports and every other `BMSSP` member — is
+unchanged from 2.0 and still pinned by `test/publicApi.test.mjs`.
+
+---
+
+## Migrating from 1.x to 2.0
 
 **TL;DR — there are no breaking changes to the documented public API.** Every program
 written against the 1.x public surface keeps working unchanged on 2.0.0. The major version
@@ -6,10 +43,6 @@ marks a **stability commitment**: the public API below is now locked and covered
 contract test (`test/publicApi.test.mjs`), so it can't drift by accident. The 2.0.0
 milestone also consolidates the capabilities that landed additively across 1.1.x / 1.2.x
 and the 2.0.0 pre-work.
-
-The runnable, always-green reference for everything here is the
-[`examples/` gallery](examples/) — each file imports from the published `bmssp` package and
-exercises exactly the public surface.
 
 ## What's new since 1.0
 
@@ -48,8 +81,8 @@ Supported members of a `BMSSP` instance:
   `bmssp(l, B, S)` (advanced — the low-level bounded multi-source primitive, returns
   `{ bound, boundKey, vertices }`), `reconstructPath(target)`, `getEdges(nodeId)`.
 - **Fields:** `shortestPaths` (`Map<id, distance>`), `nodeIDs` (`Set`), `hops` / `preds`
-  (canonical tie-break mirror), `adjacency` (`Map<id, [[to, weight], …]>`), `graph` (the
-  copied edge array).
+  (canonical tie-break mirror). _(2.0 also exposed `adjacency` and `graph`; both were
+  **removed in 3.0** — see the 2.x → 3.0 section above.)_
 
 ## What is explicitly internal
 
@@ -61,8 +94,8 @@ release — using it was never a supported contract:
   linear-time selection, and the tie-break helpers.
 - The `BMSSP` class's dense-index engine members: `csr`, `labels`, `ids`, `indexOf`,
   `bmsspIndex`, `syncLabelsIn`/`syncLabelsOut`, `boundToEngine`/`keyToPublic`, `normalizeSources`,
-  `buildIndex`, `buildAdjacency`, `deriveParameters`, `initializeShortestPaths`, and the derived
-  parameters `k` / `t` / `topLevel` / `ties`.
+  `buildIndex`, `deriveParameters`, `initializeShortestPaths`, and the derived parameters
+  `k` / `t` / `topLevel` / `ties`.
 
 These carry `@internal` in their JSDoc. If you depended on any of them, pin to the exact
 version you tested against and open an issue describing the use case — some may be worth

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ with every building block shipped, tested, and released individually:
 | Typed / flexible graph inputs: `Graph` builder + adjacency Map/object + explicit vertex universe ([#172](https://github.com/Sirivasv/bmssp-js/issues/172)) | `src/graph.mjs` + `BMSSP` constructor | ✅ done |
 | Public multi-source / bounded entrypoint ([#171](https://github.com/Sirivasv/bmssp-js/issues/171)) | `BMSSP.calculateShortestPathsFrom()` | ✅ done |
 | Public API stabilization + 1.0→2.0 migration note ([#173](https://github.com/Sirivasv/bmssp-js/issues/173)) | `MIGRATION.md` + `docs/index.html` + contract test | ✅ done — **2.0.0** |
+| Direct-CSR construction: build the index/CSR straight from the input, ~½ the construction time ([#212](https://github.com/Sirivasv/bmssp-js/issues/212)) | `BMSSP` constructor | ✅ done — **3.0.0** |
 
 > **Honest note:** the paper's win is asymptotic, and this repo optimizes for correctness
 > and readability first — but the constant factors have come down a lot. Measured
@@ -120,9 +121,10 @@ when the target is unreachable (or before any run) and throws for a node outside
 
 A reference `dijkstra` implementation is also exported. See the `examples/` directory for
 more, or the [public API reference](https://sirivasv.github.io/bmssp-js/) for the complete
-documented surface. The public API is **stable as of 2.0.0** — see
-[MIGRATION.md](MIGRATION.md) for the 1.0 → 2.0 note (no breaking changes) and the locked
-surface.
+documented surface. The public API has been **stable since 2.0.0** — see
+[MIGRATION.md](MIGRATION.md) for the migration notes and the locked surface. (3.0.0 is a
+performance release whose only public-surface change is removing the little-used
+`graph`/`adjacency` instance fields — use `getEdges(id)` for a node's outgoing edges.)
 
 ### Flexible graph inputs
 

--- a/benchmarks/bench-util.mjs
+++ b/benchmarks/bench-util.mjs
@@ -37,6 +37,19 @@ export function countMismatches(expectedDist, actualDist, nodeIDs) {
   return mismatches;
 }
 
+// Build a Map<from, [to, weight][]> adjacency (every node present, isolated
+// nodes → []) from a BMSSP instance via its public getEdges() view. Since #212
+// the instance no longer stores a `this.adjacency` Map — the CSR engine is the
+// single source of truth — so the fair-baseline Dijkstra oracle
+// (dijkstraAdjacency) builds the adjacency once here, outside the timed region.
+export function adjacencyOf(instance) {
+  const adjacency = new Map();
+  for (const from of instance.nodeIDs) {
+    adjacency.set(from, instance.getEdges(from));
+  }
+  return adjacency;
+}
+
 // Render an array of row objects as a GitHub-flavored markdown table.
 export function markdownTable(headers, rows) {
   const head = `| ${headers.join(" | ")} |`;

--- a/benchmarks/compare-counts.bench.mjs
+++ b/benchmarks/compare-counts.bench.mjs
@@ -22,7 +22,7 @@ import {
   getDijkstraComparisonCount,
 } from "./dijkstra-adj.mjs";
 import { sparseRandom, grid } from "./generators.mjs";
-import { markdownTable, countMismatches } from "./bench-util.mjs";
+import { markdownTable, countMismatches, adjacencyOf } from "./bench-util.mjs";
 
 // Sized to reproduce the crossover table in a couple of tens of seconds:
 // sparse d3 at 50k / 200k / 1M brackets the crossover; the grid shows a
@@ -53,13 +53,10 @@ export function runComparisonCountBenchmark(cases = COUNT_CASES) {
     const graph = testCase.build();
     const bmssp = new BMSSP(graph);
     const source = [...bmssp.nodeIDs][0];
+    const adjacency = adjacencyOf(bmssp);
 
     resetDijkstraComparisonCount();
-    const dijkstraDist = dijkstraAdjacency(
-      bmssp.adjacency,
-      bmssp.nodeIDs,
-      source,
-    );
+    const dijkstraDist = dijkstraAdjacency(adjacency, bmssp.nodeIDs, source);
     const dijkstraComparisons = getDijkstraComparisonCount();
 
     resetComparisonCount();

--- a/benchmarks/scenarios.bench.mjs
+++ b/benchmarks/scenarios.bench.mjs
@@ -20,6 +20,7 @@ import {
   markdownTable,
   fmt,
   countMismatches,
+  adjacencyOf,
 } from "./bench-util.mjs";
 
 export function runScenarioBenchmark(scenarios = SCENARIOS, iters = 3) {
@@ -31,9 +32,12 @@ export function runScenarioBenchmark(scenarios = SCENARIOS, iters = 3) {
 
     const bmssp = new BMSSP(graph);
     const source = [...bmssp.nodeIDs][0];
+    // #212: the instance no longer prebuilds an adjacency Map; build the fair
+    // Dijkstra baseline's adjacency once here, outside the timed region.
+    const adjacency = adjacencyOf(bmssp);
 
     const dij = timeMany(
-      () => dijkstraAdjacency(bmssp.adjacency, bmssp.nodeIDs, source),
+      () => dijkstraAdjacency(adjacency, bmssp.nodeIDs, source),
       { iters, warmup: 1 },
     );
     const alg = timeMany(() => bmssp.calculateShortestPaths(source), {
@@ -42,11 +46,7 @@ export function runScenarioBenchmark(scenarios = SCENARIOS, iters = 3) {
     });
 
     // Verify: fresh run on each side, distances must agree node-by-node.
-    const dijkstraDist = dijkstraAdjacency(
-      bmssp.adjacency,
-      bmssp.nodeIDs,
-      source,
-    );
+    const dijkstraDist = dijkstraAdjacency(adjacency, bmssp.nodeIDs, source);
     bmssp.calculateShortestPaths(source);
     const mismatches = countMismatches(
       dijkstraDist,

--- a/docs/index.html
+++ b/docs/index.html
@@ -162,9 +162,11 @@ graph.reconstructPath(1); // [0, 1]</code></pre>
         <h2>Public API</h2>
         <p>The package has exactly four exports: <code>BMSSP</code>, <code>Graph</code>,
            <code>dijkstra</code>, and <code>constantDegreeTransform</code>. This surface is
-           <strong>stable as of 2.0.0</strong> — see the
+           <strong>stable since 2.0.0</strong> (3.0.0 removed only the little-used
+           <code>graph</code>/<code>adjacency</code> instance fields — use
+           <code>getEdges(id)</code> instead) — see the
            <a href="https://github.com/Sirivasv/bmssp-js/blob/main/MIGRATION.md"
-              target="_blank" rel="noopener">1.0&nbsp;→&nbsp;2.0 migration note</a> and the
+              target="_blank" rel="noopener">migration note</a> and the
            runnable <a href="https://github.com/Sirivasv/bmssp-js/tree/main/examples"
               target="_blank" rel="noopener">examples gallery</a>. Anything not listed here
            (the block list, the indexed heap, <code>BaseCase</code>/<code>FindPivots</code>,

--- a/examples/02-dijkstra-oracle.mjs
+++ b/examples/02-dijkstra-oracle.mjs
@@ -24,9 +24,9 @@ export function run() {
   const graph = new BMSSP(edges);
   graph.calculateShortestPaths(source);
 
-  // The oracle takes the raw edge list and the node-ID set (both exposed
-  // on the BMSSP instance) plus the source.
-  const oracle = dijkstra(graph.graph, graph.nodeIDs, source);
+  // The oracle takes the raw edge list, the node-ID set (exposed on the
+  // BMSSP instance) and the source.
+  const oracle = dijkstra(edges, graph.nodeIDs, source);
 
   console.log("node │ BMSSP │ Dijkstra │ match");
   console.log("─────┼───────┼──────────┼──────");

--- a/examples/04-larger-graph.mjs
+++ b/examples/04-larger-graph.mjs
@@ -52,7 +52,7 @@ export function run() {
   );
 
   // Spot-check against the oracle on a handful of nodes.
-  const oracle = dijkstra(graph.graph, graph.nodeIDs, 0);
+  const oracle = dijkstra(edges, graph.nodeIDs, 0);
   const sample = [corner, Math.floor((n * n) / 2), n - 1, n * (n - 1)];
   const allMatch = sample.every(
     (node) => graph.shortestPaths.get(node) === oracle.get(node),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bmssp",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bmssp",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "license": "MPL-2.0",
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bmssp",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Javascript package implementation of the bmssp algorithm.",
   "main": "index.mjs",
   "keywords": [

--- a/src/bmssp.mjs
+++ b/src/bmssp.mjs
@@ -26,9 +26,9 @@ import {
  * - {@link BMSSP#bmssp} — the low-level bounded multi-source primitive (advanced;
  *   composite keys, returns `{ bound, boundKey, vertices }`).
  * - {@link BMSSP#reconstructPath} — canonical path for the latest run.
- * - {@link BMSSP#getEdges} — O(1) outgoing-edge lookup.
- * - Public fields: `shortestPaths`, `nodeIDs`, `hops`, `preds`, `adjacency`,
- *   `graph` (all documented in the constructor).
+ * - {@link BMSSP#getEdges} — outgoing-edge lookup, materialized from the CSR.
+ * - Public fields: `shortestPaths`, `nodeIDs`, `hops`, `preds` (all
+ *   documented in the constructor).
  *
  * **Everything else on this class is `@internal`** — the dense-index engine
  * (`csr`, `labels`, `ids`, `indexOf`, `bmsspIndex`, `syncLabelsIn/Out`,
@@ -56,16 +56,10 @@ class BMSSP {
     const { edges: inputEdges, vertices: declaredVertices } =
       normalizeGraphInput(inputGraph);
 
-    // Main graph represented as an array of edges
-    this.graph = [];
     // Set to store unique node IDs
     this.nodeIDs = new Set();
     // Map to store shortest paths
     this.shortestPaths = new Map();
-    // Adjacency map: nodeId -> array of [to, weight] outgoing edges.
-    // The public O(1) edge-lookup view (getEdges); since #205 the algorithm
-    // itself runs on the CSR arrays built by buildIndex below.
-    this.adjacency = new Map();
     // Canonical tie-break labels (#163): hops = edge count of the canonical
     // shortest path, preds = its predecessor pointer. Since #205 these Maps
     // are the PUBLIC mirror of the engine's typed-array labels, refreshed
@@ -75,6 +69,11 @@ class BMSSP {
     this.preds = new Map();
     this.ties = makeTies(this.hops, this.preds);
 
+    // Validate the edges and collect the node universe. #212: we no longer keep
+    // a deep-copied `this.graph` edge array or a `this.adjacency` Map — the CSR
+    // engine (buildIndex) is the single source of truth, built directly from
+    // `inputEdges`. Validation stays here so the indexed error messages remain
+    // the single source of truth.
     for (let [index, edge] of inputEdges.entries()) {
       if (!Array.isArray(edge) || edge.length !== 3) {
         throw new Error(`Edge at index ${index} must be [from, to, weight]`);
@@ -90,18 +89,14 @@ class BMSSP {
         );
       }
 
-      // Create a deep copy of each edge array
-      this.graph.push([...edge]);
-
       // Add node IDs to the set
-      this.nodeIDs.add(edge[0]);
-      this.nodeIDs.add(edge[1]);
+      this.nodeIDs.add(from);
+      this.nodeIDs.add(to);
     }
 
     // #172: fold in explicitly declared vertices (isolated nodes included).
-    // Same finiteness contract as edge endpoints; buildIndex/buildAdjacency
-    // then give every declared node an index, an empty CSR range and an
-    // empty neighbor list.
+    // Same finiteness contract as edge endpoints; buildIndex then gives every
+    // declared node an index and an empty CSR range (getEdges returns []).
     for (const id of declaredVertices) {
       if (!Number.isFinite(id)) {
         throw new Error("Declared vertex IDs must be finite numbers");
@@ -109,11 +104,10 @@ class BMSSP {
       this.nodeIDs.add(id);
     }
 
-    // Build the adjacency map from the copied edges
-    this.buildAdjacency();
-
-    // Build the dense-index engine state: sorted-id index + CSR + labels
-    this.buildIndex();
+    // Build the dense-index engine state directly from the validated edges:
+    // sorted-id index + CSR + labels. No intermediate edge-array / adjacency-Map
+    // copy — this is the #212 direct-CSR construction.
+    this.buildIndex(inputEdges);
 
     // Initialize shortest paths map
     this.initializeShortestPaths();
@@ -122,27 +116,10 @@ class BMSSP {
     this.deriveParameters();
   }
 
-  // Method to (re)build the adjacency map from this.graph.
-  // Every node ID gets an entry (an empty array for nodes with no
-  // outgoing edges) so callers can rely on .get(node) returning an array.
-  buildAdjacency() {
-    this.adjacency = new Map();
-
-    // Ensure every known node has an (initially empty) neighbor list
-    for (let nodeId of this.nodeIDs) {
-      this.adjacency.set(nodeId, []);
-    }
-
-    // Group outgoing edges by their source node
-    for (let [from, to, weight] of this.graph) {
-      this.adjacency.get(from).push([to, weight]);
-    }
-  }
-
   /**
-   * Build the dense-index engine state (#205): assign every node ID a dense
-   * index, lay the graph out in CSR form over those indices, and allocate
-   * the typed-array labels.
+   * Build the dense-index engine state (#205, direct-CSR since #212): assign
+   * every node ID a dense index, lay the given edges out in CSR form over
+   * those indices, and allocate the typed-array labels.
    *
    * Indices are assigned in ASCENDING NUMERIC ID ORDER. That makes index
    * order equal id order, so the composite-key id tie-break (#163) picks the
@@ -151,11 +128,13 @@ class BMSSP {
    * under edge-list permutation.
    *
    * @internal
+   * @param {Array<[number,number,number]>} edges - The validated input edges;
+   *   consumed directly into CSR (no intermediate `this.graph` copy).
    */
-  buildIndex() {
+  buildIndex(edges) {
     const sorted = [...this.nodeIDs].sort((a, b) => a - b);
     const n = sorted.length;
-    const m = this.graph.length;
+    const m = edges.length;
     // ids: index -> original node id; indexOf: original node id -> index
     this.ids = Float64Array.from(sorted);
     this.indexOf = new Map();
@@ -163,10 +142,10 @@ class BMSSP {
       this.indexOf.set(sorted[i], i);
     }
     // CSR: offsets[u]..offsets[u+1] delimit u's outgoing edges in
-    // targets/weights (edge order within a node follows this.graph; the
-    // #163 canonical labels are iteration-order independent anyway)
+    // targets/weights (edge order within a node follows the input edge order;
+    // the #163 canonical labels are iteration-order independent anyway)
     const offsets = new Uint32Array(n + 1);
-    for (const [from] of this.graph) {
+    for (const [from] of edges) {
       offsets[this.indexOf.get(from) + 1] += 1;
     }
     for (let i = 0; i < n; i += 1) {
@@ -175,7 +154,7 @@ class BMSSP {
     const targets = new Uint32Array(m);
     const weights = new Float64Array(m);
     const cursor = offsets.slice(0, n);
-    for (const [from, to, weight] of this.graph) {
+    for (const [from, to, weight] of edges) {
       const u = this.indexOf.get(from);
       const e = cursor[u];
       cursor[u] += 1;
@@ -187,10 +166,25 @@ class BMSSP {
     this.labels = makeLabels(n);
   }
 
-  // Return the outgoing edges of a node as an array of [to, weight].
-  // Unknown nodes return an empty array.
+  /**
+   * Return the outgoing edges of a node as a fresh array of `[to, weight]`
+   * pairs, materialized from the CSR (#212 — there is no stored adjacency Map).
+   * Unknown nodes return an empty array. Edge order follows the construction
+   * input order.
+   *
+   * @public
+   * @param {number} nodeId - A node in the graph
+   * @returns {Array<[number, number]>} Outgoing `[to, weight]` edges, `[]` if unknown
+   */
   getEdges(nodeId) {
-    return this.adjacency.get(nodeId) ?? [];
+    const u = this.indexOf.get(nodeId);
+    if (u === undefined) return [];
+    const { offsets, targets, weights } = this.csr;
+    const out = [];
+    for (let e = offsets[u]; e < offsets[u + 1]; e += 1) {
+      out.push([this.ids[targets[e]], weights[e]]);
+    }
+    return out;
   }
 
   // Method to initialize the shortest paths map, its #163 tie-break mirror

--- a/test/baseCase.test.mjs
+++ b/test/baseCase.test.mjs
@@ -3,6 +3,7 @@ import { baseCase } from "../src/baseCase.mjs";
 import { BMSSP } from "../src/bmssp.mjs";
 import { dijkstra } from "../src/dijkstra.mjs";
 import { compareKeys, labelKey } from "../src/tieBreak.mjs";
+import { edgesOf } from "./helpers.mjs";
 
 // Small deterministic PRNG so stress-test failures are reproducible
 function mulberry32(seed) {
@@ -198,7 +199,7 @@ describe("baseCase vs Dijkstra oracle (seeded)", () => {
     for (let round = 0; round < 20; round += 1) {
       const edges = randomEdges(rand, 40, 160);
       const g = setup(edges, 0);
-      const oracle = dijkstra(g.graph, g.nodeIDs, 0);
+      const oracle = dijkstra(edgesOf(g), g.nodeIDs, 0);
       const result = baseCase(
         Infinity,
         idxSet(g, [0]),
@@ -222,7 +223,7 @@ describe("baseCase vs Dijkstra oracle (seeded)", () => {
     for (let round = 0; round < 30; round += 1) {
       const edges = randomEdges(rand, 50, 200);
       const g = setup(edges, 0);
-      const oracle = dijkstra(g.graph, g.nodeIDs, 0);
+      const oracle = dijkstra(edgesOf(g), g.nodeIDs, 0);
       const finite = [...oracle.values()]
         .filter((d) => d < Infinity)
         .sort((a, b) => a - b);

--- a/test/benchmarks.test.mjs
+++ b/test/benchmarks.test.mjs
@@ -8,7 +8,7 @@ import {
 } from "../benchmarks/dijkstra-adj.mjs";
 import { runScenarioBenchmark } from "../benchmarks/scenarios.bench.mjs";
 import { runComparisonCountBenchmark } from "../benchmarks/compare-counts.bench.mjs";
-import { countMismatches } from "../benchmarks/bench-util.mjs";
+import { countMismatches, adjacencyOf } from "../benchmarks/bench-util.mjs";
 import { sparseRandom, chain, star } from "../benchmarks/generators.mjs";
 
 describe("countMismatches (#170): per-run output verification", () => {
@@ -48,7 +48,11 @@ describe("dijkstraAdjacency (#170): the fair prebuilt-adjacency baseline", () =>
       const bmssp = new BMSSP(graph);
       const source = [...bmssp.nodeIDs][0];
       const expected = dijkstra(graph, bmssp.nodeIDs, source);
-      const actual = dijkstraAdjacency(bmssp.adjacency, bmssp.nodeIDs, source);
+      const actual = dijkstraAdjacency(
+        adjacencyOf(bmssp),
+        bmssp.nodeIDs,
+        source,
+      );
       expect(actual.size).toBe(expected.size);
       for (const [id, d] of expected) {
         expect(actual.get(id)).toBe(d);
@@ -63,7 +67,7 @@ describe("dijkstraAdjacency (#170): the fair prebuilt-adjacency baseline", () =>
       [2, 3, 1],
     ];
     const bmssp = new BMSSP(graph);
-    const dist = dijkstraAdjacency(bmssp.adjacency, bmssp.nodeIDs, 0);
+    const dist = dijkstraAdjacency(adjacencyOf(bmssp), bmssp.nodeIDs, 0);
     expect(dist.get(1)).toBe(4);
     expect(dist.get(2)).toBe(Infinity);
     expect(dist.get(3)).toBe(Infinity);
@@ -71,16 +75,16 @@ describe("dijkstraAdjacency (#170): the fair prebuilt-adjacency baseline", () =>
 
   test("throws when the source is not in nodeIDs", () => {
     const bmssp = new BMSSP([[0, 1, 1]]);
-    expect(() => dijkstraAdjacency(bmssp.adjacency, bmssp.nodeIDs, 99)).toThrow(
-      "Source node not found",
-    );
+    expect(() =>
+      dijkstraAdjacency(adjacencyOf(bmssp), bmssp.nodeIDs, 99),
+    ).toThrow("Source node not found");
   });
 
   test("comparison counter counts and resets", () => {
     const bmssp = new BMSSP(sparseRandom(100, 3, 7));
     resetDijkstraComparisonCount();
     expect(getDijkstraComparisonCount()).toBe(0);
-    dijkstraAdjacency(bmssp.adjacency, bmssp.nodeIDs, 0);
+    dijkstraAdjacency(adjacencyOf(bmssp), bmssp.nodeIDs, 0);
     expect(getDijkstraComparisonCount()).toBeGreaterThan(0);
     resetDijkstraComparisonCount();
     expect(getDijkstraComparisonCount()).toBe(0);
@@ -89,10 +93,10 @@ describe("dijkstraAdjacency (#170): the fair prebuilt-adjacency baseline", () =>
   test("counts are deterministic for a fixed graph and source", () => {
     const bmssp = new BMSSP(sparseRandom(200, 3, 9));
     resetDijkstraComparisonCount();
-    dijkstraAdjacency(bmssp.adjacency, bmssp.nodeIDs, 0);
+    dijkstraAdjacency(adjacencyOf(bmssp), bmssp.nodeIDs, 0);
     const first = getDijkstraComparisonCount();
     resetDijkstraComparisonCount();
-    dijkstraAdjacency(bmssp.adjacency, bmssp.nodeIDs, 0);
+    dijkstraAdjacency(adjacencyOf(bmssp), bmssp.nodeIDs, 0);
     expect(getDijkstraComparisonCount()).toBe(first);
   });
 });

--- a/test/bmssp.test.mjs
+++ b/test/bmssp.test.mjs
@@ -1,6 +1,7 @@
 import { describe, test, expect } from "@jest/globals";
 import { BMSSP } from "../src/bmssp.mjs";
 import { dijkstra } from "../src/dijkstra.mjs";
+import { edgesOf } from "./helpers.mjs";
 
 // Small deterministic PRNG so stress-test failures are reproducible
 function mulberry32(seed) {
@@ -30,7 +31,7 @@ function randomEdges(rand, n, m, maxWeight) {
 function expectMatchesOracle(edges, source) {
   const bmssp = new BMSSP(edges);
   bmssp.calculateShortestPaths(source);
-  const oracle = dijkstra(bmssp.graph, bmssp.nodeIDs, source);
+  const oracle = dijkstra(edgesOf(bmssp), bmssp.nodeIDs, source);
   expect(bmssp.shortestPaths.size).toBe(oracle.size);
   for (const [v, d] of oracle) {
     expect(bmssp.shortestPaths.get(v)).toBe(d);
@@ -126,7 +127,7 @@ describe("BMSSP end-to-end on hand-built graphs", () => {
     const bmssp = new BMSSP(edges);
     bmssp.calculateShortestPaths(0);
     bmssp.calculateShortestPaths(2);
-    const oracle = dijkstra(bmssp.graph, bmssp.nodeIDs, 2);
+    const oracle = dijkstra(edgesOf(bmssp), bmssp.nodeIDs, 2);
     for (const [v, d] of oracle) {
       expect(bmssp.shortestPaths.get(v)).toBe(d);
     }
@@ -188,7 +189,7 @@ describe("BMSSP recursion contract (Lemma 3.1)", () => {
     for (let round = 0; round < 25; round += 1) {
       const edges = randomEdges(rand, 30, 120, 1000);
       const bmssp = new BMSSP(edges);
-      const oracle = dijkstra(bmssp.graph, bmssp.nodeIDs, 0);
+      const oracle = dijkstra(edgesOf(bmssp), bmssp.nodeIDs, 0);
       const finite = [...oracle.values()]
         .filter((d) => d < Infinity)
         .sort((a, b) => a - b);
@@ -305,7 +306,7 @@ describe("BMSSP recursion contract (Lemma 3.1)", () => {
       Infinity,
       new Set([0]),
     );
-    const oracle = dijkstra(bmssp.graph, bmssp.nodeIDs, 0);
+    const oracle = dijkstra(edgesOf(bmssp), bmssp.nodeIDs, 0);
     expect(bound).toBe(Infinity);
     const reachable = new Set(
       [...oracle].filter(([, d]) => d < Infinity).map(([v]) => v),

--- a/test/edgeCases.test.mjs
+++ b/test/edgeCases.test.mjs
@@ -1,6 +1,7 @@
 import { describe, test, expect } from "@jest/globals";
 import { BMSSP } from "../src/bmssp.mjs";
 import { dijkstra } from "../src/dijkstra.mjs";
+import { edgesOf } from "./helpers.mjs";
 
 // Deterministic edge-case fixtures for disconnected graphs and unreachable
 // nodes (#162). Every graph is hand-built and every expected distance map is
@@ -14,7 +15,7 @@ function expectDistances(edges, source, expected) {
   const bmssp = new BMSSP(edges);
   bmssp.calculateShortestPaths(source);
 
-  const oracle = dijkstra(bmssp.graph, bmssp.nodeIDs, source);
+  const oracle = dijkstra(edgesOf(bmssp), bmssp.nodeIDs, source);
   expect(bmssp.shortestPaths.size).toBe(oracle.size);
   for (const [v, d] of oracle) {
     expect(bmssp.shortestPaths.get(v)).toBe(d);
@@ -59,9 +60,10 @@ describe("Edge cases (#162): isolated and sink sources", () => {
         [2, Infinity],
       ]),
     );
-    // The adjacency map still knows the sink — with an empty edge list
+    // getEdges still knows the sink — with an empty edge list (it is a
+    // declared node in the CSR, just with an empty outgoing range)
     expect(bmssp.getEdges(1)).toEqual([]);
-    expect(bmssp.adjacency.has(1)).toBe(true);
+    expect(bmssp.nodeIDs.has(1)).toBe(true);
   });
 
   test("an empty graph rejects every start node", () => {

--- a/test/findPivots.test.mjs
+++ b/test/findPivots.test.mjs
@@ -2,6 +2,7 @@ import { describe, test, expect } from "@jest/globals";
 import { findPivots } from "../src/findPivots.mjs";
 import { BMSSP } from "../src/bmssp.mjs";
 import { dijkstra } from "../src/dijkstra.mjs";
+import { edgesOf } from "./helpers.mjs";
 
 // Small deterministic PRNG so stress-test failures are reproducible
 function mulberry32(seed) {
@@ -176,7 +177,7 @@ describe("findPivots vs Dijkstra oracle (seeded)", () => {
     for (let round = 0; round < 20; round += 1) {
       const edges = randomEdges(rand, 40, 160);
       const g = setup(edges, { 0: 0 });
-      const oracle = dijkstra(g.graph, g.nodeIDs, 0);
+      const oracle = dijkstra(edgesOf(g), g.nodeIDs, 0);
       const n = g.nodeIDs.size;
       // k = n rounds of Bellman-Ford complete everything, and the early
       // exit (|W| > n·1) can never fire since W has at most n vertices
@@ -196,7 +197,7 @@ describe("findPivots vs Dijkstra oracle (seeded)", () => {
     for (let round = 0; round < 25; round += 1) {
       const edges = randomEdges(rand, 30, 90);
       const g = setup(edges, { 0: 0 });
-      const oracle = dijkstra(g.graph, g.nodeIDs, 0);
+      const oracle = dijkstra(edgesOf(g), g.nodeIDs, 0);
       const finite = [...oracle.values()]
         .filter((d) => d < Infinity)
         .sort((a, b) => a - b);
@@ -221,7 +222,7 @@ describe("findPivots vs Dijkstra oracle (seeded)", () => {
       // The frontier-shrink contract: every vertex with d(v) < B is either
       // complete in W, or some shortest path to it visits a pivot
       const pivotOracles = new Map(
-        [...pivotIds].map((p) => [p, dijkstra(g.graph, g.nodeIDs, p)]),
+        [...pivotIds].map((p) => [p, dijkstra(edgesOf(g), g.nodeIDs, p)]),
       );
       for (const [v, d] of oracle) {
         if (d >= B) continue;

--- a/test/fuzz.test.mjs
+++ b/test/fuzz.test.mjs
@@ -9,6 +9,7 @@ import {
   chain,
   star,
 } from "../benchmarks/generators.mjs";
+import { edgesOf } from "./helpers.mjs";
 
 // High-volume property/fuzz suite (#161): seeded random graphs across many
 // shapes and weight regimes, always validated against the Dijkstra oracle.
@@ -99,7 +100,7 @@ function pickSource(rng, nodeIDs) {
 function checkFullMapAgainstOracle(edges, source, label) {
   const bmssp = new BMSSP(edges);
   bmssp.calculateShortestPaths(source);
-  const oracle = dijkstra(bmssp.graph, bmssp.nodeIDs, source);
+  const oracle = dijkstra(edgesOf(bmssp), bmssp.nodeIDs, source);
   if (bmssp.shortestPaths.size !== oracle.size) {
     throw new Error(
       `${label}: map size mismatch: BMSSP ${bmssp.shortestPaths.size}, ` +
@@ -313,7 +314,7 @@ describe("fuzz: multi-source bounded bmssp() against per-source oracles", () => 
 
     const oracles = new Map();
     for (const s of initial.keys()) {
-      oracles.set(s, dijkstra(bmssp.graph, bmssp.nodeIDs, s));
+      oracles.set(s, dijkstra(edgesOf(bmssp), bmssp.nodeIDs, s));
     }
     const trueDist = new Map();
     for (const v of nodes) {

--- a/test/graph.test.mjs
+++ b/test/graph.test.mjs
@@ -1,6 +1,7 @@
 import { describe, test, expect } from "@jest/globals";
 import { BMSSP, Graph, dijkstra } from "../index.mjs";
 import { sparseRandom } from "../benchmarks/generators.mjs";
+import { edgesOf } from "./helpers.mjs";
 
 // #172 — typed / flexible graph inputs. The BMSSP constructor now accepts an
 // edge array (unchanged), an adjacency Map/object, or a Graph builder, and
@@ -200,7 +201,7 @@ describe("cross-shape equivalence on seeded graphs (vs Dijkstra oracle)", () => 
 
     const fromArray = new BMSSP(edges);
     fromArray.calculateShortestPaths(source);
-    const oracle = dijkstra(fromArray.graph, fromArray.nodeIDs, source);
+    const oracle = dijkstra(edgesOf(fromArray), fromArray.nodeIDs, source);
 
     for (const input of [adjacencyMap, g]) {
       const bmssp = new BMSSP(input);

--- a/test/helpers.mjs
+++ b/test/helpers.mjs
@@ -1,0 +1,29 @@
+// Shared test helpers for the #212 direct-CSR world.
+//
+// Since #212 a BMSSP instance no longer exposes `this.graph` (a deep-copied
+// edge array) or `this.adjacency` (a Map) — the CSR engine is the single
+// source of truth. Tests that need those shapes (mostly to feed the
+// `dijkstra` / `dijkstraAdjacency` oracles) rebuild them from the public
+// `getEdges()` view, which materializes a node's outgoing edges from the CSR.
+
+/**
+ * Rebuild a `[from, to, weight][]` edge array from a BMSSP instance via its
+ * public `getEdges()` view — equivalent, as a multiset of edges, to the old
+ * public `this.graph`. Feed it to the `dijkstra(edges, nodeIDs, source)` oracle.
+ *
+ * @param {import("../src/bmssp.mjs").BMSSP} instance
+ * @returns {Array<[number, number, number]>}
+ */
+export function edgesOf(instance) {
+  const edges = [];
+  for (const from of instance.nodeIDs) {
+    for (const [to, weight] of instance.getEdges(from)) {
+      edges.push([from, to, weight]);
+    }
+  }
+  return edges;
+}
+
+// The Map-shaped equivalent for the benchmark oracle (`dijkstraAdjacency`)
+// lives in `benchmarks/bench-util.mjs` as `adjacencyOf`, since that is where
+// the benchmark harness (and its test) consumes it.

--- a/test/main.test.mjs
+++ b/test/main.test.mjs
@@ -1,6 +1,7 @@
 import { describe, test, expect } from "@jest/globals";
 import { BMSSP, dijkstra } from "../index.mjs";
 import { sparseRandom } from "../benchmarks/generators.mjs";
+import { edgesOf } from "./helpers.mjs";
 
 // Seeded medium-size sparse graph (m = O(n) — the regime the paper targets).
 // It replaces the old 87 MB roadNet-CA.txt fixture: the same full-map
@@ -14,8 +15,13 @@ const mediumSparse = sparseRandom(10_000, 3, 1601);
 const myBMSSP = new BMSSP(mediumSparse);
 
 describe("BMSSP constructor", () => {
-  test("initializes the graph correctly", () => {
-    expect(myBMSSP.graph).toEqual(mediumSparse);
+  test("ingests every input edge into the CSR", () => {
+    // #212: there is no public `this.graph` copy anymore — the CSR is the
+    // single source of truth. Rebuilding the edge multiset via getEdges must
+    // reproduce exactly the input edges (order-independent).
+    const sortEdges = (es) =>
+      [...es].sort((a, b) => a[0] - b[0] || a[1] - b[1] || a[2] - b[2]);
+    expect(sortEdges(edgesOf(myBMSSP))).toEqual(sortEdges(mediumSparse));
   });
 
   test("rejects an unrecognized input graph type", () => {
@@ -56,18 +62,18 @@ describe("BMSSP nodeIDs", () => {
   });
 });
 
-describe("BMSSP adjacency map", () => {
-  test("groups outgoing edges by source node", () => {
+describe("BMSSP getEdges (CSR edge view)", () => {
+  test("returns a node's outgoing edges in input order", () => {
     const small = new BMSSP([
       [0, 1, 50],
       [1, 2, 75],
       [0, 2, 25],
     ]);
-    expect(small.adjacency.get(0)).toEqual([
+    expect(small.getEdges(0)).toEqual([
       [1, 50],
       [2, 25],
     ]);
-    expect(small.adjacency.get(1)).toEqual([[2, 75]]);
+    expect(small.getEdges(1)).toEqual([[2, 75]]);
   });
 
   test("gives sink nodes an empty edge array", () => {
@@ -77,18 +83,20 @@ describe("BMSSP adjacency map", () => {
       [0, 2, 25],
     ]);
     // node 2 has no outgoing edges but is still a known node
-    expect(small.adjacency.has(2)).toBe(true);
-    expect(small.adjacency.get(2)).toEqual([]);
+    expect(small.nodeIDs.has(2)).toBe(true);
+    expect(small.getEdges(2)).toEqual([]);
   });
 
-  test("has one entry per unique node ID", () => {
-    expect(myBMSSP.adjacency.size).toBe(myBMSSP.nodeIDs.size);
+  test("covers every unique node ID with an edge list", () => {
+    for (const id of myBMSSP.nodeIDs) {
+      expect(Array.isArray(myBMSSP.getEdges(id))).toBe(true);
+    }
   });
 
-  test("preserves the total number of edges across all adjacency lists", () => {
+  test("preserves the total number of edges across all edge lists", () => {
     let edgeCount = 0;
-    for (const edges of myBMSSP.adjacency.values()) {
-      edgeCount += edges.length;
+    for (const id of myBMSSP.nodeIDs) {
+      edgeCount += myBMSSP.getEdges(id).length;
     }
     expect(edgeCount).toBe(mediumSparse.length);
   });

--- a/test/publicApi.test.mjs
+++ b/test/publicApi.test.mjs
@@ -39,14 +39,10 @@ describe("#173 BMSSP supported public methods and fields", () => {
     "reconstructPath",
     "getEdges",
   ];
-  const PUBLIC_FIELDS = [
-    "shortestPaths",
-    "nodeIDs",
-    "hops",
-    "preds",
-    "adjacency",
-    "graph",
-  ];
+  const PUBLIC_FIELDS = ["shortestPaths", "nodeIDs", "hops", "preds"];
+  // #212 removed these public fields (breaking, 3.0.0): the CSR engine is the
+  // single source of truth and the edge view is served on demand by getEdges().
+  const REMOVED_FIELDS = ["adjacency", "graph"];
 
   test("every documented public method exists on the prototype", () => {
     for (const name of PUBLIC_METHODS) {
@@ -61,8 +57,15 @@ describe("#173 BMSSP supported public methods and fields", () => {
     }
     expect(g.shortestPaths instanceof Map).toBe(true);
     expect(g.nodeIDs instanceof Set).toBe(true);
-    expect(g.adjacency instanceof Map).toBe(true);
-    expect(Array.isArray(g.graph)).toBe(true);
+    expect(g.hops instanceof Map).toBe(true);
+    expect(g.preds instanceof Map).toBe(true);
+  });
+
+  test("the #212-removed public fields are gone (breaking, 3.0.0)", () => {
+    const g = new BMSSP([[0, 1, 5]]);
+    for (const name of REMOVED_FIELDS) {
+      expect(g[name]).toBeUndefined();
+    }
   });
 
   test("the documented public methods behave as specified end-to-end", () => {

--- a/test/tieBreak.test.mjs
+++ b/test/tieBreak.test.mjs
@@ -17,6 +17,7 @@ import {
 } from "../src/tieBreak.mjs";
 import { BMSSP } from "../src/bmssp.mjs";
 import { dijkstra } from "../src/dijkstra.mjs";
+import { edgesOf } from "./helpers.mjs";
 
 // Small deterministic PRNG so stress-test failures are reproducible
 function mulberry32(seed) {
@@ -269,7 +270,7 @@ describe("determinism (#163): edge order never changes the outcome", () => {
       const n = 25 + Math.floor(rand() * 25);
       const edges = tiedEdges(rand, n, n * 4);
       const probe = new BMSSP(edges);
-      const oracle = dijkstra(probe.graph, probe.nodeIDs, 0);
+      const oracle = dijkstra(edgesOf(probe), probe.nodeIDs, 0);
       const finite = [...oracle.values()]
         .filter((d) => d < Infinity)
         .sort((a, b) => a - b);
@@ -300,7 +301,7 @@ describe("strict Lemma 3.1 (#163): no boundary ties in the composite order", () 
       const n = 20 + Math.floor(rand() * 30);
       const edges = tiedEdges(rand, n, n * 4);
       const bmssp = new BMSSP(edges);
-      const oracle = dijkstra(bmssp.graph, bmssp.nodeIDs, 0);
+      const oracle = dijkstra(edgesOf(bmssp), bmssp.nodeIDs, 0);
       const finite = [...oracle.values()]
         .filter((d) => d < Infinity)
         .sort((a, b) => a - b);
@@ -370,7 +371,7 @@ describe("canonical labels (#163): hops and preds are the lexicographic optimum"
       const edges = tiedEdges(rand, n, n * 4);
       const bmssp = new BMSSP(edges);
       bmssp.calculateShortestPaths(0);
-      const { dist, hop } = lexDijkstra(bmssp.graph, bmssp.nodeIDs, 0);
+      const { dist, hop } = lexDijkstra(edgesOf(bmssp), bmssp.nodeIDs, 0);
       for (const v of bmssp.nodeIDs) {
         expect(bmssp.shortestPaths.get(v)).toBe(dist.get(v));
         if (dist.get(v) < Infinity) {
@@ -387,13 +388,13 @@ describe("canonical labels (#163): hops and preds are the lexicographic optimum"
       const edges = tiedEdges(rand, n, n * 4);
       const bmssp = new BMSSP(edges);
       bmssp.calculateShortestPaths(0);
-      const { dist, hop } = lexDijkstra(bmssp.graph, bmssp.nodeIDs, 0);
+      const { dist, hop } = lexDijkstra(edgesOf(bmssp), bmssp.nodeIDs, 0);
       for (const v of bmssp.nodeIDs) {
         if (v === 0 || dist.get(v) === Infinity) continue;
         // The canonical parent is the smallest-id in-neighbor u with a
         // (length, hops)-tight edge into v
         let expected = null;
-        for (const [from, to, weight] of bmssp.graph) {
+        for (const [from, to, weight] of edgesOf(bmssp)) {
           if (to !== v) continue;
           if (
             dist.get(from) + weight === dist.get(v) &&


### PR DESCRIPTION
Closes #212 — the only issue in milestone **3.0.0 — performance** (milestone-closing, **major → 3.0.0**).

## Summary

Build the dense index + CSR + typed labels **directly** from the normalized input edges, instead of round-tripping through an intermediate `this.graph` edge-array copy and an eagerly-built `this.adjacency` Map.

- Constructor now calls `buildIndex(edges)` on the validated input directly; `buildAdjacency` and the `this.graph`/`this.adjacency` fields are gone.
- **BREAKING (the only public-surface change):** the public `this.graph` / `this.adjacency` instance fields are **removed** (user-confirmed: remove outright, not a lazy getter). `getEdges(nodeId)` now materializes a node's `[to, weight]` edges from the CSR on demand (`[]` for unknown/isolated nodes).
- Because the CSR is built from the same edges in the same order, it is **byte-identical** to the pre-#212 round-trip — this is a construction-side change, not an engine change.

## Payoff

Construction time **roughly halved** — clean A/B vs `main` 2.0.0 at n=500k / m=1.5M: **~510 → ~240 ms** median (min ~385 → ~202 ms).

## Correctness

Not a single oracle/determinism assertion changed. Green on the default suite, `FUZZ_ROUNDS=25`, and `FUZZ_XL=1` (2M-node round) — the proof that the CSR is identical.

## Migration handled

- `test/helpers.mjs` `edgesOf()` + `benchmarks/bench-util.mjs` `adjacencyOf()` rebuild the oracle inputs from `getEdges` (were fed `this.graph` / `this.adjacency`).
- `test/publicApi.test.mjs` pins `graph`/`adjacency` as **removed** (10 contract tests).
- `MIGRATION.md` 2.x → 3.0 section; `docs/index.html` + `README` note the removal; `05`/`06`/`07` knowledge base refreshed.

## Test / lint status

- **238 tests — 237 passing + 1 XL skipped by default.**
- `npm run lint` clean (ESLint + Prettier).
- Version bumped to **3.0.0** (`package.json` + lockfile).

## Roadmap proposals (Phase E — pending your approval, one confirmation each)

1. **Close milestone `3.0.0`** — #212 is its only issue (1/1 on merge + release).
2. **Decide the next-milestone direction with the user.** Core is feature-complete and the big construction/engine perf levers (#205, #212) are spent. Options: (a) a further-performance milestone, (b) an ergonomics/interop milestone (e.g. TypeScript declarations), or (c) declare feature-complete / maintenance mode and open nothing.
3. **(Optional) File "Skip the id sort for already-dense inputs."** `buildIndex` still sorts the node-ID set (`O(n log n)`); when ids are already `0..n-1` a fast-path avoids it. File only under a further-perf milestone (2a).

🤖 Generated with [Claude Code](https://claude.com/claude-code)